### PR TITLE
Add safe file rename with wikilink updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,33 @@ Select a book from your vault and update its status.
 libris list
 ```
 
-### 6. Find Duplicate Books
+### 6. Clean Up Book Notes
+Standardize frontmatter and optionally rename files to the canonical `Title - Author.md` format:
+```bash
+# Clean all book frontmatter (title casing, missing fields, etc.)
+libris cleanup
+
+# Also rename files to match Title - Author.md pattern (updates wikilinks)
+libris cleanup --rename
+
+# Clean a single book interactively
+libris clean
+libris clean --rename
+```
+
+### 7. Configure Obsidian Vault Root
+If your book folder is a subdirectory of a larger Obsidian vault, configure the vault root so wikilink updates search the entire vault:
+```bash
+libris config --obsidian-vault ~/Documents/ObsidianVault
+```
+
+### 8. Find Duplicate Books
 Scan your vault for duplicate book notes matched by title, ISBN, or Google Books ID.
 ```bash
 libris duplicates
 ```
 
-### 6. Audible Integration
+### 9. Audible Integration
 Connect your Audible account to sync your audiobook library.
 
 ```bash

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from .api import GoogleBooksClient, Book
 from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates, rename_book_file
-from .config import get_vault_path, set_config, get_obsidian_vault_root
+from .config import get_vault_path, set_config, get_obsidian_vault_root, set_book_vault_path
 from .audible_client import get_auth_file, is_authenticated, get_locale
 
 app = typer.Typer()
