### PR TITLE
feat: add import command with duplicate detection

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -10,6 +10,7 @@ from .api import GoogleBooksClient, Book
 from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates, rename_book_file, RenameResult
 from .config import get_vault_path, set_config, get_obsidian_vault_root, set_book_vault_path
 from .audible_client import get_auth_file, is_authenticated, get_locale
+from .importer import normalize_for_match, run_import, SUPPORTED_FORMATS
 
 app = typer.Typer()
 audible_app = typer.Typer(help="Audible integration commands.")
@@ -337,9 +338,11 @@ def cleanup(
             typer.echo(f"  • {name}")
 
 def _normalize_for_match(text: str) -> str:
-    """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""
-    text = re.sub(r'[^\w\s]', ' ', text.lower())
-    return re.sub(r'\s+', ' ', text).strip()
+    """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace.
+
+    Delegates to the shared implementation in importer module.
+    """
+    return normalize_for_match(text)
 
 
 def _titles_match(filename_stem: str, book_title: str) -> bool:
@@ -626,3 +629,56 @@ def duplicates():
             detail_str = f" ({', '.join(details)})" if details else ""
             typer.echo(f"  - {path.name}{detail_str}")
         typer.echo()
+
+
+@app.command(name="import")
+def import_cmd(
+    file: str = typer.Argument(..., help="Path to the import file (JSON or CSV)"),
+    format: str = typer.Option(None, "--format", "-f", help=f"Import format ({', '.join(SUPPORTED_FORMATS)})"),
+    apply: bool = typer.Option(False, "--apply", help="Actually create/update notes (default is dry-run)"),
+    limit: int = typer.Option(0, "--limit", "-n", help="Process only the first N entries (0 = all)"),
+):
+    """Import books from a JSON or CSV file into your vault.
+
+    By default, runs in dry-run mode showing what would happen.
+    Use --apply to actually create and update notes.
+    """
+    file_path = Path(file).expanduser().resolve()
+    if not file_path.exists():
+        typer.echo(f"File not found: {file_path}")
+        raise typer.Exit(code=1)
+
+    vault_path = get_vault_path()
+    if not vault_path.exists():
+        typer.echo(f"Vault path does not exist: {vault_path}")
+        raise typer.Exit(code=1)
+
+    try:
+        result = run_import(file_path, vault_path, apply=apply, format_name=format, limit=limit)
+    except (ValueError, FileNotFoundError) as e:
+        typer.echo(f"Error: {e}")
+        raise typer.Exit(code=1)
+
+    mode_label = "Import" if apply else "Dry run"
+    typer.echo(f"\n{mode_label} complete:")
+    typer.echo(f"  {len(result.new_books)} new book(s) {'added' if apply else 'would be added'}")
+    typer.echo(f"  {len(result.updated_books)} existing book(s) {'updated' if apply else 'would be updated'}")
+    typer.echo(f"  {len(result.skipped_books)} duplicate(s) already up-to-date (skipped)")
+
+    if result.new_books:
+        preview_count = min(len(result.new_books), 20)
+        typer.echo(f"\n{'Added' if apply else 'New'} books (showing {preview_count} of {len(result.new_books)}):")
+        for book in result.new_books[:preview_count]:
+            authors_str = ", ".join(book.authors)
+            typer.echo(f"  + {book.title} by {authors_str}")
+        if len(result.new_books) > preview_count:
+            typer.echo(f"  ... and {len(result.new_books) - preview_count} more")
+
+    if result.updated_books:
+        typer.echo(f"\n{'Updated' if apply else 'Would update'}:")
+        for book, path, updates in result.updated_books:
+            update_desc = ", ".join(updates)
+            typer.echo(f"  ~ {path.name} ({update_desc})")
+
+    if not apply and (result.new_books or result.updated_books):
+        typer.echo("\nRun with --apply to execute these changes.")

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -599,10 +599,6 @@ def audible_status():
             typer.echo("  Token: Expired (will auto-refresh on next use)")
 
 
-if __name__ == "__main__":
-    app()
-
-
 @app.command()
 def duplicates():
     """Find and report duplicate books in the vault."""
@@ -682,3 +678,7 @@ def import_cmd(
 
     if not apply and (result.new_books or result.updated_books):
         typer.echo("\nRun with --apply to execute these changes.")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -189,8 +189,6 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
         content = path.read_text(encoding="utf-8")
         # Parse frontmatter using YAML to properly handle missing fields
         match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-        if not match:
-            match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
         
         if match:
             frontmatter_yaml = match.group(1)
@@ -203,8 +201,8 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
                     data["format"] = book.format
                     # Write back the updated frontmatter
                     new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-                    # Preserve content structure: remove only leading newline if present
-                    content_part = rest_of_content.lstrip('\n') if rest_of_content.startswith('\n') else rest_of_content
+                    # Preserve content structure: remove only leading newlines
+                    content_part = rest_of_content.lstrip('\n')
                     new_content = f"---\n{new_frontmatter}\n---\n{content_part}"
                     path.write_text(new_content, encoding="utf-8")
             except yaml.YAMLError:

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,9 +1,7 @@
 import json
 import re
-import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from datetime import date
 from typing import Dict, List, Optional, Tuple
 
 from .api import Book
@@ -13,9 +11,6 @@ from .markdown import (
     read_frontmatter,
     update_book_status,
 )
-
-logger = logging.getLogger(__name__)
-
 
 def normalize_for_match(text: str) -> str:
     """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,5 +1,6 @@
 import json
 import re
+import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -186,12 +187,32 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
 
     if "format" in updates:
         content = path.read_text(encoding="utf-8")
-        pattern = r"(format:\s*)(.*)"
-        new_content = re.sub(pattern, f"\\1{book.format}", content)
-        if new_content == content:
-            # format field might be null — replace the null value
-            new_content = content.replace("format: null", f"format: {book.format}")
-        path.write_text(new_content, encoding="utf-8")
+        # Parse frontmatter using YAML to properly handle missing fields
+        match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+        if not match:
+            match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
+        
+        if match:
+            frontmatter_yaml = match.group(1)
+            rest_of_content = match.group(2)
+            
+            try:
+                data = yaml.safe_load(frontmatter_yaml)
+                if isinstance(data, dict):
+                    # Update the format field
+                    data["format"] = book.format
+                    # Write back the updated frontmatter
+                    new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
+                    new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content.lstrip()}"
+                    path.write_text(new_content, encoding="utf-8")
+            except Exception:
+                # Fallback to regex replacement if YAML parsing fails
+                pattern = r"(format:\s*)(.*)"
+                new_content = re.sub(pattern, f"\\1{book.format}", content)
+                if new_content == content:
+                    # format field might be null — replace the null value
+                    new_content = content.replace("format: null", f"format: {book.format}")
+                path.write_text(new_content, encoding="utf-8")
 
 
 def _to_api_book(import_book: ImportBook) -> Book:
