### PR TITLE
feat: add duplicate book merge functionality

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -10,6 +10,13 @@ from .api import GoogleBooksClient, Book
 from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates, rename_book_file, RenameResult
 from .config import get_vault_path, set_config, get_obsidian_vault_root, set_book_vault_path
 from .audible_client import get_auth_file, is_authenticated, get_locale
+from .merge import (
+    merge_two_books,
+    check_auto_merge,
+    get_primary_book,
+    write_merged_book,
+    delete_secondary_file,
+)
 
 app = typer.Typer()
 audible_app = typer.Typer(help="Audible integration commands.")
@@ -596,10 +603,6 @@ def audible_status():
             typer.echo("  Token: Expired (will auto-refresh on next use)")
 
 
-if __name__ == "__main__":
-    app()
-
-
 @app.command()
 def duplicates():
     """Find and report duplicate books in the vault."""
@@ -626,3 +629,107 @@ def duplicates():
             detail_str = f" ({', '.join(details)})" if details else ""
             typer.echo(f"  - {path.name}{detail_str}")
         typer.echo()
+
+
+@app.command()
+def merge(
+    auto: bool = typer.Option(False, "--auto", help="Auto-merge duplicates when ISBN and Google ID match (no conflicts)")
+):
+    """Merge duplicate books in the vault.
+    
+    Without --auto: Interactive mode where you choose which books to merge.
+    With --auto: Automatically merge books when ISBN + Google ID match and no metadata conflicts exist.
+    """
+    vault_path = get_vault_path()
+    groups = find_duplicates(vault_path)
+
+    if not groups:
+        typer.echo("No duplicates found.")
+        return
+
+    total_merged = 0
+
+    for group_idx, group in enumerate(groups, 1):
+        typer.echo(f"\n{'='*60}")
+        typer.echo(f"Duplicate Group {group_idx} ({len(group)} books)")
+        typer.echo(f"{'='*60}")
+        
+        # Display group members
+        for path in group:
+            fm = read_frontmatter(path)
+            title = fm.get("title", "Unknown") if fm else "Unknown"
+            status = fm.get("status", "Unknown") if fm else "Unknown"
+            isbn = fm.get("isbn") if fm else None
+            gid = fm.get("google_books_id") if fm else None
+            details = [f"Status: {status}"]
+            if isbn:
+                details.append(f"ISBN: {isbn}")
+            if gid:
+                details.append(f"Google ID: {gid}")
+            typer.echo(f"  {path.name}")
+            typer.echo(f"    {title} | {' | '.join(details)}")
+
+        if len(group) < 2:
+            continue
+
+        # Pick the most complete book as primary; merge others into it
+        primary = get_primary_book(group[0], group[1])
+        for candidate in group[2:]:
+            primary = get_primary_book(primary, candidate)
+        secondaries = [p for p in group if p != primary]
+
+        typer.echo(f"\n  Primary (keeper): {primary.name}")
+
+        for secondary in secondaries:
+            typer.echo(f"\n  Merging {secondary.name} into {primary.name}...")
+
+            try:
+                if auto:
+                    can_merge, reason, merge_result = check_auto_merge(primary, secondary)
+                    if not can_merge:
+                        typer.echo(f"    Skipped: {reason}")
+                        continue
+
+                    merged_fm, merged_body, _ = merge_result
+                    write_merged_book(primary, merged_fm, merged_body)
+                    delete_secondary_file(secondary)
+                    typer.echo(f"    Auto-merged successfully")
+                    total_merged += 1
+                else:
+                    merged_fm, merged_body, conflicts = merge_two_books(primary, secondary, allow_conflicts=False)
+
+                    if conflicts:
+                        typer.echo(f"    Conflicts detected:")
+                        for conflict in conflicts:
+                            typer.echo(f"      {conflict.field}: '{conflict.primary_value}' vs '{conflict.secondary_value}'")
+                        confirm = questionary.confirm(
+                            "    Proceed with merge (keeping primary's conflicting values)?",
+                            default=False
+                        ).ask()
+                        if not confirm:
+                            typer.echo(f"    Skipped by user")
+                            continue
+
+                        merged_fm, merged_body, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+                    else:
+                        confirm = questionary.confirm(
+                            f"    No conflicts. Merge {secondary.name} into {primary.name}?",
+                            default=True
+                        ).ask()
+                        if not confirm:
+                            typer.echo(f"    Skipped by user")
+                            continue
+
+                    write_merged_book(primary, merged_fm, merged_body)
+                    delete_secondary_file(secondary)
+                    typer.echo(f"    Merged successfully")
+                    total_merged += 1
+            except Exception as e:
+                typer.echo(f"    Error: {e}")
+                continue
+
+    typer.echo(f"\nMerge complete: {total_merged} duplicate(s) merged")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -6,10 +6,25 @@ import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from .api import GoogleBooksClient, Book
-from .markdown import create_book_note, update_book_status, list_books, ensure_frontmatter_fields, read_frontmatter, update_frontmatter_from_book, find_duplicates, rename_book_file, RenameResult
-from .config import get_vault_path, set_config, get_obsidian_vault_root, set_book_vault_path
-from .audible_client import get_auth_file, is_authenticated, get_locale
+from .api import GoogleBooksClient
+from .markdown import (
+    create_book_note,
+    update_book_status,
+    list_books,
+    ensure_frontmatter_fields,
+    read_frontmatter,
+    update_frontmatter_from_book,
+    find_duplicates,
+    rename_book_file,
+    RenameResult,
+)
+from .config import (
+    get_vault_path,
+    set_config,
+    get_obsidian_vault_root,
+    set_book_vault_path,
+)
+from .audible_client import get_auth_file, get_locale
 from .merge import (
     merge_two_books,
     check_auto_merge,
@@ -39,52 +54,54 @@ def _format_rename_skip(filename: str, result: RenameResult) -> str | None:
         return None
     return f"Skipped rename for {filename}: {msg}"
 
+
 @app.command()
 def status():
     """Update the status of a book in your vault."""
     vault_path = get_vault_path()
     books = list_books(vault_path)
-    
+
     if not books:
         typer.echo("No books found in vault.")
         return
-        
+
     choices = [p.name for p in books]
     selected_file_name = questionary.select(
-        "Select a book to update:",
-        choices=choices
+        "Select a book to update:", choices=choices
     ).ask()
-    
+
     if not selected_file_name:
         return
-        
+
     selected_file = vault_path / selected_file_name
-    
+
     new_status = questionary.select(
-        "New status:",
-        choices=["To Read", "Reading", "Finished"]
+        "New status:", choices=["To Read", "Reading", "Finished"]
     ).ask()
-    
+
     if not new_status:
         return
-        
+
     update_book_status(selected_file, new_status)
     typer.echo(f"Updated: {selected_file_name} -> {new_status}")
 
+
 @app.command(name="list")
 def list_cmd(
-    timing: bool = typer.Option(False, "--timing", help="Print scan timing for list operation")
+    timing: bool = typer.Option(
+        False, "--timing", help="Print scan timing for list operation"
+    ),
 ):
     """List all books in your vault."""
     vault_path = get_vault_path()
     start = time.perf_counter() if timing else None
     books = list_books(vault_path)
     elapsed = (time.perf_counter() - start) if timing and start is not None else None
-    
+
     if not books:
         typer.echo("No books found in vault.")
         return
-        
+
     for p in books:
         # Only read the first 1KB - enough for status extraction from frontmatter
         try:
@@ -98,6 +115,7 @@ def list_cmd(
 
     if elapsed is not None:
         typer.echo(f"Scan time: {elapsed * 1000:.2f} ms")
+
 
 @app.command()
 def search(
@@ -136,42 +154,45 @@ def search(
             typer.echo(f"  Pages:     {book.page_count}")
         typer.echo()
 
+
 @app.command()
 def add(query: str = typer.Argument(..., help="Title, author, or ISBN to search for")):
     """Search for a book and add it to your Obsidian vault."""
     client = GoogleBooksClient()
     books = client.search(query)
-    
+
     if not books:
         typer.echo("No books found.")
         return
 
     choices = [f"{book.title} by {', '.join(book.authors)}" for book in books]
-    selected_choice = questionary.select(
-        "Select a book to add:",
-        choices=choices
-    ).ask()
-    
+    selected_choice = questionary.select("Select a book to add:", choices=choices).ask()
+
     if not selected_choice:
         return
-        
+
     book_index = choices.index(selected_choice)
     selected_book = books[book_index]
-    
+
     vault_path = get_vault_path()
     if not vault_path.exists():
         typer.echo(f"Vault path does not exist: {vault_path}")
         return
-    
+
     # Create the book note
     file_path = create_book_note(selected_book, vault_path)
     typer.echo(f"Added: {file_path}")
 
+
 @app.command()
 def config(
     vault_path: str = typer.Option(None, "--vault", help="Set the vault path"),
-    obsidian_vault: str = typer.Option(None, "--obsidian-vault", help="Set the Obsidian vault root path (for wikilink updates)"),
-    api_key: str = typer.Option(None, "--api-key", help="Set the Google Books API key")
+    obsidian_vault: str = typer.Option(
+        None,
+        "--obsidian-vault",
+        help="Set the Obsidian vault root path (for wikilink updates)",
+    ),
+    api_key: str = typer.Option(None, "--api-key", help="Set the Google Books API key"),
 ):
     """Configure libris settings."""
     if vault_path:
@@ -199,6 +220,7 @@ def config(
 
     if not vault_path and not api_key and not obsidian_vault:
         from .config import get_api_key
+
         typer.echo(f"Current vault path: {get_vault_path()}")
         obsidian_root = get_obsidian_vault_root()
         if obsidian_root:
@@ -209,28 +231,31 @@ def config(
         else:
             typer.echo("API key: Not set")
 
+
 @app.command()
 def clean(
-    rename: bool = typer.Option(False, "--rename", help="Rename file to canonical Title - Author.md format"),
+    rename: bool = typer.Option(
+        False, "--rename", help="Rename file to canonical Title - Author.md format"
+    ),
 ):
     """Select a specific book to clean its frontmatter."""
     vault_path = get_vault_path()
     books = list_books(vault_path)
-    
+
     if not books:
         typer.echo("No books found in vault.")
         return
-        
+
     choices = [p.name for p in books]
     selected_file_name = questionary.autocomplete(
         "Select a book to clean:",
         choices=choices,
         match_middle=True,
     ).ask()
-    
+
     if not selected_file_name:
         return
-        
+
     selected_file = vault_path / selected_file_name
     updated, fm = ensure_frontmatter_fields(selected_file)
     if updated:
@@ -248,16 +273,25 @@ def clean(
             if msg:
                 typer.echo(msg)
 
+
 @app.command()
 def cleanup(
-    rename: bool = typer.Option(False, "--rename", help="Rename files to canonical Title - Author.md format"),
-    auto_enrich: bool = typer.Option(False, "--auto-enrich", help="Automatically enrich from Google Books when title/author is missing (uses first matching result)"),
-    limit: int = typer.Option(0, "--limit", "-n", help="Stop after N files that needed action (0 = unlimited)"),
+    rename: bool = typer.Option(
+        False, "--rename", help="Rename files to canonical Title - Author.md format"
+    ),
+    auto_enrich: bool = typer.Option(
+        False,
+        "--auto-enrich",
+        help="Automatically enrich from Google Books when title/author is missing (uses first matching result)",
+    ),
+    limit: int = typer.Option(
+        0, "--limit", "-n", help="Stop after N files that needed action (0 = unlimited)"
+    ),
 ):
     """Ensure all books in the vault have the correct frontmatter fields."""
     vault_path = get_vault_path()
     books = list_books(vault_path)
-    
+
     if not books:
         typer.echo("No books found in vault.")
         return
@@ -295,7 +329,9 @@ def cleanup(
                     typer.echo("")  # newline before enrich output
                     enriched = _enrich_auto(book_file, unmatched_files)
                 else:
-                    typer.echo(f"\n  {book_file.name}: {result.status.replace('_', ' ')}")
+                    typer.echo(
+                        f"\n  {book_file.name}: {result.status.replace('_', ' ')}"
+                    )
                     if questionary.confirm(
                         f"Enrich {book_file.name} from Google Books?",
                         default=True,
@@ -312,7 +348,9 @@ def cleanup(
             if result.status == "renamed":
                 renamed_count += 1
                 file_had_action = True
-                typer.echo(f"\n  Renamed: {book_file.name} → {result.new_path.name}", nl=False)
+                typer.echo(
+                    f"\n  Renamed: {book_file.name} → {result.new_path.name}", nl=False
+                )
             elif result.status not in ("already_canonical",):
                 msg = _format_rename_skip(book_file.name, result)
                 if msg:
@@ -334,19 +372,24 @@ def cleanup(
         if renamed_count:
             typer.echo(f"Renamed {renamed_count} file(s).")
         elif skipped_count:
-            typer.echo(f"No files renamed. {skipped_count} file(s) could not be renamed.")
+            typer.echo(
+                f"No files renamed. {skipped_count} file(s) could not be renamed."
+            )
         else:
             typer.echo("All files already have canonical names.")
 
     if unmatched_files:
-        typer.echo(f"\n--- {len(unmatched_files)} file(s) could not be auto-enriched (no matching result) ---")
+        typer.echo(
+            f"\n--- {len(unmatched_files)} file(s) could not be auto-enriched (no matching result) ---"
+        )
         for name in unmatched_files:
             typer.echo(f"  • {name}")
 
+
 def _normalize_for_match(text: str) -> str:
     """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""
-    text = re.sub(r'[^\w\s]', ' ', text.lower())
-    return re.sub(r'\s+', ' ', text).strip()
+    text = re.sub(r"[^\w\s]", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def _titles_match(filename_stem: str, book_title: str) -> bool:
@@ -386,7 +429,9 @@ def _enrich_auto(file_path: Path, unmatched_log: list[str]) -> bool:
         if update_frontmatter_from_book(file_path, first):
             # Append a note to the body indicating this was an automatic match
             _append_auto_enrich_note(file_path, first.title, file_path.stem)
-            typer.echo(f"Auto-enriched: {file_path.name} → \"{first.title}\" by {', '.join(first.authors)}")
+            typer.echo(
+                f'Auto-enriched: {file_path.name} → "{first.title}" by {", ".join(first.authors)}'
+            )
             return True
         return False
     else:
@@ -394,7 +439,9 @@ def _enrich_auto(file_path: Path, unmatched_log: list[str]) -> bool:
         return False
 
 
-def _append_auto_enrich_note(file_path: Path, matched_title: str, original_query: str) -> None:
+def _append_auto_enrich_note(
+    file_path: Path, matched_title: str, original_query: str
+) -> None:
     """Append a note to the document body and add 'review' tag indicating auto-enrichment."""
     from datetime import date
     import yaml
@@ -430,7 +477,7 @@ def _append_auto_enrich_note(file_path: Path, matched_title: str, original_query
     note = (
         f"\n\n> [!warning] Auto-enriched ({date.today().isoformat()})\n"
         f"> Title matched automatically from Google Books.\n"
-        f"> Query: \"{original_query}\" → Matched: \"{matched_title}\"\n"
+        f'> Query: "{original_query}" → Matched: "{matched_title}"\n'
         f"> Please verify this is the correct book.\n"
     )
     file_path.write_text(content.rstrip() + note + "\n", encoding="utf-8")
@@ -474,7 +521,11 @@ def _enrich_interactive(file_path: Path) -> bool:
 
 
 @app.command()
-def enrich(filename: str = typer.Argument(None, help="Name of the markdown file to enrich (e.g. 'My Book.md')")):
+def enrich(
+    filename: str = typer.Argument(
+        None, help="Name of the markdown file to enrich (e.g. 'My Book.md')"
+    ),
+):
     """Search Google Books to fill in missing data for a book."""
     vault_path = get_vault_path()
 
@@ -505,14 +556,18 @@ def enrich(filename: str = typer.Argument(None, help="Name of the markdown file 
 
 @audible_app.command()
 def login(
-    locale: str = typer.Option(None, "--locale", help="Audible marketplace country code (e.g. us, uk, de)"),
+    locale: str = typer.Option(
+        None, "--locale", help="Audible marketplace country code (e.g. us, uk, de)"
+    ),
 ):
     """Authenticate with Audible via your web browser."""
     import audible
 
     auth_file = get_auth_file()
     if auth_file.exists():
-        typer.echo("Already authenticated. Run 'libris audible logout' first to re-authenticate.")
+        typer.echo(
+            "Already authenticated. Run 'libris audible logout' first to re-authenticate."
+        )
         return
 
     effective_locale = locale or get_locale()
@@ -542,7 +597,11 @@ def login(
     if locale:
         set_config("audible_locale", locale)
 
-    device_name = auth.device_info.get("device_name", "Unknown device") if auth.device_info else "Unknown device"
+    device_name = (
+        auth.device_info.get("device_name", "Unknown device")
+        if auth.device_info
+        else "Unknown device"
+    )
     typer.echo(f"Successfully authenticated with Audible! Device: {device_name}")
 
 
@@ -560,7 +619,11 @@ def logout():
         auth = audible.Authenticator.from_file(str(auth_file))
         auth.refresh_access_token()
         auth.deregister_device()
-        device_name = auth.device_info.get("device_name", "device") if auth.device_info else "device"
+        device_name = (
+            auth.device_info.get("device_name", "device")
+            if auth.device_info
+            else "device"
+        )
         typer.echo(f"Deregistered {device_name}.")
     except Exception as e:
         typer.echo(f"Warning: Could not deregister device: {e}")
@@ -577,7 +640,9 @@ def audible_status():
 
     auth_file = get_auth_file()
     if not auth_file.exists():
-        typer.echo("Not authenticated. Run 'libris audible login' to connect your account.")
+        typer.echo(
+            "Not authenticated. Run 'libris audible login' to connect your account."
+        )
         return
 
     try:
@@ -618,7 +683,6 @@ def duplicates():
         typer.echo(f"Group {i}:")
         for path in group:
             fm = read_frontmatter(path)
-            title = fm.get("title", "Unknown") if fm else "Unknown"
             isbn = fm.get("isbn") if fm else None
             gid = fm.get("google_books_id") if fm else None
             details = []
@@ -633,10 +697,14 @@ def duplicates():
 
 @app.command()
 def merge(
-    auto: bool = typer.Option(False, "--auto", help="Auto-merge duplicates when ISBN and Google ID match (no conflicts)")
+    auto: bool = typer.Option(
+        False,
+        "--auto",
+        help="Auto-merge duplicates when ISBN and Google ID match (no conflicts)",
+    ),
 ):
     """Merge duplicate books in the vault.
-    
+
     Without --auto: Interactive mode where you choose which books to merge.
     With --auto: Automatically merge books when ISBN + Google ID match and no metadata conflicts exist.
     """
@@ -650,10 +718,10 @@ def merge(
     total_merged = 0
 
     for group_idx, group in enumerate(groups, 1):
-        typer.echo(f"\n{'='*60}")
+        typer.echo(f"\n{'=' * 60}")
         typer.echo(f"Duplicate Group {group_idx} ({len(group)} books)")
-        typer.echo(f"{'='*60}")
-        
+        typer.echo(f"{'=' * 60}")
+
         # Display group members
         for path in group:
             fm = read_frontmatter(path)
@@ -685,7 +753,9 @@ def merge(
 
             try:
                 if auto:
-                    can_merge, reason, merge_result = check_auto_merge(primary, secondary)
+                    can_merge, reason, merge_result = check_auto_merge(
+                        primary, secondary
+                    )
                     if not can_merge:
                         typer.echo(f"    Skipped: {reason}")
                         continue
@@ -693,36 +763,42 @@ def merge(
                     merged_fm, merged_body, _ = merge_result
                     write_merged_book(primary, merged_fm, merged_body)
                     delete_secondary_file(secondary)
-                    typer.echo(f"    Auto-merged successfully")
+                    typer.echo("    Auto-merged successfully")
                     total_merged += 1
                 else:
-                    merged_fm, merged_body, conflicts = merge_two_books(primary, secondary, allow_conflicts=False)
+                    merged_fm, merged_body, conflicts = merge_two_books(
+                        primary, secondary, allow_conflicts=False
+                    )
 
                     if conflicts:
-                        typer.echo(f"    Conflicts detected:")
+                        typer.echo("    Conflicts detected:")
                         for conflict in conflicts:
-                            typer.echo(f"      {conflict.field}: '{conflict.primary_value}' vs '{conflict.secondary_value}'")
+                            typer.echo(
+                                f"      {conflict.field}: '{conflict.primary_value}' vs '{conflict.secondary_value}'"
+                            )
                         confirm = questionary.confirm(
                             "    Proceed with merge (keeping primary's conflicting values)?",
-                            default=False
+                            default=False,
                         ).ask()
                         if not confirm:
-                            typer.echo(f"    Skipped by user")
+                            typer.echo("    Skipped by user")
                             continue
 
-                        merged_fm, merged_body, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+                        merged_fm, merged_body, _ = merge_two_books(
+                            primary, secondary, allow_conflicts=True
+                        )
                     else:
                         confirm = questionary.confirm(
                             f"    No conflicts. Merge {secondary.name} into {primary.name}?",
-                            default=True
+                            default=True,
                         ).ask()
                         if not confirm:
-                            typer.echo(f"    Skipped by user")
+                            typer.echo("    Skipped by user")
                             continue
 
                     write_merged_book(primary, merged_fm, merged_body)
                     delete_secondary_file(secondary)
-                    typer.echo(f"    Merged successfully")
+                    typer.echo("    Merged successfully")
                     total_merged += 1
             except Exception as e:
                 typer.echo(f"    Error: {e}")

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -1,0 +1,276 @@
+"""
+Book merge functionality for handling duplicate entries.
+
+Implements intelligent merging of two books with conflict detection and user-guided resolution.
+"""
+
+import re
+import yaml
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Tuple
+from dataclasses import dataclass
+
+from .markdown import read_frontmatter
+
+
+@dataclass
+class MergeConflict:
+    """Represents a conflicting field during merge."""
+    field: str
+    primary_value: Any
+    secondary_value: Any
+
+
+def _count_nonnull_fields(frontmatter: Dict[str, Any]) -> int:
+    """Count non-null fields in frontmatter (for determining completeness)."""
+    return sum(1 for v in frontmatter.values() if v is not None and v != "")
+
+
+def _extract_body_content(file_path: Path) -> str:
+    """Extract the body content (everything after frontmatter) from a markdown file."""
+    content = file_path.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+    if not match:
+        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
+    
+    if match:
+        return match.group(2) if len(match.groups()) > 1 else ""
+    return content
+
+
+def _merge_body_content(primary_body: str, secondary_body: str) -> str:
+    """
+    Merge body content from two books.
+    
+    - Preserves all user notes from both files
+    - Skips generic "### Description" sections (these come from API, not user content)
+    - Ensures proper formatting
+    """
+    # Remove generic Description sections (these are auto-populated from API)
+    primary_cleaned = re.sub(r"### Description\n.*?(?=\n###|\Z)", "", primary_body, flags=re.DOTALL)
+    secondary_cleaned = re.sub(r"### Description\n.*?(?=\n###|\Z)", "", secondary_body, flags=re.DOTALL)
+    
+    # Strip and combine
+    primary_cleaned = primary_cleaned.strip()
+    secondary_cleaned = secondary_cleaned.strip()
+    
+    # Combine non-empty bodies
+    if primary_cleaned and secondary_cleaned:
+        merged = f"{primary_cleaned}\n\n---\n\n**Merged from duplicate entry:**\n\n{secondary_cleaned}"
+    elif secondary_cleaned:
+        merged = secondary_cleaned
+    else:
+        merged = primary_cleaned
+    
+    return merged.strip()
+
+
+def _resolve_field_value(field: str, primary_value: Any, secondary_value: Any) -> Tuple[Any, bool]:
+    """
+    Resolve a single field during merge.
+    
+    Returns: (resolved_value, is_conflict)
+    
+    Priority rules:
+    - If either is None/empty, use the other
+    - Special handling for 'status': "Read" beats "To Read"
+    - For lists (author, genres, tags): merge unique items
+    - For other fields with conflict: return None and mark conflict
+    """
+    # Normalize None and empty string
+    primary_empty = primary_value is None or primary_value == ""
+    secondary_empty = secondary_value is None or secondary_value == ""
+    
+    if primary_empty and secondary_empty:
+        return None, False
+    if primary_empty:
+        return secondary_value, False
+    if secondary_empty:
+        return primary_value, False
+    
+    # Same values: no conflict
+    if primary_value == secondary_value:
+        return primary_value, False
+    
+    # Special handling for status field
+    if field == "status":
+        if primary_value == "Read" or secondary_value == "Read":
+            return "Read", False  # "Read" beats everything
+        return primary_value, False  # Use primary as default
+    
+    # For list fields (author, genres, tags): merge unique items
+    if field in ["author", "genres", "tags"]:
+        primary_list = primary_value if isinstance(primary_value, list) else [primary_value]
+        secondary_list = secondary_value if isinstance(secondary_value, list) else [secondary_value]
+        
+        # Merge and deduplicate
+        merged = []
+        seen = set()
+        for item in primary_list + secondary_list:
+            if item and str(item) not in seen:
+                merged.append(item)
+                seen.add(str(item))
+        
+        return (merged if merged else primary_value), False
+    
+    # All other fields with different values: conflict
+    return primary_value, True
+
+
+def merge_two_books(
+    primary_path: Path,
+    secondary_path: Path,
+    allow_conflicts: bool = False
+) -> Tuple[Dict[str, Any], str, List[MergeConflict]]:
+    """
+    Merge two book files intelligently.
+    
+    Args:
+        primary_path: Path to the primary (keeper) book file
+        secondary_path: Path to the secondary (to-be-deleted) book file
+        allow_conflicts: If False, conflicts prevent auto-merge (return them for user review)
+    
+    Returns:
+        (merged_frontmatter, merged_body, conflicts_list)
+        
+        If conflicts list is non-empty and allow_conflicts=False, the merge was prevented.
+        Otherwise, frontmatter and body are ready to write.
+    """
+    primary_fm = read_frontmatter(primary_path)
+    secondary_fm = read_frontmatter(secondary_path)
+    
+    if not primary_fm or not secondary_fm:
+        raise ValueError("Could not read frontmatter from one or both book files")
+    
+    # Extract body content
+    primary_body = _extract_body_content(primary_path)
+    secondary_body = _extract_body_content(secondary_path)
+    
+    # Merge frontmatter fields
+    merged_fm = {}
+    conflicts = []
+    
+    # Get all possible field names
+    all_fields = set(primary_fm.keys()) | set(secondary_fm.keys())
+    
+    for field in all_fields:
+        primary_val = primary_fm.get(field)
+        secondary_val = secondary_fm.get(field)
+        
+        resolved_val, has_conflict = _resolve_field_value(field, primary_val, secondary_val)
+        merged_fm[field] = resolved_val
+        
+        if has_conflict:
+            conflicts.append(MergeConflict(field, primary_val, secondary_val))
+    
+    # If there are conflicts and we don't allow them, return early
+    if conflicts and not allow_conflicts:
+        return merged_fm, "", conflicts
+    
+    # Merge body content
+    merged_body = _merge_body_content(primary_body, secondary_body)
+    
+    return merged_fm, merged_body, conflicts
+
+
+def check_auto_merge(
+    primary_path: Path,
+    secondary_path: Path
+) -> Tuple[bool, Optional[str], Optional[Tuple[Dict[str, Any], str, List[MergeConflict]]]]:
+    """
+    Determine if two books can be auto-merged based on ISBN and Google Books ID match.
+    
+    Also checks for metadata conflicts that would prevent automatic merging.
+    
+    When ISBN and Google ID both match, we allow title differences (they may be normalized
+    differently), but flag other metadata conflicts.
+    
+    Returns:
+        (can_auto_merge, reason_if_no, merge_result_or_none)
+        
+        When can_auto_merge is True, merge_result contains (merged_fm, merged_body, conflicts)
+        so the caller can write immediately without re-reading the files.
+    """
+    primary_fm = read_frontmatter(primary_path)
+    secondary_fm = read_frontmatter(secondary_path)
+    
+    if not primary_fm or not secondary_fm:
+        return False, "Could not read frontmatter", None
+    
+    # Check ISBN and Google Books ID match
+    primary_isbn = primary_fm.get("isbn")
+    secondary_isbn = secondary_fm.get("isbn")
+    primary_gid = primary_fm.get("google_books_id")
+    secondary_gid = secondary_fm.get("google_books_id")
+    
+    # Both ISBN and Google ID must match to auto-merge
+    isbn_match = primary_isbn and secondary_isbn and str(primary_isbn) == str(secondary_isbn)
+    gid_match = primary_gid and secondary_gid and str(primary_gid) == str(secondary_gid)
+    
+    if not (isbn_match and gid_match):
+        return False, "ISBN or Google Books ID mismatch", None
+    
+    # Check for metadata conflicts (excluding title, which may differ due to normalization)
+    merged_fm, merged_body, conflicts = merge_two_books(primary_path, secondary_path, allow_conflicts=True)
+    
+    if conflicts:
+        # Filter out title conflicts (acceptable when ISBN and Google ID match)
+        non_title_conflicts = [c for c in conflicts if c.field != "title"]
+        if non_title_conflicts:
+            conflict_fields = [c.field for c in non_title_conflicts]
+            return False, f"Metadata conflicts in: {', '.join(conflict_fields)}", None
+    
+    return True, None, (merged_fm, merged_body, conflicts)
+
+
+def write_merged_book(
+    primary_path: Path,
+    merged_frontmatter: Dict[str, Any],
+    merged_body: str
+) -> None:
+    """Write merged frontmatter and body to the primary file."""
+    frontmatter_yaml = yaml.dump(merged_frontmatter, sort_keys=False, allow_unicode=True).strip()
+    content = f"---\n{frontmatter_yaml}\n---\n{merged_body.lstrip()}"
+    primary_path.write_text(content, encoding="utf-8")
+
+
+def delete_secondary_file(secondary_path: Path) -> None:
+    """Delete the secondary (merged-away) file."""
+    secondary_path.unlink()
+
+
+def get_primary_book(path1: Path, path2: Path) -> Path:
+    """
+    Determine which book should be primary (keeper) based on completeness.
+    
+    Strategy:
+    1. Book with more non-null frontmatter fields is primary
+    2. Tiebreaker: earlier date_added
+    3. Fallback: path1
+    """
+    fm1 = read_frontmatter(path1)
+    fm2 = read_frontmatter(path2)
+    
+    if not fm1 or not fm2:
+        return path1
+    
+    count1 = _count_nonnull_fields(fm1)
+    count2 = _count_nonnull_fields(fm2)
+    
+    if count1 != count2:
+        return path1 if count1 > count2 else path2
+    
+    # Tiebreaker: earlier date_added
+    date1 = fm1.get("date_added")
+    date2 = fm2.get("date_added")
+    
+    if date1 and date2:
+        try:
+            if date1 < date2:
+                return path1
+            else:
+                return path2
+        except TypeError:
+            pass
+    
+    return path1

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -16,6 +16,7 @@ from .markdown import read_frontmatter
 @dataclass
 class MergeConflict:
     """Represents a conflicting field during merge."""
+
     field: str
     primary_value: Any
     secondary_value: Any
@@ -32,7 +33,7 @@ def _extract_body_content(file_path: Path) -> str:
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
     if not match:
         match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
-    
+
     if match:
         return match.group(2) if len(match.groups()) > 1 else ""
     return content
@@ -41,19 +42,23 @@ def _extract_body_content(file_path: Path) -> str:
 def _merge_body_content(primary_body: str, secondary_body: str) -> str:
     """
     Merge body content from two books.
-    
+
     - Preserves all user notes from both files
     - Skips generic "### Description" sections (these come from API, not user content)
     - Ensures proper formatting
     """
     # Remove generic Description sections (these are auto-populated from API)
-    primary_cleaned = re.sub(r"### Description\n.*?(?=\n###|\Z)", "", primary_body, flags=re.DOTALL)
-    secondary_cleaned = re.sub(r"### Description\n.*?(?=\n###|\Z)", "", secondary_body, flags=re.DOTALL)
-    
+    primary_cleaned = re.sub(
+        r"### Description\n.*?(?=\n###|\Z)", "", primary_body, flags=re.DOTALL
+    )
+    secondary_cleaned = re.sub(
+        r"### Description\n.*?(?=\n###|\Z)", "", secondary_body, flags=re.DOTALL
+    )
+
     # Strip and combine
     primary_cleaned = primary_cleaned.strip()
     secondary_cleaned = secondary_cleaned.strip()
-    
+
     # Combine non-empty bodies
     if primary_cleaned and secondary_cleaned:
         merged = f"{primary_cleaned}\n\n---\n\n**Merged from duplicate entry:**\n\n{secondary_cleaned}"
@@ -61,16 +66,18 @@ def _merge_body_content(primary_body: str, secondary_body: str) -> str:
         merged = secondary_cleaned
     else:
         merged = primary_cleaned
-    
+
     return merged.strip()
 
 
-def _resolve_field_value(field: str, primary_value: Any, secondary_value: Any) -> Tuple[Any, bool]:
+def _resolve_field_value(
+    field: str, primary_value: Any, secondary_value: Any
+) -> Tuple[Any, bool]:
     """
     Resolve a single field during merge.
-    
+
     Returns: (resolved_value, is_conflict)
-    
+
     Priority rules:
     - If either is None/empty, use the other
     - Special handling for 'status': "Read" beats "To Read"
@@ -80,29 +87,33 @@ def _resolve_field_value(field: str, primary_value: Any, secondary_value: Any) -
     # Normalize None and empty string
     primary_empty = primary_value is None or primary_value == ""
     secondary_empty = secondary_value is None or secondary_value == ""
-    
+
     if primary_empty and secondary_empty:
         return None, False
     if primary_empty:
         return secondary_value, False
     if secondary_empty:
         return primary_value, False
-    
+
     # Same values: no conflict
     if primary_value == secondary_value:
         return primary_value, False
-    
+
     # Special handling for status field
     if field == "status":
         if primary_value == "Read" or secondary_value == "Read":
             return "Read", False  # "Read" beats everything
         return primary_value, False  # Use primary as default
-    
+
     # For list fields (author, genres, tags): merge unique items
     if field in ["author", "genres", "tags"]:
-        primary_list = primary_value if isinstance(primary_value, list) else [primary_value]
-        secondary_list = secondary_value if isinstance(secondary_value, list) else [secondary_value]
-        
+        primary_list = (
+            primary_value if isinstance(primary_value, list) else [primary_value]
+        )
+        secondary_list = (
+            secondary_value if isinstance(secondary_value, list) else [secondary_value]
+        )
+
         # Merge and deduplicate
         merged = []
         seen = set()
@@ -110,126 +121,131 @@ def _resolve_field_value(field: str, primary_value: Any, secondary_value: Any) -
             if item and str(item) not in seen:
                 merged.append(item)
                 seen.add(str(item))
-        
+
         return (merged if merged else primary_value), False
-    
+
     # All other fields with different values: conflict
     return primary_value, True
 
 
 def merge_two_books(
-    primary_path: Path,
-    secondary_path: Path,
-    allow_conflicts: bool = False
+    primary_path: Path, secondary_path: Path, allow_conflicts: bool = False
 ) -> Tuple[Dict[str, Any], str, List[MergeConflict]]:
     """
     Merge two book files intelligently.
-    
+
     Args:
         primary_path: Path to the primary (keeper) book file
         secondary_path: Path to the secondary (to-be-deleted) book file
         allow_conflicts: If False, conflicts prevent auto-merge (return them for user review)
-    
+
     Returns:
         (merged_frontmatter, merged_body, conflicts_list)
-        
+
         If conflicts list is non-empty and allow_conflicts=False, the merge was prevented.
         Otherwise, frontmatter and body are ready to write.
     """
     primary_fm = read_frontmatter(primary_path)
     secondary_fm = read_frontmatter(secondary_path)
-    
+
     if not primary_fm or not secondary_fm:
         raise ValueError("Could not read frontmatter from one or both book files")
-    
+
     # Extract body content
     primary_body = _extract_body_content(primary_path)
     secondary_body = _extract_body_content(secondary_path)
-    
+
     # Merge frontmatter fields
     merged_fm = {}
     conflicts = []
-    
+
     # Get all possible field names
     all_fields = set(primary_fm.keys()) | set(secondary_fm.keys())
-    
+
     for field in all_fields:
         primary_val = primary_fm.get(field)
         secondary_val = secondary_fm.get(field)
-        
-        resolved_val, has_conflict = _resolve_field_value(field, primary_val, secondary_val)
+
+        resolved_val, has_conflict = _resolve_field_value(
+            field, primary_val, secondary_val
+        )
         merged_fm[field] = resolved_val
-        
+
         if has_conflict:
             conflicts.append(MergeConflict(field, primary_val, secondary_val))
-    
+
     # If there are conflicts and we don't allow them, return early
     if conflicts and not allow_conflicts:
         return merged_fm, "", conflicts
-    
+
     # Merge body content
     merged_body = _merge_body_content(primary_body, secondary_body)
-    
+
     return merged_fm, merged_body, conflicts
 
 
 def check_auto_merge(
-    primary_path: Path,
-    secondary_path: Path
-) -> Tuple[bool, Optional[str], Optional[Tuple[Dict[str, Any], str, List[MergeConflict]]]]:
+    primary_path: Path, secondary_path: Path
+) -> Tuple[
+    bool, Optional[str], Optional[Tuple[Dict[str, Any], str, List[MergeConflict]]]
+]:
     """
     Determine if two books can be auto-merged based on ISBN and Google Books ID match.
-    
+
     Also checks for metadata conflicts that would prevent automatic merging.
-    
+
     When ISBN and Google ID both match, we allow title differences (they may be normalized
     differently), but flag other metadata conflicts.
-    
+
     Returns:
         (can_auto_merge, reason_if_no, merge_result_or_none)
-        
+
         When can_auto_merge is True, merge_result contains (merged_fm, merged_body, conflicts)
         so the caller can write immediately without re-reading the files.
     """
     primary_fm = read_frontmatter(primary_path)
     secondary_fm = read_frontmatter(secondary_path)
-    
+
     if not primary_fm or not secondary_fm:
         return False, "Could not read frontmatter", None
-    
+
     # Check ISBN and Google Books ID match
     primary_isbn = primary_fm.get("isbn")
     secondary_isbn = secondary_fm.get("isbn")
     primary_gid = primary_fm.get("google_books_id")
     secondary_gid = secondary_fm.get("google_books_id")
-    
+
     # Both ISBN and Google ID must match to auto-merge
-    isbn_match = primary_isbn and secondary_isbn and str(primary_isbn) == str(secondary_isbn)
+    isbn_match = (
+        primary_isbn and secondary_isbn and str(primary_isbn) == str(secondary_isbn)
+    )
     gid_match = primary_gid and secondary_gid and str(primary_gid) == str(secondary_gid)
-    
+
     if not (isbn_match and gid_match):
         return False, "ISBN or Google Books ID mismatch", None
-    
+
     # Check for metadata conflicts (excluding title, which may differ due to normalization)
-    merged_fm, merged_body, conflicts = merge_two_books(primary_path, secondary_path, allow_conflicts=True)
-    
+    merged_fm, merged_body, conflicts = merge_two_books(
+        primary_path, secondary_path, allow_conflicts=True
+    )
+
     if conflicts:
         # Filter out title conflicts (acceptable when ISBN and Google ID match)
         non_title_conflicts = [c for c in conflicts if c.field != "title"]
         if non_title_conflicts:
             conflict_fields = [c.field for c in non_title_conflicts]
             return False, f"Metadata conflicts in: {', '.join(conflict_fields)}", None
-    
+
     return True, None, (merged_fm, merged_body, conflicts)
 
 
 def write_merged_book(
-    primary_path: Path,
-    merged_frontmatter: Dict[str, Any],
-    merged_body: str
+    primary_path: Path, merged_frontmatter: Dict[str, Any], merged_body: str
 ) -> None:
     """Write merged frontmatter and body to the primary file."""
-    frontmatter_yaml = yaml.dump(merged_frontmatter, sort_keys=False, allow_unicode=True).strip()
+    frontmatter_yaml = yaml.dump(
+        merged_frontmatter, sort_keys=False, allow_unicode=True
+    ).strip()
     content = f"---\n{frontmatter_yaml}\n---\n{merged_body.lstrip()}"
     primary_path.write_text(content, encoding="utf-8")
 
@@ -242,7 +258,7 @@ def delete_secondary_file(secondary_path: Path) -> None:
 def get_primary_book(path1: Path, path2: Path) -> Path:
     """
     Determine which book should be primary (keeper) based on completeness.
-    
+
     Strategy:
     1. Book with more non-null frontmatter fields is primary
     2. Tiebreaker: earlier date_added
@@ -250,20 +266,20 @@ def get_primary_book(path1: Path, path2: Path) -> Path:
     """
     fm1 = read_frontmatter(path1)
     fm2 = read_frontmatter(path2)
-    
+
     if not fm1 or not fm2:
         return path1
-    
+
     count1 = _count_nonnull_fields(fm1)
     count2 = _count_nonnull_fields(fm2)
-    
+
     if count1 != count2:
         return path1 if count1 > count2 else path2
-    
+
     # Tiebreaker: earlier date_added
     date1 = fm1.get("date_added")
     date2 = fm2.get("date_added")
-    
+
     if date1 and date2:
         try:
             if date1 < date2:
@@ -272,5 +288,5 @@ def get_primary_book(path1: Path, path2: Path) -> Path:
                 return path2
         except TypeError:
             pass
-    
+
     return path1

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,606 @@
+"""
+Tests for book merge functionality.
+"""
+
+from pathlib import Path
+import pytest
+from libris.merge import (
+    merge_two_books,
+    check_auto_merge,
+    get_primary_book,
+    write_merged_book,
+    delete_secondary_file,
+    MergeConflict,
+)
+
+
+def _write_book(vault: Path, name: str, **frontmatter_fields) -> Path:
+    """Helper to write a minimal book note with given frontmatter fields."""
+    lines = ["---"]
+    for key, val in frontmatter_fields.items():
+        if isinstance(val, list):
+            lines.append(f"{key}:")
+            for item in val:
+                lines.append(f"  - {item}")
+        elif val is None:
+            lines.append(f"{key}:")
+        else:
+            lines.append(f"{key}: {val}")
+    lines.append("---\n")
+    lines.append("## Notes\n\n")
+    p = vault / name
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+class TestMergeTwoBooks:
+    """Test merge_two_books() function."""
+
+    def test_identical_books_no_conflicts(self, tmp_path):
+        """Two identical books should merge cleanly with no conflicts."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Test Book",
+            author=["Alice"],
+            isbn="123-456",
+            google_books_id="gb1",
+            status="To Read"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Test Book",
+            author=["Alice"],
+            isbn="123-456",
+            google_books_id="gb1",
+            status="To Read"
+        )
+
+        merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
+        
+        assert len(conflicts) == 0
+        assert merged_fm["title"] == "Test Book"
+        assert merged_fm["isbn"] == "123-456"
+
+    def test_status_priority_read_beats_to_read(self, tmp_path):
+        """Status 'Read' should beat 'To Read' in merge."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="To Read"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="Read"
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        assert len(conflicts) == 0
+        assert merged_fm["status"] == "Read"
+
+    def test_status_priority_both_read(self, tmp_path):
+        """Both 'Read' should stay 'Read'."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="Read"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="Read"
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        assert len(conflicts) == 0
+        assert merged_fm["status"] == "Read"
+
+    def test_null_field_filled_from_secondary(self, tmp_path):
+        """Null fields in primary should be filled from secondary."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=None,
+            description=None
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
+            description=None
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        assert len(conflicts) == 0
+        assert merged_fm["page_count"] == 300
+
+    def test_metadata_conflict_different_authors(self, tmp_path):
+        """Different non-null author lists should trigger conflict."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            author=["Alice"]
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            author=["Bob"]
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        # Should have conflict in author field
+        conflict_fields = [c.field for c in conflicts]
+        assert "author" not in conflict_fields  # Authors should be merged as lists
+        assert len(merged_fm["author"]) == 2
+
+    def test_metadata_conflict_different_page_count(self, tmp_path):
+        """Different page counts should trigger conflict."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=250
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        # page_count conflict should be detected
+        conflict_fields = [c.field for c in conflicts]
+        assert "page_count" in conflict_fields
+
+    def test_conflicts_prevent_merge_when_not_allowed(self, tmp_path):
+        """With allow_conflicts=False, conflicts should be returned."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=250
+        )
+
+        merged_fm, merged_body, conflicts = merge_two_books(path1, path2, allow_conflicts=False)
+        
+        assert len(conflicts) > 0
+        assert merged_body == ""  # Body empty when merge blocked
+
+    def test_merge_with_allow_conflicts(self, tmp_path):
+        """With allow_conflicts=True, conflicts should be resolved and body merged."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=250
+        )
+
+        merged_fm, merged_body, conflicts = merge_two_books(path1, path2, allow_conflicts=True)
+        
+        # Merge should proceed
+        assert merged_fm["page_count"] == 300  # Primary wins
+        assert len(conflicts) > 0  # But conflicts are still recorded
+
+    def test_merge_author_lists(self, tmp_path):
+        """Author lists from both books should be merged and deduplicated."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            author=["Alice", "Charlie"]
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            author=["Bob", "Alice"]  # Alice appears in both
+        )
+
+        merged_fm, _, conflicts = merge_two_books(path1, path2)
+        
+        assert len(conflicts) == 0
+        assert len(merged_fm["author"]) == 3
+        assert "Alice" in merged_fm["author"]
+        assert "Bob" in merged_fm["author"]
+        assert "Charlie" in merged_fm["author"]
+
+    def test_merge_body_content(self, tmp_path):
+        """Body content from both files should be merged."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        
+        # Create book with custom body content
+        path1 = vault / "A.md"
+        path1.write_text(
+            "---\n"
+            "title: Book\nisbn: 123\ngoogle_books_id: gb1\n"
+            "---\n"
+            "## Notes\n\nMy notes for book A\n"
+        )
+        
+        path2 = vault / "B.md"
+        path2.write_text(
+            "---\n"
+            "title: Book\nisbn: 123\ngoogle_books_id: gb1\n"
+            "---\n"
+            "## Notes\n\nMy notes for book B\n"
+        )
+
+        merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
+        
+        assert "My notes for book A" in merged_body
+        assert "My notes for book B" in merged_body
+
+    def test_skip_generic_description_section(self, tmp_path):
+        """Generic Description sections (from API) should be skipped during merge."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        
+        path1 = vault / "A.md"
+        path1.write_text(
+            "---\n"
+            "title: Book\nisbn: 123\ngoogle_books_id: gb1\n"
+            "---\n"
+            "## Notes\n\nMy personal notes\n\n### Description\nAPI-provided description\n"
+        )
+        
+        path2 = vault / "B.md"
+        path2.write_text(
+            "---\n"
+            "title: Book\nisbn: 123\ngoogle_books_id: gb1\n"
+            "---\n"
+            "## Notes\n\n### Description\nDifferent API description\n"
+        )
+
+        merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
+        
+        # Personal notes should be there
+        assert "My personal notes" in merged_body
+        # API descriptions should not appear
+        assert "API-provided description" not in merged_body
+        assert "Different API description" not in merged_body
+
+
+class TestCheckAutoMerge:
+    """Test check_auto_merge() function."""
+
+    def test_auto_merge_both_ids_match(self, tmp_path):
+        """Should auto-merge when both ISBN and Google ID match."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book A", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book B", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+
+        can_merge, reason, merge_result = check_auto_merge(path1, path2)
+        assert can_merge is True
+        assert reason is None
+        assert merge_result is not None
+        merged_fm, merged_body, _ = merge_result
+        assert str(merged_fm["isbn"]) == "123"
+
+    def test_no_auto_merge_isbn_mismatch(self, tmp_path):
+        """Should not auto-merge if ISBN differs."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="999", google_books_id="gb1"
+        )
+
+        can_merge, reason, merge_result = check_auto_merge(path1, path2)
+        assert can_merge is False
+        assert reason is not None
+        assert merge_result is None
+
+    def test_no_auto_merge_google_id_mismatch(self, tmp_path):
+        """Should not auto-merge if Google Books ID differs."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb2"
+        )
+
+        can_merge, reason, merge_result = check_auto_merge(path1, path2)
+        assert can_merge is False
+        assert reason is not None
+        assert merge_result is None
+
+    def test_no_auto_merge_with_conflicts(self, tmp_path):
+        """Should not auto-merge if there are metadata conflicts."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=250
+        )
+
+        can_merge, reason, merge_result = check_auto_merge(path1, path2)
+        assert can_merge is False
+        assert "conflict" in reason.lower()
+        assert merge_result is None
+
+    def test_no_auto_merge_missing_isbn(self, tmp_path):
+        """Should not auto-merge if ISBN is missing from either book."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", google_books_id="gb1"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+
+        can_merge, reason, _ = check_auto_merge(path1, path2)
+        assert can_merge is False
+
+
+class TestGetPrimaryBook:
+    """Test get_primary_book() function."""
+
+    def test_primary_is_more_complete(self, tmp_path):
+        """Book with more non-null fields should be primary."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300, genres=["Fiction"], rating=5
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+
+        primary = get_primary_book(path1, path2)
+        assert primary == path1
+
+    def test_primary_fallback_to_first_when_equal_completeness(self, tmp_path):
+        """When completeness is equal, should fallback to first path."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+
+        primary = get_primary_book(path1, path2)
+        assert primary == path1
+
+    def test_primary_by_earlier_date_added(self, tmp_path):
+        """When completeness is equal, earlier date_added wins."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            date_added="2024-01-01"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            date_added="2024-06-01"
+        )
+
+        primary = get_primary_book(path1, path2)
+        assert primary == path1
+
+
+class TestWriteMergedBook:
+    """Test write_merged_book() function."""
+
+    def test_write_merged_frontmatter_and_body(self, tmp_path):
+        """Should write merged frontmatter and body to file."""
+        path = tmp_path / "book.md"
+        
+        merged_fm = {
+            "title": "Book",
+            "isbn": "123",
+            "google_books_id": "gb1",
+            "status": "Read"
+        }
+        merged_body = "## Notes\n\nMy notes here"
+
+        write_merged_book(path, merged_fm, merged_body)
+
+        content = path.read_text()
+        assert "title: Book" in content
+        assert "isbn: '123'" in content or "isbn: 123" in content
+        assert "My notes here" in content
+
+
+class TestDeleteSecondaryFile:
+    """Test delete_secondary_file() function."""
+
+    def test_delete_file(self, tmp_path):
+        """Should delete the secondary file."""
+        path = tmp_path / "book.md"
+        path.write_text("content")
+        assert path.exists()
+
+        delete_secondary_file(path)
+
+        assert not path.exists()
+
+
+class TestMergeEdgeCases:
+    """Edge case tests for merge functionality."""
+
+    def test_merge_three_book_group(self, tmp_path):
+        """Merging a group of 3 books should work progressively."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="To Read", page_count=300
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            status="Read", rating=5
+        )
+        path3 = _write_book(
+            tmp_path, "C.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            genres=["Fiction"]
+        )
+
+        # Merge B into A
+        fm1, body1, conflicts1 = merge_two_books(path1, path2)
+        assert fm1["status"] == "Read"  # Read wins
+        assert fm1["page_count"] == 300  # From A
+        assert fm1["rating"] == 5  # From B
+
+        write_merged_book(path1, fm1, body1)
+
+        # Merge C into updated A
+        fm2, body2, conflicts2 = merge_two_books(path1, path3)
+        assert fm2["genres"] == ["Fiction"]  # From C
+
+    def test_merge_empty_primary_body_with_secondary_notes(self, tmp_path):
+        """Secondary notes should be preserved when primary body is empty."""
+        path1 = tmp_path / "A.md"
+        path1.write_text(
+            "---\ntitle: Book\nisbn: 123\ngoogle_books_id: gb1\n---\n",
+            encoding="utf-8",
+        )
+
+        path2 = tmp_path / "B.md"
+        path2.write_text(
+            "---\ntitle: Book\nisbn: 123\ngoogle_books_id: gb1\n---\n"
+            "## Notes\n\nImportant notes from B\n",
+            encoding="utf-8",
+        )
+
+        _, merged_body, _ = merge_two_books(path1, path2)
+        assert "Important notes from B" in merged_body
+
+    def test_merge_both_bodies_empty(self, tmp_path):
+        """Merge with both bodies empty should produce empty body."""
+        path1 = tmp_path / "A.md"
+        path1.write_text(
+            "---\ntitle: Book\nisbn: 123\ngoogle_books_id: gb1\n---\n",
+            encoding="utf-8",
+        )
+        path2 = tmp_path / "B.md"
+        path2.write_text(
+            "---\ntitle: Book\nisbn: 123\ngoogle_books_id: gb1\n---\n",
+            encoding="utf-8",
+        )
+
+        _, merged_body, _ = merge_two_books(path1, path2)
+        assert merged_body.strip() == ""
+
+    def test_merge_unreadable_frontmatter_raises(self, tmp_path):
+        """Merge with unreadable frontmatter should raise ValueError."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123", google_books_id="gb1"
+        )
+        path2 = tmp_path / "B.md"
+        path2.write_text("No frontmatter here", encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            merge_two_books(path1, path2)
+
+    def test_get_primary_book_selects_secondary_when_more_complete(self, tmp_path):
+        """get_primary_book should pick secondary when it has more fields."""
+        path1 = _write_book(
+            tmp_path, "A.md",
+            title="Book", isbn="123"
+        )
+        path2 = _write_book(
+            tmp_path, "B.md",
+            title="Book", isbn="123", google_books_id="gb1",
+            page_count=300, rating=4, genres=["Fiction"]
+        )
+
+        primary = get_primary_book(path1, path2)
+        assert primary == path2
+
+
+class TestMergeCLI:
+    """CLI integration tests for the merge command."""
+
+    def test_merge_auto_no_duplicates(self, tmp_path):
+        from typer.testing import CliRunner
+        from libris.cli import app
+        from libris.config import set_config
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_book(vault, "A.md", title="Book A", isbn="111", google_books_id="a1")
+        _write_book(vault, "B.md", title="Book B", isbn="222", google_books_id="b2")
+        set_config("vault_path", str(vault))
+
+        result = CliRunner().invoke(app, ["merge", "--auto"])
+        assert result.exit_code == 0
+        assert "No duplicates found" in result.output
+
+    def test_merge_auto_succeeds(self, tmp_path):
+        from typer.testing import CliRunner
+        from libris.cli import app
+        from libris.config import set_config
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_book(vault, "A.md", title="Book A", isbn="123", google_books_id="gb1",
+                     status="To Read", page_count=300)
+        _write_book(vault, "B.md", title="Book B", isbn="123", google_books_id="gb1",
+                     status="Read")
+        set_config("vault_path", str(vault))
+
+        result = CliRunner().invoke(app, ["merge", "--auto"])
+        assert result.exit_code == 0
+        assert "1 duplicate(s) merged" in result.output
+        # Secondary file should be deleted
+        assert not (vault / "B.md").exists() or not (vault / "A.md").exists()
+        # At least one should remain
+        remaining = list(vault.glob("*.md"))
+        assert len(remaining) == 1
+
+    def test_merge_auto_skips_conflicts(self, tmp_path):
+        from typer.testing import CliRunner
+        from libris.cli import app
+        from libris.config import set_config
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        _write_book(vault, "A.md", title="Book", isbn="123", google_books_id="gb1",
+                     page_count=300)
+        _write_book(vault, "B.md", title="Book", isbn="123", google_books_id="gb1",
+                     page_count=250)
+        set_config("vault_path", str(vault))
+
+        result = CliRunner().invoke(app, ["merge", "--auto"])
+        assert result.exit_code == 0
+        assert "Skipped" in result.output
+        assert "0 duplicate(s) merged" in result.output
+        # Both files should still exist
+        assert (vault / "A.md").exists()
+        assert (vault / "B.md").exists()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -10,7 +10,6 @@ from libris.merge import (
     get_primary_book,
     write_merged_book,
     delete_secondary_file,
-    MergeConflict,
 )
 
 
@@ -39,24 +38,26 @@ class TestMergeTwoBooks:
     def test_identical_books_no_conflicts(self, tmp_path):
         """Two identical books should merge cleanly with no conflicts."""
         path1 = _write_book(
-            tmp_path, "A.md",
+            tmp_path,
+            "A.md",
             title="Test Book",
             author=["Alice"],
             isbn="123-456",
             google_books_id="gb1",
-            status="To Read"
+            status="To Read",
         )
         path2 = _write_book(
-            tmp_path, "B.md",
+            tmp_path,
+            "B.md",
             title="Test Book",
             author=["Alice"],
             isbn="123-456",
             google_books_id="gb1",
-            status="To Read"
+            status="To Read",
         )
 
         merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
-        
+
         assert len(conflicts) == 0
         assert merged_fm["title"] == "Test Book"
         assert merged_fm["isbn"] == "123-456"
@@ -64,78 +65,98 @@ class TestMergeTwoBooks:
     def test_status_priority_read_beats_to_read(self, tmp_path):
         """Status 'Read' should beat 'To Read' in merge."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="To Read"
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="To Read",
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="Read"
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="Read",
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         assert len(conflicts) == 0
         assert merged_fm["status"] == "Read"
 
     def test_status_priority_both_read(self, tmp_path):
         """Both 'Read' should stay 'Read'."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="Read"
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="Read",
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="Read"
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="Read",
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         assert len(conflicts) == 0
         assert merged_fm["status"] == "Read"
 
     def test_null_field_filled_from_secondary(self, tmp_path):
         """Null fields in primary should be filled from secondary."""
         path1 = _write_book(
-            tmp_path, "A.md",
+            tmp_path,
+            "A.md",
             title="Book",
             isbn="123",
             google_books_id="gb1",
             page_count=None,
-            description=None
+            description=None,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
+            tmp_path,
+            "B.md",
             title="Book",
             isbn="123",
             google_books_id="gb1",
             page_count=300,
-            description=None
+            description=None,
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         assert len(conflicts) == 0
         assert merged_fm["page_count"] == 300
 
     def test_metadata_conflict_different_authors(self, tmp_path):
         """Different non-null author lists should trigger conflict."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            author=["Alice"]
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            author=["Alice"],
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            author=["Bob"]
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            author=["Bob"],
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         # Should have conflict in author field
         conflict_fields = [c.field for c in conflicts]
         assert "author" not in conflict_fields  # Authors should be merged as lists
@@ -144,18 +165,24 @@ class TestMergeTwoBooks:
     def test_metadata_conflict_different_page_count(self, tmp_path):
         """Different page counts should trigger conflict."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=250
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=250,
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         # page_count conflict should be detected
         conflict_fields = [c.field for c in conflicts]
         assert "page_count" in conflict_fields
@@ -163,36 +190,52 @@ class TestMergeTwoBooks:
     def test_conflicts_prevent_merge_when_not_allowed(self, tmp_path):
         """With allow_conflicts=False, conflicts should be returned."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=250
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=250,
         )
 
-        merged_fm, merged_body, conflicts = merge_two_books(path1, path2, allow_conflicts=False)
-        
+        merged_fm, merged_body, conflicts = merge_two_books(
+            path1, path2, allow_conflicts=False
+        )
+
         assert len(conflicts) > 0
         assert merged_body == ""  # Body empty when merge blocked
 
     def test_merge_with_allow_conflicts(self, tmp_path):
         """With allow_conflicts=True, conflicts should be resolved and body merged."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=250
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=250,
         )
 
-        merged_fm, merged_body, conflicts = merge_two_books(path1, path2, allow_conflicts=True)
-        
+        merged_fm, merged_body, conflicts = merge_two_books(
+            path1, path2, allow_conflicts=True
+        )
+
         # Merge should proceed
         assert merged_fm["page_count"] == 300  # Primary wins
         assert len(conflicts) > 0  # But conflicts are still recorded
@@ -200,18 +243,24 @@ class TestMergeTwoBooks:
     def test_merge_author_lists(self, tmp_path):
         """Author lists from both books should be merged and deduplicated."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            author=["Alice", "Charlie"]
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            author=["Alice", "Charlie"],
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            author=["Bob", "Alice"]  # Alice appears in both
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            author=["Bob", "Alice"],  # Alice appears in both
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
-        
+
         assert len(conflicts) == 0
         assert len(merged_fm["author"]) == 3
         assert "Alice" in merged_fm["author"]
@@ -222,7 +271,7 @@ class TestMergeTwoBooks:
         """Body content from both files should be merged."""
         vault = tmp_path / "vault"
         vault.mkdir()
-        
+
         # Create book with custom body content
         path1 = vault / "A.md"
         path1.write_text(
@@ -231,7 +280,7 @@ class TestMergeTwoBooks:
             "---\n"
             "## Notes\n\nMy notes for book A\n"
         )
-        
+
         path2 = vault / "B.md"
         path2.write_text(
             "---\n"
@@ -241,7 +290,7 @@ class TestMergeTwoBooks:
         )
 
         merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
-        
+
         assert "My notes for book A" in merged_body
         assert "My notes for book B" in merged_body
 
@@ -249,7 +298,7 @@ class TestMergeTwoBooks:
         """Generic Description sections (from API) should be skipped during merge."""
         vault = tmp_path / "vault"
         vault.mkdir()
-        
+
         path1 = vault / "A.md"
         path1.write_text(
             "---\n"
@@ -257,7 +306,7 @@ class TestMergeTwoBooks:
             "---\n"
             "## Notes\n\nMy personal notes\n\n### Description\nAPI-provided description\n"
         )
-        
+
         path2 = vault / "B.md"
         path2.write_text(
             "---\n"
@@ -267,7 +316,7 @@ class TestMergeTwoBooks:
         )
 
         merged_fm, merged_body, conflicts = merge_two_books(path1, path2)
-        
+
         # Personal notes should be there
         assert "My personal notes" in merged_body
         # API descriptions should not appear
@@ -281,14 +330,20 @@ class TestCheckAutoMerge:
     def test_auto_merge_both_ids_match(self, tmp_path):
         """Should auto-merge when both ISBN and Google ID match."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book A", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "A.md",
+            title="Book A",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book B", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "B.md",
+            title="Book B",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
 
         can_merge, reason, merge_result = check_auto_merge(path1, path2)
@@ -301,12 +356,10 @@ class TestCheckAutoMerge:
     def test_no_auto_merge_isbn_mismatch(self, tmp_path):
         """Should not auto-merge if ISBN differs."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "A.md", title="Book", isbn="123", google_books_id="gb1"
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="999", google_books_id="gb1"
+            tmp_path, "B.md", title="Book", isbn="999", google_books_id="gb1"
         )
 
         can_merge, reason, merge_result = check_auto_merge(path1, path2)
@@ -317,12 +370,10 @@ class TestCheckAutoMerge:
     def test_no_auto_merge_google_id_mismatch(self, tmp_path):
         """Should not auto-merge if Google Books ID differs."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "A.md", title="Book", isbn="123", google_books_id="gb1"
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb2"
+            tmp_path, "B.md", title="Book", isbn="123", google_books_id="gb2"
         )
 
         can_merge, reason, merge_result = check_auto_merge(path1, path2)
@@ -333,14 +384,20 @@ class TestCheckAutoMerge:
     def test_no_auto_merge_with_conflicts(self, tmp_path):
         """Should not auto-merge if there are metadata conflicts."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=250
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=250,
         )
 
         can_merge, reason, merge_result = check_auto_merge(path1, path2)
@@ -350,13 +407,9 @@ class TestCheckAutoMerge:
 
     def test_no_auto_merge_missing_isbn(self, tmp_path):
         """Should not auto-merge if ISBN is missing from either book."""
-        path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", google_books_id="gb1"
-        )
+        path1 = _write_book(tmp_path, "A.md", title="Book", google_books_id="gb1")
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "B.md", title="Book", isbn="123", google_books_id="gb1"
         )
 
         can_merge, reason, _ = check_auto_merge(path1, path2)
@@ -369,13 +422,17 @@ class TestGetPrimaryBook:
     def test_primary_is_more_complete(self, tmp_path):
         """Book with more non-null fields should be primary."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300, genres=["Fiction"], rating=5
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
+            genres=["Fiction"],
+            rating=5,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "B.md", title="Book", isbn="123", google_books_id="gb1"
         )
 
         primary = get_primary_book(path1, path2)
@@ -384,12 +441,10 @@ class TestGetPrimaryBook:
     def test_primary_fallback_to_first_when_equal_completeness(self, tmp_path):
         """When completeness is equal, should fallback to first path."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "A.md", title="Book", isbn="123", google_books_id="gb1"
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "B.md", title="Book", isbn="123", google_books_id="gb1"
         )
 
         primary = get_primary_book(path1, path2)
@@ -398,14 +453,20 @@ class TestGetPrimaryBook:
     def test_primary_by_earlier_date_added(self, tmp_path):
         """When completeness is equal, earlier date_added wins."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            date_added="2024-01-01"
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            date_added="2024-01-01",
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            date_added="2024-06-01"
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            date_added="2024-06-01",
         )
 
         primary = get_primary_book(path1, path2)
@@ -418,12 +479,12 @@ class TestWriteMergedBook:
     def test_write_merged_frontmatter_and_body(self, tmp_path):
         """Should write merged frontmatter and body to file."""
         path = tmp_path / "book.md"
-        
+
         merged_fm = {
             "title": "Book",
             "isbn": "123",
             "google_books_id": "gb1",
-            "status": "Read"
+            "status": "Read",
         }
         merged_body = "## Notes\n\nMy notes here"
 
@@ -455,19 +516,30 @@ class TestMergeEdgeCases:
     def test_merge_three_book_group(self, tmp_path):
         """Merging a group of 3 books should work progressively."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="To Read", page_count=300
+            tmp_path,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="To Read",
+            page_count=300,
         )
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            status="Read", rating=5
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            status="Read",
+            rating=5,
         )
         path3 = _write_book(
-            tmp_path, "C.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            genres=["Fiction"]
+            tmp_path,
+            "C.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            genres=["Fiction"],
         )
 
         # Merge B into A
