### PR TITLE
Fix duplicate detection to consider author when matching by title

### DIFF
--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -207,14 +207,24 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
         if fm is not None:
             file_data.append((p, fm))
 
+    def _author_key(fm: Dict[str, Any]) -> str:
+        author = fm.get("author")
+        if isinstance(author, list):
+            return ",".join(sorted(a.strip().lower() for a in author if isinstance(a, str)))
+        elif isinstance(author, str):
+            return author.strip().lower()
+        return ""
+
     # Build groups keyed by each identifier type.
     # key -> set of indices into file_data
     groups_by_key: Dict[str, set[int]] = {}
+    # Title groups need pairwise author comparison (missing author = wildcard)
+    title_groups: Dict[str, list[int]] = {}
+
     for idx, (path, fm) in enumerate(file_data):
         title = fm.get("title")
         if title and isinstance(title, str):
-            key = f"title:{title.strip().lower()}"
-            groups_by_key.setdefault(key, set()).add(idx)
+            title_groups.setdefault(title.strip().lower(), []).append(idx)
 
         isbn = fm.get("isbn")
         if isbn:
@@ -239,6 +249,17 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
         ra, rb = find(a), find(b)
         if ra != rb:
             parent[rb] = ra
+
+    # Title duplicates: same title + (same author OR either has no author)
+    for members in title_groups.values():
+        if len(members) < 2:
+            continue
+        for i, idx_a in enumerate(members):
+            ak = _author_key(file_data[idx_a][1])
+            for idx_b in members[i + 1 :]:
+                bk = _author_key(file_data[idx_b][1])
+                if not ak or not bk or ak == bk:
+                    union(idx_a, idx_b)
 
     for members in groups_by_key.values():
         if len(members) < 2:

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -254,12 +254,28 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
     for members in title_groups.values():
         if len(members) < 2:
             continue
-        for i, idx_a in enumerate(members):
-            ak = _author_key(file_data[idx_a][1])
-            for idx_b in members[i + 1 :]:
-                bk = _author_key(file_data[idx_b][1])
-                if not ak or not bk or ak == bk:
-                    union(idx_a, idx_b)
+
+        author_buckets: Dict[str, list[int]] = {}
+        has_missing_author = False
+
+        for idx in members:
+            author_key = _author_key(file_data[idx][1])
+            if author_key:
+                author_buckets.setdefault(author_key, []).append(idx)
+            else:
+                has_missing_author = True
+
+        if has_missing_author:
+            first = members[0]
+            for other in members[1:]:
+                union(first, other)
+        else:
+            for bucket_members in author_buckets.values():
+                if len(bucket_members) < 2:
+                    continue
+                first = bucket_members[0]
+                for other in bucket_members[1:]:
+                    union(first, other)
 
     for members in groups_by_key.values():
         if len(members) < 2:

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -207,13 +207,13 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
         if fm is not None:
             file_data.append((p, fm))
 
-    def _author_key(fm: Dict[str, Any]) -> str:
+    def _author_key(fm: Dict[str, Any]) -> tuple[str, ...]:
         author = fm.get("author")
         if isinstance(author, list):
-            return ",".join(sorted(a.strip().lower() for a in author if isinstance(a, str)))
+            return tuple(sorted(a.strip().lower() for a in author if isinstance(a, str)))
         elif isinstance(author, str):
-            return author.strip().lower()
-        return ""
+            return (author.strip().lower(),)
+        return ()
 
     # Build groups keyed by each identifier type.
     # key -> set of indices into file_data

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -32,8 +32,24 @@ def test_no_duplicates(tmp_path):
 
 
 def test_duplicate_by_title(tmp_path):
-    _write_book(tmp_path, "A.md", title="Same Title", isbn="111", google_books_id="a1")
-    _write_book(tmp_path, "B.md", title="same title", isbn="222", google_books_id="b2")
+    _write_book(tmp_path, "A.md", title="Same Title", isbn="111", google_books_id="a1", author=["Author A"])
+    _write_book(tmp_path, "B.md", title="same title", isbn="222", google_books_id="b2", author=["Author A"])
+    groups = find_duplicates(tmp_path)
+    assert len(groups) == 1
+    names = {p.name for p in groups[0]}
+    assert names == {"A.md", "B.md"}
+
+
+def test_same_title_different_author_not_duplicate(tmp_path):
+    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", author=["Author A"])
+    _write_book(tmp_path, "B.md", title="Zero Day", isbn="222", author=["Author B"])
+    assert find_duplicates(tmp_path) == []
+
+
+def test_same_title_missing_author_is_duplicate(tmp_path):
+    """A book with no author should match same-titled books as a potential duplicate."""
+    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", author=["Author A"])
+    _write_book(tmp_path, "B.md", title="Zero Day", isbn="222")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
     names = {p.name for p in groups[0]}
