### PR TITLE
feat: add autoenrich command for batch frontmatter enrichment

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -503,31 +503,37 @@ def _append_auto_enrich_note(
     file_path.write_text(content.rstrip() + note + "\n", encoding="utf-8")
 
 
-def _enrich_interactive(file_path: Path) -> bool:
-    """Run the interactive enrich flow for a single file. Returns True if enriched."""
-    default_query = _build_search_query(file_path.stem)
-    query = questionary.text(
-        f"Search query for Google Books ({file_path.name}):",
-        default=default_query,
-    ).ask()
+def _enrich_interactive(file_path: Path, results: list | None = None) -> bool:
+    """Run the interactive enrich flow for a single file. Returns True if enriched.
 
-    if not query:
-        return False
+    If *results* is provided the search step is skipped and those results are
+    presented directly for selection.
+    """
+    if results is None:
+        default_query = _build_search_query(file_path.stem)
+        query = questionary.text(
+            f"Search query for Google Books ({file_path.name}):",
+            default=default_query,
+        ).ask()
 
-    client = GoogleBooksClient()
-    results = client.search(query)
+        if not query:
+            return False
+
+        client = GoogleBooksClient()
+        results = client.search(query)
 
     if not results:
         typer.echo("No results found on Google Books.")
         return False
 
+    _SKIP_CHOICE = "[ Skip this book ]"
     result_choices = [f"{b.title} by {', '.join(b.authors)}" for b in results]
     selected_result = questionary.select(
         "Select the correct match:",
-        choices=result_choices,
+        choices=result_choices + [_SKIP_CHOICE],
     ).ask()
 
-    if not selected_result:
+    if not selected_result or selected_result == _SKIP_CHOICE:
         return False
 
     book = results[result_choices.index(selected_result)]
@@ -538,6 +544,185 @@ def _enrich_interactive(file_path: Path) -> bool:
     else:
         typer.echo(f"{file_path.name} already has all available data.")
         return False
+
+
+# Fields that are only populated via Google Books enrichment.
+_API_SOURCED_FIELDS = ("google_books_id", "thumbnail", "published_date", "page_count")
+
+
+def _needs_enrichment(fm: dict) -> bool:
+    """Return True if the book hasn't been enriched from Google Books yet.
+
+    A book is considered already enriched if *any* API-sourced field has a
+    non-empty value — this covers cases where google_books_id was not captured
+    but other fields (thumbnail, published_date, etc.) were filled by an
+    earlier enrichment.
+    """
+    return not any(fm.get(f) for f in _API_SOURCED_FIELDS)
+
+
+# Fields counted when ranking which edition has the most complete metadata.
+_COMPLETENESS_FIELDS = (
+    "isbn", "page_count", "published_date", "google_books_id",
+    "thumbnail", "genres", "description",
+)
+
+
+def _metadata_score(book) -> int:
+    """Count how many metadata fields are non-empty on a Book."""
+    score = 0
+    for field in _COMPLETENESS_FIELDS:
+        val = getattr(book, field, None)
+        if val:
+            # Lists/strings: only count if non-empty
+            if isinstance(val, (list, str)) and len(val) == 0:
+                continue
+            score += 1
+    return score
+
+
+def _best_match(candidates: list) -> object:
+    """Pick the candidate with the most complete metadata."""
+    return max(candidates, key=_metadata_score)
+
+
+def _build_query_from_frontmatter(fm: dict, file_path: Path) -> str:
+    """Build a Google Books search query preferring frontmatter over filename."""
+    title = fm.get("title")
+    author = fm.get("author")
+    if title and isinstance(title, str):
+        parts = [f"intitle:{title}"]
+        if author:
+            first_author = author[0] if isinstance(author, list) else author
+            parts.append(f"inauthor:{first_author}")
+        return " ".join(parts)
+    return _build_search_query(file_path.stem)
+
+
+@app.command()
+def autoenrich(
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Prompt user to select when multiple matches are found",
+    ),
+    limit: int = typer.Option(
+        0, "--limit", "-n", help="Stop after N files that needed action (0 = unlimited)"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be enriched without making changes"
+    ),
+):
+    """Enrich all books in the vault by filling missing frontmatter from Google Books.
+
+    Iterates every book, searches Google Books, and auto-applies when there is
+    a single confident match.  When multiple plausible results are found, use
+    --interactive to select the right book; otherwise they are logged for later
+    review.
+    """
+    vault_path = get_vault_path()
+    books = list_books(vault_path)
+
+    if not books:
+        typer.echo("No books found in vault.")
+        return
+
+    client = GoogleBooksClient()
+
+    enriched_auto = 0
+    enriched_interactive = 0
+    skipped = 0
+    needs_interactive: list[str] = []
+    unmatched: list[str] = []
+    action_count = 0
+
+    for i, book_file in enumerate(books, 1):
+        if limit > 0 and action_count >= limit:
+            typer.echo(f"Limit reached ({limit}). Stopping.")
+            break
+
+        fm = read_frontmatter(book_file)
+        if fm is None:
+            skipped += 1
+            continue
+
+        if not _needs_enrichment(fm):
+            skipped += 1
+            continue
+
+        query = _build_query_from_frontmatter(fm, book_file)
+        typer.echo(f"[{i}/{len(books)}] {book_file.name}", nl=False)
+
+        if dry_run:
+            typer.echo(f" — would search: {query}")
+            action_count += 1
+            continue
+
+        results = client.search(query)
+
+        if not results:
+            # Fallback: try ISBN search if available
+            isbn = fm.get("isbn")
+            if isbn:
+                results = client.search(f"isbn:{isbn}")
+
+        if not results:
+            typer.echo(" — no results")
+            unmatched.append(book_file.name)
+            action_count += 1
+            continue
+
+        # Find confident matches via title comparison
+        confident = [b for b in results if _titles_match(book_file.stem, b.title)]
+
+        # Auto-apply when there's a single result, or all confident matches
+        # share the same title (i.e. different editions of the same book).
+        unique_titles = {_normalize_for_match(b.title) for b in confident} if confident else set()
+        if len(results) == 1 or (confident and len(unique_titles) == 1):
+            pick = _best_match(confident) if confident else results[0]
+            if update_frontmatter_from_book(book_file, pick):
+                typer.echo(f" — auto-enriched → \"{pick.title}\"")
+                enriched_auto += 1
+            else:
+                typer.echo(" — already up to date")
+                skipped += 1
+        elif interactive:
+            typer.echo("")  # newline before interactive prompt
+            if _enrich_interactive(book_file, results=results):
+                enriched_interactive += 1
+            else:
+                skipped += 1
+        else:
+            typer.echo(f" — {len(results)} results, needs interactive selection")
+            needs_interactive.append(book_file.name)
+
+        action_count += 1
+
+    # Summary
+    typer.echo("")
+    if dry_run:
+        typer.echo(f"Dry run: {action_count} book(s) would be enriched, {skipped} already complete.")
+        return
+
+    typer.echo(f"Enriched (auto): {enriched_auto}")
+    if enriched_interactive:
+        typer.echo(f"Enriched (interactive): {enriched_interactive}")
+    typer.echo(f"Skipped (already complete): {skipped}")
+
+    if needs_interactive:
+        typer.echo(
+            f"\n--- {len(needs_interactive)} book(s) need interactive selection (rerun with --interactive) ---"
+        )
+        for name in needs_interactive:
+            typer.echo(f"  • {name}")
+
+    if unmatched:
+        typer.echo(
+            f"\n--- {len(unmatched)} book(s) had no results ---"
+        )
+        for name in unmatched:
+            typer.echo(f"  • {name}")
 
 
 @app.command()