@@ -155,7 +155,7 @@ def config(
         if not p.exists():
             typer.echo(f"Warning: Path {p} does not exist. Creating it...")
             p.mkdir(parents=True, exist_ok=True)
-        set_config("vault_path", str(p))
+        set_book_vault_path(p)
         typer.echo(f"Vault path set to: {p}")
 
     if obsidian_vault:

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -7,8 +7,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from .api import GoogleBooksClient, Book
-from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates
-from .config import get_vault_path, set_config
+from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates, rename_book_file
+from .config import get_vault_path, set_config, get_obsidian_vault_root
 from .audible_client import get_auth_file, is_authenticated, get_locale
 
 app = typer.Typer()
@@ -146,6 +146,7 @@ def add(query: str = typer.Argument(..., help="Title, author, or ISBN to search 
 @app.command()
 def config(
     vault_path: str = typer.Option(None, "--vault", help="Set the vault path"),
+    obsidian_vault: str = typer.Option(None, "--obsidian-vault", help="Set the Obsidian vault root path (for wikilink updates)"),
     api_key: str = typer.Option(None, "--api-key", help="Set the Google Books API key")
 ):
     """Configure libris settings."""
@@ -156,14 +157,25 @@ def config(
             p.mkdir(parents=True, exist_ok=True)
         set_config("vault_path", str(p))
         typer.echo(f"Vault path set to: {p}")
-    
+
+    if obsidian_vault:
+        p = Path(obsidian_vault).expanduser().resolve()
+        if not p.exists():
+            typer.echo(f"Warning: Path {p} does not exist.")
+            raise typer.Exit(code=1)
+        set_config("obsidian_vault_root", str(p))
+        typer.echo(f"Obsidian vault root set to: {p}")
+
     if api_key:
         set_config("google_books_api_key", api_key)
         typer.echo("API key set successfully.")
 
-    if not vault_path and not api_key:
+    if not vault_path and not api_key and not obsidian_vault:
         from .config import get_api_key
         typer.echo(f"Current vault path: {get_vault_path()}")
+        obsidian_root = get_obsidian_vault_root()
+        if obsidian_root:
+            typer.echo(f"Obsidian vault root: {obsidian_root}")
         key = get_api_key()
         if key:
             typer.echo(f"API key: {'*' * (len(key) - 4)}{key[-4:]}")
@@ -171,7 +183,9 @@ def config(
             typer.echo("API key: Not set")
 
 @app.command()
-def clean():
+def clean(
+    rename: bool = typer.Option(False, "--rename", help="Rename file to canonical Title - Author.md format"),
+):
     """Select a specific book to clean its frontmatter."""
     vault_path = get_vault_path()
     books = list_books(vault_path)
@@ -196,8 +210,16 @@ def clean():
     else:
         typer.echo(f"{selected_file_name} is already up to date or invalid.")
 
+    if rename:
+        vault_root = get_obsidian_vault_root() or vault_path
+        new_path = rename_book_file(selected_file, vault_root)
+        if new_path:
+            typer.echo(f"Renamed: {selected_file_name} → {new_path.name}")
+
 @app.command()
-def cleanup():
+def cleanup(
+    rename: bool = typer.Option(False, "--rename", help="Rename files to canonical Title - Author.md format"),
+):
     """Ensure all books in the vault have the correct frontmatter fields."""
     vault_path = get_vault_path()
     books = list_books(vault_path)
@@ -216,6 +238,19 @@ def cleanup():
         typer.echo("All books are already up to date.")
     else:
         typer.echo(f"Finished. Updated {updated_count} books.")
+
+    if rename:
+        vault_root = get_obsidian_vault_root() or vault_path
+        renamed_count = 0
+        for book_file in list_books(vault_path):
+            new_path = rename_book_file(book_file, vault_root)
+            if new_path:
+                renamed_count += 1
+                typer.echo(f"Renamed: {book_file.name} → {new_path.name}")
+        if renamed_count:
+            typer.echo(f"Renamed {renamed_count} file(s).")
+        else:
+            typer.echo("No files needed renaming.")
 
 @app.command()
 def enrich(filename: str = typer.Argument(None, help="Name of the markdown file to enrich (e.g. 'My Book.md')")):

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -163,6 +163,9 @@ def config(
         if not p.exists():
             typer.echo(f"Warning: Path {p} does not exist.")
             raise typer.Exit(code=1)
+        if not p.is_dir():
+            typer.echo(f"Error: Obsidian vault root must be a directory: {p}")
+            raise typer.Exit(code=1)
         set_config("obsidian_vault_root", str(p))
         typer.echo(f"Obsidian vault root set to: {p}")
 

--- a/src/libris/config.py
+++ b/src/libris/config.py
@@ -3,6 +3,9 @@ import os
 from pathlib import Path
 from typing import Optional
 
+LEGACY_VAULT_KEY = "vault_path"
+BOOK_VAULT_KEY = "book_vault"
+
 def get_config_dir() -> Path:
     env_config_dir = os.environ.get("LIBRIS_CONFIG_DIR")
     if env_config_dir:
@@ -27,9 +30,15 @@ def set_config(key: str, value: str):
     with open(get_config_file(), "w") as f:
         yaml.dump(config, f)
 
+def set_book_vault_path(path: Path):
+    resolved = str(path.expanduser().resolve())
+    set_config(BOOK_VAULT_KEY, resolved)
+    # Keep legacy key for backward compatibility with existing configs.
+    set_config(LEGACY_VAULT_KEY, resolved)
+
 def get_vault_path() -> Path:
     config = get_config()
-    path_str = config.get("vault_path")
+    path_str = config.get(BOOK_VAULT_KEY) or config.get(LEGACY_VAULT_KEY)
     if not path_str:
         return Path(".").resolve()
     return Path(path_str).expanduser().resolve()

--- a/src/libris/config.py
+++ b/src/libris/config.py
@@ -37,3 +37,11 @@ def get_vault_path() -> Path:
 def get_api_key() -> Optional[str]:
     config = get_config()
     return config.get("google_books_api_key")
+
+def get_obsidian_vault_root() -> Optional[Path]:
+    """Get the Obsidian vault root path, or None if not configured."""
+    config = get_config()
+    path_str = config.get("obsidian_vault_root")
+    if not path_str:
+        return None
+    return Path(path_str).expanduser().resolve()

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -370,12 +370,13 @@ def rename_book_file(file_path: Path, vault_root: Optional[Path] = None) -> Opti
     if new_path.exists():
         return None  # collision — don't overwrite
 
-    # Update wikilinks across the vault
     search_root = vault_root or file_path.parent
     old_stem = file_path.stem
     new_stem = new_path.stem
-    update_wikilinks_in_vault(search_root, old_stem, new_stem, exclude=file_path)
 
-    # Perform the rename
+    # Perform the rename first so wikilinks are only updated if it succeeds.
     file_path.rename(new_path)
+
+    # Update wikilinks across the vault
+    update_wikilinks_in_vault(search_root, old_stem, new_stem, exclude=new_path)
     return new_path

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -339,24 +339,25 @@ def compute_canonical_filename(file_path: Path) -> Optional[str]:
 def update_wikilinks_in_vault(vault_root: Path, old_stem: str, new_stem: str, exclude: Optional[Path] = None) -> int:
     """Update all wikilinks from old_stem to new_stem across the vault. Returns count of files updated."""
     updated_count = 0
-    for md_file in vault_root.rglob("*.md"):
-        if exclude and md_file.resolve() == exclude.resolve():
-            continue
-        # Skip hidden directories (.obsidian, .git, etc.)
-        try:
-            rel = md_file.relative_to(vault_root)
-            if any(part.startswith(".") for part in rel.parts):
+    exclude_resolved = exclude.resolve() if exclude else None
+    for root, dirnames, filenames in os.walk(vault_root):
+        # Skip hidden directories (.obsidian, .git, etc.) before descending into them.
+        dirnames[:] = [dirname for dirname in dirnames if not dirname.startswith(".")]
+        root_path = Path(root)
+        for filename in filenames:
+            if not filename.endswith(".md") or filename.startswith("."):
                 continue
-        except ValueError:
-            continue
-        content = md_file.read_text(encoding="utf-8")
-        new_content = content.replace(f"[[{old_stem}]]", f"[[{new_stem}]]")
-        new_content = new_content.replace(f"[[{old_stem}|", f"[[{new_stem}|")
-        new_content = new_content.replace(f"[[{old_stem}#", f"[[{new_stem}#")
-        new_content = new_content.replace(f"[[{old_stem}^", f"[[{new_stem}^")
-        if new_content != content:
-            md_file.write_text(new_content, encoding="utf-8")
-            updated_count += 1
+            md_file = root_path / filename
+            if exclude_resolved and md_file.resolve() == exclude_resolved:
+                continue
+            content = md_file.read_text(encoding="utf-8")
+            new_content = content.replace(f"[[{old_stem}]]", f"[[{new_stem}]]")
+            new_content = new_content.replace(f"[[{old_stem}|", f"[[{new_stem}|")
+            new_content = new_content.replace(f"[[{old_stem}#", f"[[{new_stem}#")
+            new_content = new_content.replace(f"[[{old_stem}^", f"[[{new_stem}^")
+            if new_content != content:
+                md_file.write_text(new_content, encoding="utf-8")
+                updated_count += 1
     return updated_count
 
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -307,3 +307,63 @@ def update_frontmatter_from_book(file_path: Path, book: Book) -> bool:
         return True
 
     return False
+
+
+def compute_canonical_filename(file_path: Path) -> Optional[str]:
+    """Compute the canonical 'Title - Author.md' filename from frontmatter."""
+    fm = read_frontmatter(file_path)
+    if not fm:
+        return None
+    title = fm.get("title")
+    author = fm.get("author")
+    if not title or not isinstance(title, str):
+        return None
+    if not author:
+        return None
+    first_author = author[0] if isinstance(author, list) else author
+    return sanitize_filename(f"{title} - {first_author}.md")
+
+
+def update_wikilinks_in_vault(vault_root: Path, old_stem: str, new_stem: str, exclude: Optional[Path] = None) -> int:
+    """Update all wikilinks from old_stem to new_stem across the vault. Returns count of files updated."""
+    updated_count = 0
+    for md_file in vault_root.rglob("*.md"):
+        if exclude and md_file.resolve() == exclude.resolve():
+            continue
+        # Skip hidden directories (.obsidian, .git, etc.)
+        try:
+            rel = md_file.relative_to(vault_root)
+            if any(part.startswith(".") for part in rel.parts):
+                continue
+        except ValueError:
+            continue
+        content = md_file.read_text(encoding="utf-8")
+        new_content = content.replace(f"[[{old_stem}]]", f"[[{new_stem}]]")
+        new_content = new_content.replace(f"[[{old_stem}|", f"[[{new_stem}|")
+        new_content = new_content.replace(f"[[{old_stem}#", f"[[{new_stem}#")
+        new_content = new_content.replace(f"[[{old_stem}^", f"[[{new_stem}^")
+        if new_content != content:
+            md_file.write_text(new_content, encoding="utf-8")
+            updated_count += 1
+    return updated_count
+
+
+def rename_book_file(file_path: Path, vault_root: Optional[Path] = None) -> Optional[Path]:
+    """Rename a book file to canonical format and update wikilinks. Returns new path or None."""
+    canonical_name = compute_canonical_filename(file_path)
+    if not canonical_name or canonical_name == file_path.name:
+        return None
+
+    new_path = file_path.parent / canonical_name
+    if new_path.exists():
+        return None  # collision — don't overwrite
+
+    # Update wikilinks across the vault
+    search_root = vault_root or file_path.parent
+    old_stem = file_path.stem
+    new_stem = new_path.stem
+    update_wikilinks_in_vault(search_root, old_stem, new_stem, exclude=file_path)
+
+    # Perform the rename
+    file_path.rename(new_path)
+    return new_path

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -318,9 +318,21 @@ def compute_canonical_filename(file_path: Path) -> Optional[str]:
     author = fm.get("author")
     if not title or not isinstance(title, str):
         return None
-    if not author:
+
+    if isinstance(author, list):
+        author_candidates = author
+    elif isinstance(author, str):
+        author_candidates = [author]
+    else:
         return None
-    first_author = author[0] if isinstance(author, list) else author
+
+    first_author = next(
+        (candidate.strip() for candidate in author_candidates if isinstance(candidate, str) and candidate.strip()),
+        None,
+    )
+    if first_author is None:
+        return None
+
     return sanitize_filename(f"{title} - {first_author}.md")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,33 @@ def test_config_vault_path(tmp_path):
     assert result.exit_code == 0
     assert "API key: *********-key" in result.output
 
+def test_config_vault_path_writes_legacy_and_new_keys(tmp_path):
+    from libris.config import get_config_file
+
+    vault_path = tmp_path / "my_vault"
+    result = runner.invoke(app, ["config", "--vault", str(vault_path)])
+
+    assert result.exit_code == 0
+    config_data = yaml.safe_load(get_config_file().read_text(encoding="utf-8"))
+    assert config_data["book_vault"] == str(vault_path.resolve())
+    assert config_data["vault_path"] == str(vault_path.resolve())
+
+
+def test_config_command_reads_legacy_vault_key(tmp_path):
+    from libris.config import get_config_file
+
+    legacy_vault = tmp_path / "legacy_vault"
+    legacy_vault.mkdir()
+    get_config_file().write_text(
+        yaml.safe_dump({"vault_path": str(legacy_vault.resolve())}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["config"])
+
+    assert result.exit_code == 0
+    assert f"Current vault path: {legacy_vault.resolve()}" in result.output
+
 def test_cleanup_command(tmp_path):
     # Mock vault path
     vault_path = tmp_path / "my_vault"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import time
 from statistics import median
 from libris.api import Book
-from libris.markdown import create_book_note, sanitize_filename, standardize_title, list_books, read_frontmatter, update_frontmatter_from_book
+from libris.markdown import create_book_note, sanitize_filename, standardize_title, list_books, read_frontmatter, update_frontmatter_from_book, compute_canonical_filename, update_wikilinks_in_vault, rename_book_file
 
 def test_sanitize_filename():
     assert sanitize_filename("Title: With Colon") == "Title With Colon"
@@ -386,3 +386,126 @@ def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
 
     updated = ensure_frontmatter_fields(file_path)
     assert updated is False
+
+
+# --- File Rename Tests ---
+
+def test_compute_canonical_filename(tmp_path):
+    f = tmp_path / "old name.md"
+    f.write_text("---\ntitle: The Great Gatsby\nauthor:\n- F. Scott Fitzgerald\n---\n")
+    result = compute_canonical_filename(f)
+    assert result == "The Great Gatsby - F. Scott Fitzgerald.md"
+
+
+def test_compute_canonical_filename_missing_author(tmp_path):
+    f = tmp_path / "no_author.md"
+    f.write_text("---\ntitle: Solo Title\nauthor: null\n---\n")
+    assert compute_canonical_filename(f) is None
+
+
+def test_compute_canonical_filename_missing_title(tmp_path):
+    f = tmp_path / "no_title.md"
+    f.write_text("---\ntitle: null\nauthor:\n- Someone\n---\n")
+    assert compute_canonical_filename(f) is None
+
+
+def test_compute_canonical_filename_sanitizes(tmp_path):
+    f = tmp_path / "bad.md"
+    f.write_text("---\ntitle: 'Title: With Colon'\nauthor:\n- Author\n---\n")
+    result = compute_canonical_filename(f)
+    assert ":" not in result
+    assert result == "Title With Colon - Author.md"
+
+
+def test_update_wikilinks_basic(tmp_path):
+    note = tmp_path / "daily.md"
+    note.write_text("I read [[Old Name]] today and loved it.\n")
+    count = update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert count == 1
+    assert "[[New Name]]" in note.read_text()
+    assert "[[Old Name]]" not in note.read_text()
+
+
+def test_update_wikilinks_with_alias(tmp_path):
+    note = tmp_path / "note.md"
+    note.write_text("See [[Old Name|that book]] for details.\n")
+    update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert "[[New Name|that book]]" in note.read_text()
+
+
+def test_update_wikilinks_with_heading(tmp_path):
+    note = tmp_path / "note.md"
+    note.write_text("Check [[Old Name#Chapter 1]] for the quote.\n")
+    update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert "[[New Name#Chapter 1]]" in note.read_text()
+
+
+def test_update_wikilinks_with_block_ref(tmp_path):
+    note = tmp_path / "note.md"
+    note.write_text("Reference [[Old Name^abc123]] here.\n")
+    update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert "[[New Name^abc123]]" in note.read_text()
+
+
+def test_update_wikilinks_with_embed(tmp_path):
+    note = tmp_path / "note.md"
+    note.write_text("Embedding: ![[Old Name]]\n")
+    update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert "![[New Name]]" in note.read_text()
+
+
+def test_update_wikilinks_skips_hidden_dirs(tmp_path):
+    hidden = tmp_path / ".obsidian"
+    hidden.mkdir()
+    note = hidden / "config.md"
+    note.write_text("[[Old Name]] in hidden dir.\n")
+    count = update_wikilinks_in_vault(tmp_path, "Old Name", "New Name")
+    assert count == 0
+    assert "[[Old Name]]" in note.read_text()
+
+
+def test_update_wikilinks_excludes_target_file(tmp_path):
+    target = tmp_path / "Old Name.md"
+    target.write_text("Self reference [[Old Name]] should not change.\n")
+    count = update_wikilinks_in_vault(tmp_path, "Old Name", "New Name", exclude=target)
+    assert count == 0
+    assert "[[Old Name]]" in target.read_text()
+
+
+def test_rename_book_file(tmp_path):
+    f = tmp_path / "wrong name.md"
+    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    new_path = rename_book_file(f, tmp_path)
+    assert new_path is not None
+    assert new_path.name == "Dune - Frank Herbert.md"
+    assert new_path.exists()
+    assert not f.exists()
+
+
+def test_rename_book_file_updates_links(tmp_path):
+    book = tmp_path / "wrong name.md"
+    book.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    note = tmp_path / "reading log.md"
+    note.write_text("Currently reading [[wrong name]].\n")
+
+    new_path = rename_book_file(book, tmp_path)
+    assert new_path.name == "Dune - Frank Herbert.md"
+    assert "[[Dune - Frank Herbert]]" in note.read_text()
+
+
+def test_rename_book_file_collision_skips(tmp_path):
+    f = tmp_path / "wrong name.md"
+    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    collision = tmp_path / "Dune - Frank Herbert.md"
+    collision.write_text("---\ntitle: Dune\n---\n")
+
+    result = rename_book_file(f, tmp_path)
+    assert result is None
+    assert f.exists()
+
+
+def test_rename_book_file_already_canonical(tmp_path):
+    f = tmp_path / "Dune - Frank Herbert.md"
+    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    result = rename_book_file(f, tmp_path)
+    assert result is None


### PR DESCRIPTION
Closes #16

## Summary
Adds an opt-in `--rename` flag to `clean`/`cleanup` that renames book files to the canonical `Title - Author.md` pattern while safely updating all Obsidian wikilinks across the vault.

## Changes
- **New config:** `obsidian_vault_root` — configurable vault root for wikilink searching (separate from book folder)
- **New functions in `markdown.py`:**
  - `compute_canonical_filename()` — derives `Title - Author.md` from frontmatter
  - `update_wikilinks_in_vault()` — recursively finds and updates all wikilink variants (`[[name]]`, `[[name|alias]]`, `[[name#heading]]`, `[[name^block]]`, embeds)
  - `rename_book_file()` — orchestrates collision check → link update → file rename
- **CLI:** `--rename` flag on `clean` and `cleanup`; `--obsidian-vault` on `config`
- **Safety:** Skips hidden directories, skips on collision, skips if title/author missing

## Testing
- 15 new tests covering: canonical filename computation, all wikilink variants, hidden dir skipping, collision handling, end-to-end rename with link updates
- All 82 tests pass