### PR TITLE
Add title standardizer to clean/cleanup functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pytest>=9.0.2",
     "pyyaml>=6.0.3",
     "questionary>=2.1.1",
+    "titlecase>=2.4",
     "typer>=0.24.1",
 ]
 [dependency-groups]

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from datetime import date
 from typing import Dict, Any, Optional
+from titlecase import titlecase
 from .api import Book
 
 DEFAULT_FRONTMATTER = {
@@ -37,9 +38,29 @@ FIELD_MIGRATIONS = {
 }
 
 def sanitize_filename(name: str) -> str:
-    """Removes invalid characters for a filename."""
+    """Removes invalid characters for a filename and collapses whitespace."""
     name = re.sub(r'[\\/*?:"<>|]', "", name)
+    name = re.sub(r'\s+', ' ', name)
     return name.strip()
+
+
+# Patterns for publisher/format annotations (not genuine title content)
+_BRACKET_ANNOTATION_PAT = re.compile(r'\s*[\[\{][^\[\]\{\}]*[\]\}]')
+_WHITESPACE_PAT = re.compile(r'\s+')
+
+
+def standardize_title(raw: str) -> str:
+    """Standardize a book title: strip annotations, normalize whitespace, apply title case."""
+    if not raw or not isinstance(raw, str):
+        return raw
+    title = raw.strip()
+    # Remove bracket annotations like [Illustrated], {Kindle Edition}
+    title = _BRACKET_ANNOTATION_PAT.sub('', title)
+    # Collapse multiple whitespace to single space
+    title = _WHITESPACE_PAT.sub(' ', title).strip()
+    # Apply title case (NYT Manual of Style rules)
+    title = titlecase(title)
+    return title
 
 def create_book_note(book: Book, vault_path: Path, status: str = "To Read") -> Path:
     """Creates a Markdown note for a book in the specified vault path."""
@@ -135,6 +156,14 @@ def ensure_frontmatter_fields(file_path: Path) -> bool:
     if isinstance(data.get("author"), str):
         data["author"] = [data["author"]]
         updated = True
+
+    # Standardize title casing and strip annotations
+    title_val = data.get("title")
+    if title_val and isinstance(title_val, str):
+        standardized = standardize_title(title_val)
+        if standardized != title_val:
+            data["title"] = standardized
+            updated = True
             
     if updated:
         # Use dump but ensure we don't add unnecessary trailing newlines or spaces

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -49,7 +49,7 @@ _BRACKET_ANNOTATION_PAT = re.compile(r'\s*[\[\{][^\[\]\{\}]*[\]\}]')
 _WHITESPACE_PAT = re.compile(r'\s+')
 
 
-def standardize_title(raw: str) -> str:
+def standardize_title(raw: Optional[str]) -> Optional[str]:
     """Standardize a book title: strip annotations, normalize whitespace, apply title case."""
     if not raw or not isinstance(raw, str):
         return raw

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,11 +2,11 @@ from pathlib import Path
 import time
 from statistics import median
 from libris.api import Book
-from libris.markdown import create_book_note, sanitize_filename, list_books, read_frontmatter, update_frontmatter_from_book
+from libris.markdown import create_book_note, sanitize_filename, standardize_title, list_books, read_frontmatter, update_frontmatter_from_book
 
 def test_sanitize_filename():
     assert sanitize_filename("Title: With Colon") == "Title With Colon"
-    assert sanitize_filename("Title / With / Slash") == "Title  With  Slash"
+    assert sanitize_filename("Title / With / Slash") == "Title With Slash"
 
 def test_create_book_note(tmp_path):
     book = Book(
@@ -323,3 +323,66 @@ def test_list_books_benchmark_against_legacy_read_pattern(tmp_path):
     # Runtime can vary by filesystem and cache behavior.
     # Guard against major regressions while still tracking benchmark timings.
     assert median(new_times) <= median(old_times) * 2.0
+
+
+# --- Title Standardizer Tests ---
+
+def test_standardize_title_basic():
+    assert standardize_title("the great gatsby") == "The Great Gatsby"
+    assert standardize_title("THE GREAT GATSBY") == "The Great Gatsby"
+    assert standardize_title("a tale of two cities") == "A Tale of Two Cities"
+
+
+def test_standardize_title_preserves_subtitle():
+    assert standardize_title("dune: the machine crusade") == "Dune: The Machine Crusade"
+    assert standardize_title("clean code: a handbook of agile software craftsmanship") == "Clean Code: A Handbook of Agile Software Craftsmanship"
+
+
+def test_standardize_title_strips_brackets():
+    assert standardize_title("Dune [Illustrated]") == "Dune"
+    assert standardize_title("Python {Kindle Edition}") == "Python"
+    assert standardize_title("The Art of War [Annotated] [Illustrated]") == "The Art of War"
+
+
+def test_standardize_title_collapses_whitespace():
+    assert standardize_title("Title  With  Spaces") == "Title With Spaces"
+    assert standardize_title("  Extra   Leading  ") == "Extra Leading"
+
+
+def test_standardize_title_handles_none_and_empty():
+    assert standardize_title(None) is None
+    assert standardize_title("") == ""
+
+
+def test_standardize_title_preserves_mixed_case():
+    # titlecase preserves words with internal caps
+    result = standardize_title("the iPhone revolution")
+    assert "iPhone" in result
+
+
+def test_ensure_frontmatter_standardizes_title(tmp_path):
+    from libris.markdown import ensure_frontmatter_fields
+    file_path = tmp_path / "caps_book.md"
+    file_path.write_text("---\ntitle: THE GREAT GATSBY\ngoogle_books_id: abc\n---\n")
+
+    updated = ensure_frontmatter_fields(file_path)
+    assert updated is True
+
+    content = file_path.read_text()
+    assert "title: The Great Gatsby" in content
+
+
+def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
+    from libris.markdown import ensure_frontmatter_fields
+    file_path = tmp_path / "good_book.md"
+    # Write a file with all fields present and title already standardized
+    file_path.write_text(
+        "---\ntitle: The Great Gatsby\nauthor:\n- F. Scott Fitzgerald\nisbn: '123'\n"
+        "page_count: 200\npublished_date: '1925'\ngoogle_books_id: abc\n"
+        "thumbnail: null\ngenres: null\ntags: Book\nformat: null\n"
+        "status: To Read\nrating: null\nreferred_by: null\n"
+        "date_added: null\ndate_started: null\ndate_finished: null\n---\n"
+    )
+
+    updated = ensure_frontmatter_fields(file_path)
+    assert updated is False

--- a/uv.lock
+++ b/uv.lock
@@ -305,6 +305,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "questionary" },
+    { name = "titlecase" },
     { name = "typer" },
 ]
 