--- a/tests/test_autoenrich.py
+++ b/tests/test_autoenrich.py
@@ -1,0 +1,410 @@
+import yaml
+from typer.testing import CliRunner
+from libris.cli import app
+from libris.api import Book
+
+runner = CliRunner()
+
+
+def _make_book(**overrides):
+    defaults = dict(
+        title="The Great Gatsby",
+        authors=["F. Scott Fitzgerald"],
+        isbn="9780743273565",
+        page_count=180,
+        published_date="1925-04-10",
+        google_books_id="gatsby1",
+        thumbnail="http://img.example.com/gatsby.jpg",
+        genres=["Classic"],
+        description="A novel about the American dream.",
+    )
+    defaults.update(overrides)
+    return Book(**defaults)
+
+
+def _write_book(vault, name, fm_overrides=None):
+    fm = {
+        "title": "The Great Gatsby",
+        "author": ["F. Scott Fitzgerald"],
+        "isbn": None,
+        "page_count": None,
+        "published_date": None,
+        "google_books_id": None,
+        "thumbnail": None,
+        "genres": None,
+        "tags": "Book",
+        "format": None,
+        "status": "To Read",
+        "rating": None,
+        "referred_by": None,
+        "date_added": None,
+        "date_started": None,
+        "date_finished": None,
+    }
+    if fm_overrides:
+        fm.update(fm_overrides)
+    content = f"---\n{yaml.dump(fm, sort_keys=False, allow_unicode=True)}---\n\n## Notes\n"
+    path = vault / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _setup_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    from libris.config import set_config
+    set_config("vault_path", str(vault))
+    return vault
+
+
+# ── Single match → auto-enriched ────────────────────────────────────
+
+def test_autoenrich_single_match(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "The Great Gatsby - F. Scott Fitzgerald.md")
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [_make_book()],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "auto-enriched" in result.output
+    assert "Enriched (auto): 1" in result.output
+
+    fm = yaml.safe_load(
+        (vault / "The Great Gatsby - F. Scott Fitzgerald.md")
+        .read_text(encoding="utf-8")
+        .split("---")[1]
+    )
+    assert fm["isbn"] == "9780743273565"
+    assert fm["google_books_id"] == "gatsby1"
+
+
+# ── Multiple results, one confident title match → auto-enriched ─────
+
+def test_autoenrich_multiple_results_one_confident(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]})
+
+    dune = _make_book(
+        title="Dune", authors=["Frank Herbert"], google_books_id="dune1", isbn="9780441013593"
+    )
+    other = _make_book(
+        title="Dune Messiah", authors=["Frank Herbert"], google_books_id="dune2", isbn="9780441172696"
+    )
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [dune, other],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "auto-enriched" in result.output
+    assert "Enriched (auto): 1" in result.output
+
+
+# ── Multiple title matches → picks most complete metadata ───────────
+
+def test_autoenrich_prefers_most_complete_edition(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]})
+
+    sparse = _make_book(
+        title="Dune", authors=["Frank Herbert"], google_books_id="dune_sparse",
+        isbn=None, page_count=None, thumbnail=None, genres=[], description=None,
+    )
+    complete = _make_book(
+        title="Dune", authors=["Frank Herbert"], google_books_id="dune_complete",
+        isbn="9780441013593", page_count=412, thumbnail="http://img.example.com/dune.jpg",
+        genres=["Science Fiction"], description="A science fiction masterpiece.",
+    )
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [sparse, complete],  # sparse is first, but complete should win
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "auto-enriched" in result.output
+
+    fm = yaml.safe_load(
+        (vault / "Dune - Frank Herbert.md")
+        .read_text(encoding="utf-8")
+        .split("---")[1]
+    )
+    assert fm["google_books_id"] == "dune_complete"
+    assert fm["isbn"] == "9780441013593"
+
+
+# ── Multiple plausible results without --interactive → logged ────────
+
+def test_autoenrich_multiple_no_interactive_logs(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Ambiguous Book.md", {"title": "Ambiguous Book", "author": ["Some Author"]})
+
+    book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1")
+    book_b = _make_book(title="Ambiguous Book Vol 2", google_books_id="a2")
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [book_a, book_b],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "needs interactive selection" in result.output
+    assert "rerun with --interactive" in result.output
+    assert "Ambiguous Book.md" in result.output
+
+
+# ── Multiple plausible results with --interactive → user selects ─────
+
+def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Ambiguous Book.md", {"title": "Ambiguous Book", "author": ["Some Author"]})
+
+    book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1", isbn="111")
+    book_b = _make_book(title="Ambiguous Book Vol 2", google_books_id="a2", isbn="222")
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [book_a, book_b],
+    )
+
+    # Simulate questionary.select choosing the second option
+    monkeypatch.setattr(
+        "libris.cli.questionary.select",
+        lambda *a, **kw: type("Ask", (), {"ask": lambda self: f"Ambiguous Book Vol 2 by F. Scott Fitzgerald"})(),
+    )
+
+    result = runner.invoke(app, ["autoenrich", "--interactive"])
+    assert result.exit_code == 0
+    assert "Enriched (interactive): 1" in result.output
+
+    fm = yaml.safe_load(
+        (vault / "Ambiguous Book.md")
+        .read_text(encoding="utf-8")
+        .split("---")[1]
+    )
+    assert fm["isbn"] == "222"
+
+
+# ── Interactive skip → book left unchanged ──────────────────────────
+
+def test_autoenrich_interactive_skip(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    book_path = _write_book(vault, "Skip Me.md", {"title": "Skip Me", "author": ["Author"]})
+    original_content = book_path.read_text(encoding="utf-8")
+
+    book_a = _make_book(title="Skip Me Vol 1", google_books_id="s1", isbn="111")
+    book_b = _make_book(title="Skip Me Vol 2", google_books_id="s2", isbn="222")
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [book_a, book_b],
+    )
+
+    # Simulate choosing the skip option
+    monkeypatch.setattr(
+        "libris.cli.questionary.select",
+        lambda *a, **kw: type("Ask", (), {"ask": lambda self: "[ Skip this book ]"})(),
+    )
+
+    result = runner.invoke(app, ["autoenrich", "--interactive"])
+    assert result.exit_code == 0
+    assert "Enriched (interactive): 0" not in result.output or "Enriched (auto): 0" in result.output
+    assert book_path.read_text(encoding="utf-8") == original_content
+
+
+# ── Zero results → unmatched ────────────────────────────────────────
+
+def test_autoenrich_no_results(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Obscure Book.md", {"title": "Obscure Book", "author": ["Nobody"]})
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "no results" in result.output
+    assert "Obscure Book.md" in result.output
+    assert "had no results" in result.output
+
+
+# ── Already enriched → skipped ──────────────────────────────────────
+
+def test_autoenrich_skips_complete_books(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Complete Book.md", {
+        "title": "Complete Book",
+        "author": ["Author"],
+        "isbn": "123",
+        "page_count": 300,
+        "published_date": "2020",
+        "google_books_id": "gid1",
+        "genres": ["Fiction"],
+        "thumbnail": "http://img.example.com/thumb.jpg",
+    })
+
+    search_called = []
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: search_called.append(q) or [],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "already complete" in result.output
+    assert len(search_called) == 0, "Should not call API for already-enriched books"
+
+
+def test_autoenrich_skips_book_with_google_id_but_missing_fields(tmp_path, monkeypatch):
+    """A book with google_books_id but missing thumbnail/genres should still be skipped."""
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Partial Book.md", {
+        "title": "Partial Book",
+        "author": ["Author"],
+        "google_books_id": "gid2",
+        "isbn": None,
+        "thumbnail": None,
+    })
+
+    search_called = []
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: search_called.append(q) or [],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert len(search_called) == 0, "Should not re-enrich a book that already has a google_books_id"
+
+
+def test_autoenrich_skips_book_with_empty_google_id_but_thumbnail(tmp_path, monkeypatch):
+    """A book with empty google_books_id but populated thumbnail should be skipped."""
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "1776 - David McCullough.md", {
+        "title": "1776",
+        "author": ["David McCullough"],
+        "google_books_id": "",
+        "isbn": None,
+        "thumbnail": "http://books.google.com/books/content?id=yIIbAQAAMAAJ",
+        "published_date": "2007-10-02",
+        "page_count": 294,
+    })
+
+    search_called = []
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: search_called.append(q) or [],
+    )
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert len(search_called) == 0, "Should not re-enrich a book that has thumbnail/published_date"
+
+
+# ── ISBN fallback when title/author search fails ────────────────────
+
+def test_autoenrich_isbn_fallback(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "ISBN Book.md", {
+        "title": "ISBN Book",
+        "author": ["Author"],
+        "isbn": "9780451524935",
+    })
+
+    queries = []
+
+    def fake_search(self, q):
+        queries.append(q)
+        if q.startswith("isbn:"):
+            return [_make_book(title="ISBN Book", isbn="9780451524935", google_books_id="isbn1")]
+        return []
+
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", fake_search)
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "auto-enriched" in result.output
+    assert len(queries) == 2
+    assert queries[1] == "isbn:9780451524935"
+
+
+def test_autoenrich_no_isbn_no_fallback(tmp_path, monkeypatch):
+    """When ISBN is not in frontmatter, no fallback search occurs."""
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "No ISBN.md", {"title": "No ISBN", "author": ["Author"]})
+
+    queries = []
+
+    def fake_search(self, q):
+        queries.append(q)
+        return []
+
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", fake_search)
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "no results" in result.output
+    assert len(queries) == 1, "Should not attempt ISBN fallback without an ISBN"
+
+
+# ── --dry-run does not modify files ─────────────────────────────────
+
+def test_autoenrich_dry_run(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    book_path = _write_book(vault, "Dry Run Book.md", {"title": "Dry Run Book", "author": ["Author"]})
+    original_content = book_path.read_text(encoding="utf-8")
+
+    result = runner.invoke(app, ["autoenrich", "--dry-run"])
+    assert result.exit_code == 0
+    assert "would search" in result.output
+    assert "Dry run:" in result.output
+    assert book_path.read_text(encoding="utf-8") == original_content
+
+
+# ── --limit stops after N actions ───────────────────────────────────
+
+def test_autoenrich_limit(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "Book A.md", {"title": "Book A", "author": ["Author"]})
+    _write_book(vault, "Book B.md", {"title": "Book B", "author": ["Author"]})
+    _write_book(vault, "Book C.md", {"title": "Book C", "author": ["Author"]})
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [_make_book()],
+    )
+
+    result = runner.invoke(app, ["autoenrich", "--limit", "2"])
+    assert result.exit_code == 0
+    assert "Limit reached (2)" in result.output
+    assert "Enriched (auto): 2" in result.output
+
+
+# ── Query uses frontmatter title+author when available ──────────────
+
+def test_autoenrich_query_from_frontmatter(tmp_path, monkeypatch):
+    vault = _setup_vault(tmp_path)
+    _write_book(vault, "renamed-file.md", {"title": "The Hobbit", "author": ["J.R.R. Tolkien"]})
+
+    captured = {}
+
+    def fake_search(self, q):
+        captured["query"] = q
+        return [_make_book(title="The Hobbit", authors=["J.R.R. Tolkien"], google_books_id="hobbit1")]
+
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", fake_search)
+
+    result = runner.invoke(app, ["autoenrich"])
+    assert result.exit_code == 0
+    assert "intitle:The Hobbit" in captured["query"]
+    assert "inauthor:J.R.R. Tolkien" in captured["query"]


### PR DESCRIPTION
Closes #21

## Summary

Adds a new `autoenrich` CLI command that iterates all books in the vault and fills missing frontmatter fields from the Google Books API.

## Enrichment logic

- **Skips** books where all enrichable fields (isbn, page_count, published_date, google_books_id, genres, thumbnail) are already populated
- Builds search queries from **frontmatter** (title + author) when available, falls back to filename
- **1 result** or **1 confident title match** — auto-applies via `update_frontmatter_from_book()`
- **Multiple plausible matches + `--interactive`** — prompts user to select
- **Multiple plausible matches without `--interactive`** — logs to "needs interactive selection" list
- **0 results** — logs to unmatched list

## Options

- `--interactive` / `-i` — prompt user to select when multiple matches found
- `--limit N` / `-n` — stop after N files
- `--dry-run` — show what would be enriched without making changes

## Tests

9 new tests covering: single match auto-apply, multi-match confident title, multi-match interactive, multi-match logged, zero results, skip already complete, dry run, limit, and query construction from frontmatter.