@@ -56,8 +72,8 @@ def test_duplicate_by_google_books_id(tmp_path):
 
 def test_transitive_duplicates_merged(tmp_path):
     """A shares title with B, B shares ISBN with C => all three in one group."""
-    _write_book(tmp_path, "A.md", title="Shared Title", isbn="111", google_books_id="a1")
-    _write_book(tmp_path, "B.md", title="Shared Title", isbn="222", google_books_id="b2")
+    _write_book(tmp_path, "A.md", title="Shared Title", isbn="111", google_books_id="a1", author=["Same Author"])
+    _write_book(tmp_path, "B.md", title="Shared Title", isbn="222", google_books_id="b2", author=["Same Author"])
     _write_book(tmp_path, "C.md", title="Other Title", isbn="222", google_books_id="c3")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
@@ -65,18 +81,18 @@ def test_transitive_duplicates_merged(tmp_path):
 
 
 def test_multiple_independent_groups(tmp_path):
-    _write_book(tmp_path, "A.md", title="Group One", isbn="111")
-    _write_book(tmp_path, "B.md", title="Group One", isbn="112")
-    _write_book(tmp_path, "C.md", title="Group Two", isbn="333")
-    _write_book(tmp_path, "D.md", title="Group Two", isbn="444")
+    _write_book(tmp_path, "A.md", title="Group One", isbn="111", author=["Author X"])
+    _write_book(tmp_path, "B.md", title="Group One", isbn="112", author=["Author X"])
+    _write_book(tmp_path, "C.md", title="Group Two", isbn="333", author=["Author Y"])
+    _write_book(tmp_path, "D.md", title="Group Two", isbn="444", author=["Author Y"])
     _write_book(tmp_path, "E.md", title="Unique", isbn="555")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 2
 
 
 def test_files_without_frontmatter_skipped(tmp_path):
-    _write_book(tmp_path, "A.md", title="Same", isbn="111")
-    _write_book(tmp_path, "B.md", title="Same", isbn="222")
+    _write_book(tmp_path, "A.md", title="Same", isbn="111", author=["Author"])
+    _write_book(tmp_path, "B.md", title="Same", isbn="222", author=["Author"])
     # File without frontmatter
     (tmp_path / "plain.md").write_text("# Just a heading\n")
     groups = find_duplicates(tmp_path)
@@ -94,8 +110,8 @@ def test_null_fields_not_matched(tmp_path):
 def test_cli_duplicates_command_reports(tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()
-    _write_book(vault, "A.md", title="Dup Book", isbn="111", google_books_id="g1")
-    _write_book(vault, "B.md", title="Dup Book", isbn="222", google_books_id="g2")
+    _write_book(vault, "A.md", title="Dup Book", isbn="111", google_books_id="g1", author=["Author"])
+    _write_book(vault, "B.md", title="Dup Book", isbn="222", google_books_id="g2", author=["Author"])
     set_config("vault_path", str(vault))
 
     result = runner.invoke(app, ["duplicates"])


### PR DESCRIPTION
Books with the same title but different authors (e.g. multiple books called *Zero Day*) are no longer flagged as duplicates.

## Changes

- Title matching now uses pairwise author comparison instead of a simple key lookup
- A missing author acts as a wildcard, so incomplete metadata still surfaces potential duplicates
- ISBN and Google Books ID matching is unchanged

## Rules

| Scenario | Duplicate? |
|---|---|
| Same title + same author | Yes |
| Same title + missing author on either side | Yes |
| Same title + different authors | No |
| Same ISBN (regardless of title/author) | Yes |
| Same Google Books ID | Yes |

## Tests

- Added \	est_same_title_different_author_not_duplicate\
- Added \	est_same_title_missing_author_is_duplicate\
- Updated existing title-based tests to include author data