@@ -519,8 +591,7 @@ class TestMergeEdgeCases:
     def test_merge_unreadable_frontmatter_raises(self, tmp_path):
         """Merge with unreadable frontmatter should raise ValueError."""
         path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123", google_books_id="gb1"
+            tmp_path, "A.md", title="Book", isbn="123", google_books_id="gb1"
         )
         path2 = tmp_path / "B.md"
         path2.write_text("No frontmatter here", encoding="utf-8")
@@ -530,14 +601,16 @@ class TestMergeEdgeCases:
 
     def test_get_primary_book_selects_secondary_when_more_complete(self, tmp_path):
         """get_primary_book should pick secondary when it has more fields."""
-        path1 = _write_book(
-            tmp_path, "A.md",
-            title="Book", isbn="123"
-        )
+        path1 = _write_book(tmp_path, "A.md", title="Book", isbn="123")
         path2 = _write_book(
-            tmp_path, "B.md",
-            title="Book", isbn="123", google_books_id="gb1",
-            page_count=300, rating=4, genres=["Fiction"]
+            tmp_path,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
+            rating=4,
+            genres=["Fiction"],
         )
 
         primary = get_primary_book(path1, path2)
@@ -569,10 +642,23 @@ class TestMergeCLI:
 
         vault = tmp_path / "vault"
         vault.mkdir()