@@ -241,7 +262,7 @@ def run_import(
                     new_content = content.replace("format: null", f"format: {book.format}")
                     created_path.write_text(new_content, encoding="utf-8")
         else:
-            dup_path, dup_fm, updates = dup
+            dup_path, _, updates = dup
             if updates:
                 result.updated_books.append((book, dup_path, updates))
                 if apply:

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,0 +1,257 @@
+import json
+import re
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from datetime import date
+from typing import Dict, List, Optional, Tuple
+
+from .api import Book
+from .markdown import (
+    create_book_note,
+    list_books,
+    read_frontmatter,
+    update_book_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_for_match(text: str) -> str:
+    """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""
+    text = re.sub(r'[^\w\s]', ' ', text.lower())
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+@dataclass
+class ImportBook:
+    """Common representation for a book from any import source."""
+    title: str
+    authors: List[str]
+    status: str  # "Read", "To Read", "Reading"
+    format: Optional[str] = None  # "Audiobook", "Hardcover", "Paperback", "eBook"
+    isbn: Optional[str] = None
+    page_count: Optional[int] = None
+    published_date: Optional[str] = None
+    rating: Optional[float] = None
+    date_added: Optional[str] = None
+    date_finished: Optional[str] = None
+    genres: List[str] = field(default_factory=list)
+    description: Optional[str] = None
+    source_id: Optional[str] = None
+    source_format: str = ""
+
+
+def parse_audible_json(path: Path) -> List[ImportBook]:
+    """Parse an Audible library JSON export into ImportBook instances."""
+    with open(path, encoding="utf-8-sig") as f:
+        data = json.load(f)
+
+    if not isinstance(data, list):
+        raise ValueError("Expected a JSON array of book objects")
+
+    books: List[ImportBook] = []
+    for entry in data:
+        title = entry.get("title", "").strip()
+        if not title:
+            continue
+
+        author_str = entry.get("author", "").strip()
+        authors = [a.strip() for a in author_str.split(",") if a.strip()] if author_str else ["Unknown Author"]
+
+        finished = entry.get("finished", "").strip().lower() == "yes"
+        status = "Read" if finished else "To Read"
+
+        books.append(ImportBook(
+            title=title,
+            authors=authors,
+            status=status,
+            format="Audiobook",
+            source_format="audible-json",
+        ))
+
+    return books
+
+
+SUPPORTED_FORMATS = {
+    "audible-json": parse_audible_json,
+}
+
+
+def detect_format(path: Path) -> Optional[str]:
+    """Auto-detect the import file format based on extension and content."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "audible-json"
+    # Future: inspect CSV header for Goodreads vs StoryGraph
+    return None
+
+
+def parse_import_file(path: Path, format_name: Optional[str] = None) -> List[ImportBook]:
+    """Parse an import file, auto-detecting format if not specified."""
+    if not path.exists():
+        raise FileNotFoundError(f"Import file not found: {path}")
+
+    if format_name is None:
+        format_name = detect_format(path)
+
+    if format_name is None:
+        raise ValueError(
+            f"Cannot detect format for {path.name}. "
+            f"Use --format with one of: {', '.join(SUPPORTED_FORMATS)}"
+        )
+
+    parser = SUPPORTED_FORMATS.get(format_name)
+    if parser is None:
+        raise ValueError(
+            f"Unknown format: {format_name}. "
+            f"Supported: {', '.join(SUPPORTED_FORMATS)}"
+        )
+
+    return parser(path)
+
+
+def _build_vault_index(vault_path: Path) -> Dict[Tuple[str, str], Tuple[Path, Dict]]:
+    """Build an index of existing vault books keyed by normalized (title, first_author)."""
+    index: Dict[Tuple[str, str], Tuple[Path, Dict]] = {}
+    for book_path in list_books(vault_path):
+        fm = read_frontmatter(book_path)
+        if fm is None:
+            continue
+
+        title = fm.get("title")
+        if not isinstance(title, str) or not title.strip():
+            continue
+
+        author = fm.get("author")
+        if isinstance(author, list):
+            first_author = next(
+                (a.strip() for a in author if isinstance(a, str) and a.strip()),
+                None,
+            )
+        elif isinstance(author, str):
+            first_author = author.strip() or None
+        else:
+            first_author = None
+
+        if first_author is None:
+            continue
+
+        key = (normalize_for_match(title), normalize_for_match(first_author))
+        index[key] = (book_path, fm)
+
+    return index
+
+
+@dataclass
+class ImportResult:
+    """Tracks the outcome of an import operation."""
+    new_books: List[ImportBook] = field(default_factory=list)
+    updated_books: List[Tuple[ImportBook, Path, List[str]]] = field(default_factory=list)
+    skipped_books: List[ImportBook] = field(default_factory=list)
+
+
+def _check_duplicate(
+    book: ImportBook,
+    vault_index: Dict[Tuple[str, str], Tuple[Path, Dict]],
+) -> Optional[Tuple[Path, Dict, List[str]]]:
+    """Check if an import book matches an existing vault entry.
+
+    Returns (path, frontmatter, list_of_updates_needed) if a duplicate is
+    found that should be updated, or (path, frontmatter, []) if the
+    duplicate is already up-to-date. Returns None if no duplicate.
+    """
+    first_author = book.authors[0] if book.authors else None
+    if first_author is None:
+        return None
+
+    key = (normalize_for_match(book.title), normalize_for_match(first_author))
+    match = vault_index.get(key)
+    if match is None:
+        return None
+
+    path, fm = match
+    updates: List[str] = []
+
+    existing_status = fm.get("status", "")
+    if existing_status == "To Read" and book.status == "Read":
+        updates.append("status")
+
+    existing_format = fm.get("format")
+    if not existing_format and book.format:
+        updates.append("format")
+
+    return (path, fm, updates)
+
+
+def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
+    """Apply field updates to an existing vault note."""
+    if "status" in updates:
+        update_book_status(path, book.status)
+
+    if "format" in updates:
+        content = path.read_text(encoding="utf-8")
+        pattern = r"(format:\s*)(.*)"
+        new_content = re.sub(pattern, f"\\1{book.format}", content)
+        if new_content == content:
+            # format field might be null — replace the null value
+            new_content = content.replace("format: null", f"format: {book.format}")
+        path.write_text(new_content, encoding="utf-8")
+
+
+def _to_api_book(import_book: ImportBook) -> Book:
+    """Convert an ImportBook to an api.Book for note creation."""
+    return Book(
+        title=import_book.title,
+        authors=import_book.authors,
+        isbn=import_book.isbn,
+        page_count=import_book.page_count,
+        published_date=import_book.published_date,
+        google_books_id="",
+        thumbnail=None,
+        genres=import_book.genres,
+        description=import_book.description,
+    )
+
+
+def run_import(
+    path: Path,
+    vault_path: Path,
+    apply: bool = False,
+    format_name: Optional[str] = None,
+    limit: int = 0,
+) -> ImportResult:
+    """Run the import process: parse, detect duplicates, optionally write.
+
+    Returns an ImportResult with categorized books regardless of apply mode.
+    """
+    books = parse_import_file(path, format_name)
+    if limit > 0:
+        books = books[:limit]
+
+    vault_index = _build_vault_index(vault_path)
+    result = ImportResult()
+
+    for book in books:
+        dup = _check_duplicate(book, vault_index)
+
+        if dup is None:
+            result.new_books.append(book)
+            if apply:
+                api_book = _to_api_book(book)
+                created_path = create_book_note(api_book, vault_path, status=book.status)
+                # Update format in the newly created note if specified
+                if book.format:
+                    content = created_path.read_text(encoding="utf-8")
+                    new_content = content.replace("format: null", f"format: {book.format}")
+                    created_path.write_text(new_content, encoding="utf-8")
+        else:
+            dup_path, dup_fm, updates = dup
+            if updates:
+                result.updated_books.append((book, dup_path, updates))
+                if apply:
+                    _apply_updates(dup_path, book, updates)
+            else:
+                result.skipped_books.append(book)
+
+    return result

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -203,9 +203,11 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
                     data["format"] = book.format
                     # Write back the updated frontmatter
                     new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-                    new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content.lstrip()}"
+                    # Preserve content structure: remove only leading newline if present
+                    content_part = rest_of_content.lstrip('\n') if rest_of_content.startswith('\n') else rest_of_content
+                    new_content = f"---\n{new_frontmatter}\n---\n{content_part}"
                     path.write_text(new_content, encoding="utf-8")
-            except Exception:
+            except yaml.YAMLError:
                 # Fallback to regex replacement if YAML parsing fails
                 pattern = r"(format:\s*)(.*)"
                 new_content = re.sub(pattern, f"\\1{book.format}", content)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -7,8 +7,6 @@ from typer.testing import CliRunner
 from libris.cli import app
 from libris.config import set_config
 from libris.importer import (
-    ImportBook,
-    ImportResult,
     normalize_for_match,
     parse_audible_json,
     run_import,

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -242,6 +242,35 @@ def test_import_updates_format_on_duplicate(tmp_path):
     assert "format: Audiobook" in content
 
 
+def test_import_updates_format_when_field_missing(tmp_path):
+    """Test that format update works when the format field is completely missing from frontmatter."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    # Create a book note without a format field at all
+    existing = vault / "My Book - Author A.md"
+    existing.write_text(
+        "---\n"
+        "title: My Book\n"
+        "author:\n"
+        "- Author A\n"
+        "status: Read\n"
+        "---\n",
+        encoding="utf-8"
+    )
+
+    data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=True)
+    assert len(result.updated_books) == 1
+    assert "format" in result.updated_books[0][2]
+
+    content = existing.read_text(encoding="utf-8")
+    assert "format: Audiobook" in content
+
+
 def test_import_updates_both_status_and_format(tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,390 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from libris.cli import app
+from libris.config import set_config
+from libris.importer import (
+    ImportBook,
+    ImportResult,
+    normalize_for_match,
+    parse_audible_json,
+    run_import,
+)
+
+runner = CliRunner()
+
+
+def _write_book(vault: Path, name: str, **frontmatter_fields) -> Path:
+    """Helper to write a minimal book note with given frontmatter fields."""
+    lines = ["---"]
+    for key, val in frontmatter_fields.items():
+        if isinstance(val, list):
+            lines.append(f"{key}:")
+            for item in val:
+                lines.append(f"- {item}")
+        elif val is None:
+            lines.append(f"{key}: null")
+        else:
+            lines.append(f"{key}: {val}")
+    lines.append("---\n")
+    p = vault / name
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+def _write_audible_json(path: Path, entries: list[dict]) -> Path:
+    """Helper to write a JSON file with Audible-format entries."""
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+# --- normalize_for_match tests ---
+
+
+def test_normalize_for_match_basic():
+    assert normalize_for_match("Hello, World!") == "hello world"
+
+
+def test_normalize_for_match_extra_whitespace():
+    assert normalize_for_match("  foo   bar  ") == "foo bar"
+
+
+def test_normalize_for_match_punctuation():
+    assert normalize_for_match("It's a Test: Book #1") == "it s a test book 1"
+
+
+# --- parse_audible_json tests ---
+
+
+def test_parse_audible_json_basic(tmp_path):
+    data = [
+        {
+            "title": "The Great Book",
+            "author": "Jane Smith",
+            "narrator": "John Doe",
+            "series": "",
+            "length": "8h 30m",
+            "finished": "Yes",
+            "progress": "Finished",
+        },
+        {
+            "title": "Another Book",
+            "author": "Bob Jones, Alice Lee",
+            "narrator": "Someone",
+            "series": "Series A , Book 1",
+            "length": "4h",
+            "finished": "No",
+            "progress": "",
+        },
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+    books = parse_audible_json(json_file)
+
+    assert len(books) == 2
+
+    assert books[0].title == "The Great Book"
+    assert books[0].authors == ["Jane Smith"]
+    assert books[0].status == "Read"
+    assert books[0].format == "Audiobook"
+    assert books[0].source_format == "audible-json"
+
+    assert books[1].title == "Another Book"
+    assert books[1].authors == ["Bob Jones", "Alice Lee"]
+    assert books[1].status == "To Read"
+
+
+def test_parse_audible_json_skips_empty_title(tmp_path):
+    data = [
+        {"title": "", "author": "Someone", "finished": "No"},
+        {"title": "Valid Book", "author": "Author", "finished": "No"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+    books = parse_audible_json(json_file)
+    assert len(books) == 1
+    assert books[0].title == "Valid Book"
+
+
+def test_parse_audible_json_empty_author(tmp_path):
+    data = [{"title": "No Author Book", "author": "", "finished": "No"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+    books = parse_audible_json(json_file)
+    assert len(books) == 1
+    assert books[0].authors == ["Unknown Author"]
+
+
+def test_parse_audible_json_invalid_format(tmp_path):
+    json_file = tmp_path / "bad.json"
+    json_file.write_text('{"not": "an array"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected a JSON array"):
+        parse_audible_json(json_file)
+
+
+def test_parse_audible_json_empty_array(tmp_path):
+    json_file = _write_audible_json(tmp_path / "library.json", [])
+    books = parse_audible_json(json_file)
+    assert books == []
+
+
+# --- run_import / duplicate detection tests ---
+
+
+def test_import_new_books_dry_run(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": "Book One", "author": "Author A", "finished": "No"},
+        {"title": "Book Two", "author": "Author B", "finished": "Yes"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=False)
+    assert len(result.new_books) == 2
+    assert len(result.updated_books) == 0
+    assert len(result.skipped_books) == 0
+    # Dry run: no files created
+    assert list(vault.glob("*.md")) == []
+
+
+def test_import_new_books_apply(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": "Book One", "author": "Author A", "finished": "No"},
+        {"title": "Book Two", "author": "Author B", "finished": "Yes"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=True)
+    assert len(result.new_books) == 2
+
+    md_files = list(vault.glob("*.md"))
+    assert len(md_files) == 2
+
+    # Check that the status is set correctly
+    for f in md_files:
+        content = f.read_text(encoding="utf-8")
+        if "Book One" in content:
+            assert "status: To Read" in content
+            assert "format: Audiobook" in content
+        elif "Book Two" in content:
+            assert "status: Read" in content
+            assert "format: Audiobook" in content
+
+
+def test_import_detects_duplicates(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    # Pre-existing book in vault
+    _write_book(vault, "Existing Book - Author A.md",
+                title="Existing Book", author=["Author A"],
+                status="Read", format="Audiobook")
+
+    data = [
+        {"title": "Existing Book", "author": "Author A", "finished": "Yes"},
+        {"title": "New Book", "author": "Author B", "finished": "No"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=False)
+    assert len(result.new_books) == 1
+    assert len(result.skipped_books) == 1
+    assert result.skipped_books[0].title == "Existing Book"
+
+
+def test_import_updates_status_on_duplicate(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    # Existing book with "To Read" status
+    existing = _write_book(vault, "My Book - Author A.md",
+                           title="My Book", author=["Author A"],
+                           status="To Read", format=None)
+
+    data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=True)
+    assert len(result.updated_books) == 1
+    assert "status" in result.updated_books[0][2]
+
+    content = existing.read_text(encoding="utf-8")
+    assert "status: Read" in content
+
+
+def test_import_updates_format_on_duplicate(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    # Existing book with no format
+    existing = _write_book(vault, "My Book - Author A.md",
+                           title="My Book", author=["Author A"],
+                           status="Read", format=None)
+
+    data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=True)
+    assert len(result.updated_books) == 1
+    assert "format" in result.updated_books[0][2]
+
+    content = existing.read_text(encoding="utf-8")
+    assert "format: Audiobook" in content
+
+
+def test_import_updates_both_status_and_format(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    existing = _write_book(vault, "My Book - Author A.md",
+                           title="My Book", author=["Author A"],
+                           status="To Read", format=None)
+
+    data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=True)
+    assert len(result.updated_books) == 1
+    updates = result.updated_books[0][2]
+    assert "status" in updates
+    assert "format" in updates
+
+    content = existing.read_text(encoding="utf-8")
+    assert "status: Read" in content
+    assert "format: Audiobook" in content
+
+
+def test_import_skips_up_to_date_duplicate(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    _write_book(vault, "My Book - Author A.md",
+                title="My Book", author=["Author A"],
+                status="Read", format="Audiobook")
+
+    data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=False)
+    assert len(result.skipped_books) == 1
+    assert len(result.updated_books) == 0
+    assert len(result.new_books) == 0
+
+
+def test_import_limit(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": f"Book {i}", "author": f"Author {i}", "finished": "No"}
+        for i in range(10)
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=False, limit=3)
+    assert len(result.new_books) == 3
+
+
+def test_import_case_insensitive_duplicate(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    _write_book(vault, "The Great Book - Jane Smith.md",
+                title="The Great Book", author=["Jane Smith"],
+                status="Read", format="Audiobook")
+
+    # Same book with different casing
+    data = [{"title": "the great book", "author": "jane smith", "finished": "Yes"}]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = run_import(json_file, vault, apply=False)
+    assert len(result.skipped_books) == 1
+    assert len(result.new_books) == 0
+
+
+# --- CLI tests ---
+
+
+def test_cli_import_dry_run(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": "CLI Book", "author": "CLI Author", "finished": "No"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = runner.invoke(app, ["import", str(json_file)])
+    assert result.exit_code == 0
+    assert "Dry run complete" in result.output
+    assert "1 new book(s) would be added" in result.output
+    assert "Run with --apply" in result.output
+    # No files created
+    assert list(vault.glob("*.md")) == []
+
+
+def test_cli_import_apply(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": "CLI Book", "author": "CLI Author", "finished": "Yes"},
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = runner.invoke(app, ["import", str(json_file), "--apply"])
+    assert result.exit_code == 0
+    assert "Import complete" in result.output
+    assert "1 new book(s) added" in result.output
+    assert len(list(vault.glob("*.md"))) == 1
+
+
+def test_cli_import_file_not_found(tmp_path):
+    result = runner.invoke(app, ["import", str(tmp_path / "nonexistent.json")])
+    assert result.exit_code == 1
+    assert "File not found" in result.output
+
+
+def test_cli_import_with_limit(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    data = [
+        {"title": f"Book {i}", "author": f"Author {i}", "finished": "No"}
+        for i in range(10)
+    ]
+    json_file = _write_audible_json(tmp_path / "library.json", data)
+
+    result = runner.invoke(app, ["import", str(json_file), "--limit", "3"])
+    assert result.exit_code == 0
+    assert "3 new book(s) would be added" in result.output
+
+
+def test_cli_import_unknown_format(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    set_config("book_vault", str(vault))
+
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("title,author\nFoo,Bar\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["import", str(csv_file)])
+    assert result.exit_code == 1
+    assert "Cannot detect format" in result.output


### PR DESCRIPTION
## Summary
Closes #11

Adds a `libris import` command to import books from JSON/CSV files into the vault with duplicate prevention and merging.

## Changes
- **`src/libris/importer.py`** — New module with:
  - `ImportBook` dataclass (common representation for all import sources)
  - Audible JSON parser (first supported format)
  - Duplicate detection via normalized title + first author
  - Duplicate merging: upgrades status (`To Read` → `Read`) and backfills `format`
  - Pluggable `SUPPORTED_FORMATS` dict for future parsers
- **`src/libris/cli.py`** — New `libris import` command:
  - Dry-run by default, `--apply` to execute
  - `--format` to override auto-detection, `--limit N` for partial imports
  - Shared `normalize_for_match` extracted for reuse
- **`tests/test_importer.py`** — 22 tests covering parsing, dedup, merging, CLI

## Usage
```bash
# Preview what would happen
libris import library.json

# Actually import
libris import library.json --apply

# Import first 10 entries only
libris import library.json --apply --limit 10
```

## Design
Researched Goodreads CSV (31-col, ISBN `="..."` quirk) and StoryGraph CSV (half-star ratings, HTML reviews) to ensure the architecture accommodates future formats.