### PR TITLE
docs: document all CLI commands and add module docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ libris merge --auto
 ```
 
 ### 10. Auto-Enrich All Books
-Batch-enrich every book in your vault by filling missing frontmatter fields from Google Books. Automatically applies when a single confident match is found.
+Batch-enrich every book in your vault by filling missing frontmatter fields from Google Books. Automatically applies when there is a single result, or when all confident matches share the same title (e.g., different editions).
 ```bash
 # Enrich all books (auto-match only)
 libris autoenrich

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Batch-enrich every book in your vault by filling missing frontmatter fields from
 # Enrich all books (auto-match only)
 libris autoenrich
 
-# Prompt for selection when multiple matches are found
+# Prompt for selection when multiple ambiguous matches are found
 libris autoenrich --interactive
 
 # Preview what would be enriched without making changes

--- a/README.md
+++ b/README.md
@@ -104,6 +104,51 @@ Scan your vault for duplicate book notes matched by title, ISBN, or Google Books
 libris duplicates
 ```
 
+### 9. Merge Duplicates
+Merge duplicate book notes, combining metadata from both files into one.
+```bash
+# Interactive merge — review each duplicate group
+libris merge
+
+# Auto-merge when ISBN + Google ID match and no conflicts exist
+libris merge --auto
+```
+
+### 10. Auto-Enrich All Books
+Batch-enrich every book in your vault by filling missing frontmatter fields from Google Books. Automatically applies when a single confident match is found.
+```bash
+# Enrich all books (auto-match only)
+libris autoenrich
+
+# Prompt for selection when multiple matches are found
+libris autoenrich --interactive
+
+# Preview what would be enriched without making changes
+libris autoenrich --dry-run
+
+# Stop after N files that needed action
+libris autoenrich --limit 10
+```
+
+### 11. Import Books
+Import books from external sources (e.g., Audible JSON export) into your vault. By default runs in dry-run mode showing what would happen.
+```bash
+# Dry-run: preview what would be imported
+libris import library.json
+
+# Actually create/update notes
+libris import library.json --apply
+
+# Specify format explicitly
+libris import library.json --format audible-json
+
+# Limit to first N entries
+libris import library.json --apply --limit 50
+```
+
+Currently supported import formats:
+- `audible-json` — Audible library JSON export (auto-detected for `.json` files)
+
 ## Schema
 Books are saved as Markdown files with the following frontmatter:
 - `title`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "libris"
 version = "0.1.0"
-description = "Add your description here"
+description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -1,3 +1,5 @@
+"""Google Books API client for searching and retrieving book metadata."""
+
 import httpx
 import time
 import logging

--- a/src/libris/config.py
+++ b/src/libris/config.py
@@ -1,3 +1,5 @@
+"""Configuration management for Libris (vault paths, API keys, settings)."""
+
 import yaml
 import os
 from pathlib import Path

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,4 +1,4 @@
-"""Import books from external sources (Audible JSON, CSV) into the vault."""
+"""Import books from external sources (currently Audible JSON) into the vault."""
 
 import json
 import re

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,3 +1,5 @@
+"""Import books from external sources (Audible JSON, CSV) into the vault."""
+
 import json
 import re
 import yaml

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -1,3 +1,5 @@
+"""Markdown file operations for book notes (frontmatter, creation, enrichment)."""
+
 import yaml
 import os
 import re


### PR DESCRIPTION
## Summary

Fixes #15 — ensures all CLI commands and modules are properly documented.

### Changes

- **README.md**: Added documentation for \merge\, \utoenrich\, and \import\ commands (sections 9–11)
- **pyproject.toml**: Fixed placeholder project description
- **Module docstrings**: Added to \pi.py\, \config.py\, \markdown.py\, and \importer.py\

### Testing

All 139 existing tests pass. Ruff lint clean.