-        _write_book(vault, "A.md", title="Book A", isbn="123", google_books_id="gb1",
-                     status="To Read", page_count=300)
-        _write_book(vault, "B.md", title="Book B", isbn="123", google_books_id="gb1",
-                     status="Read")
+        _write_book(
+            vault,
+            "A.md",
+            title="Book A",
+            isbn="123",
+            google_books_id="gb1",
+            status="To Read",
+            page_count=300,
+        )
+        _write_book(
+            vault,
+            "B.md",
+            title="Book B",
+            isbn="123",
+            google_books_id="gb1",
+            status="Read",
+        )
         set_config("vault_path", str(vault))
 
         result = CliRunner().invoke(app, ["merge", "--auto"])
@@ -591,10 +677,22 @@ class TestMergeCLI:
 
         vault = tmp_path / "vault"
         vault.mkdir()
-        _write_book(vault, "A.md", title="Book", isbn="123", google_books_id="gb1",
-                     page_count=300)
-        _write_book(vault, "B.md", title="Book", isbn="123", google_books_id="gb1",
-                     page_count=250)
+        _write_book(
+            vault,
+            "A.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=300,
+        )
+        _write_book(
+            vault,
+            "B.md",
+            title="Book",
+            isbn="123",
+            google_books_id="gb1",
+            page_count=250,
+        )
         set_config("vault_path", str(vault))
 
         result = CliRunner().invoke(app, ["merge", "--auto"])


### PR DESCRIPTION
## Summary

Expands the existing duplicate detection into a full merge workflow.

### New CLI command

\\\ash
libris merge          # Interactive mode
libris merge --auto   # Auto-merge when ISBN + Google ID match
\\\

### Merge behavior

| Scenario | Result |
|----------|--------|
| ISBN + Google ID match, no conflicts | Auto-merges silently (with --auto) |
| ISBN + Google ID match, title differs | Auto-merges (title variance acceptable) |
| Metadata conflicts (page count, etc.) | Blocks auto-merge; asks in interactive mode |
| Status: Read vs To Read | 'Read' wins automatically |

### Implementation

- **src/libris/merge.py** — Core merge logic (conflict detection, field resolution, body merging)
- **src/libris/cli.py** — \merge\ command with \--auto\ flag
- **tests/test_merge.py** — 29 tests covering merge logic, auto-merge criteria, CLI integration

### Key design decisions

- Primary book = most complete frontmatter (tiebreaker: earliest date_added)
- List fields (authors, genres, tags) are merged and deduplicated rather than conflicting
- Generic Description sections (from Google Books API) are stripped during body merge
- \check_auto_merge()\ returns the merge result to avoid double file reads
- Error handling per-pair so one bad file doesn't crash the whole merge run