@@ -330,6 +331,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.1.1" },
+    { name = "titlecase", specifier = ">=2.4" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
 
@@ -716,6 +718,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
 ]
+
+[[package]]
+name = "titlecase"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/17/04d2d3e30e2bc5a3eefa1060b08e3fb628510440f938eaecabbe08976a26/titlecase-2.4.1.tar.gz", hash = "sha256:7d83a277ccbbda11a2944e78a63e5ccaf3d32f828c594312e4862f9a07f635f5", size = 14434, upload-time = "2023-09-23T05:03:46.389Z" }
 
 [[package]]
 name = "traitlets"


### PR DESCRIPTION
Closes #14

## Summary
Adds a `standardize_title()` function that normalizes book titles during `clean`/`cleanup` operations.

## Changes
- **New dependency:** `titlecase>=2.4` (NYT Manual of Style title casing)
- **New function:** `standardize_title()` in `markdown.py`
  - Strips bracket annotations (`[Illustrated]`, `{Kindle Edition}`)
  - Collapses multiple whitespace to single space
  - Applies proper title case (handles ALL CAPS, small words, subtitles after `:`)
- **Integration:** Added to `ensure_frontmatter_fields()` so both `clean` and `cleanup` standardize titles
- **Bug fix:** `sanitize_filename()` now collapses whitespace after stripping invalid characters (previously left double-spaces)

## Testing
- 8 new tests covering: basic casing, subtitles, bracket stripping, whitespace, None/empty, mixed-case preservation, integration, idempotency
- All 67 tests pass