### PR TITLE
Add GitHub Actions CI, Dependabot, and ruff security rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+version: 2
+updates:
+  # Dependabot does not currently update `uv.lock` for uv-managed projects; keep Python deps updated via a dedicated workflow or a tool that supports uv.
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --group lint
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Check linting
+        run: uv run ruff check .
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Audit dependencies
+        run: uv export --no-hashes --frozen | pip-audit -r /dev/stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,6 @@ jobs:
         run: uv sync --frozen
 
       - name: Audit dependencies
-        run: uv export --no-hashes --frozen | pip-audit -r /dev/stdin
+        run: |
+          uv export --no-hashes --frozen > requirements.txt
+          uv tool run pip-audit -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,9 @@ exclude = [
     "venv",
     ".claude",
 ]
+
+[tool.ruff.lint]
+select = ["E", "F", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "S"]
+ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -36,11 +36,12 @@ class GoogleBooksClient:
         if api_key:
             params["key"] = api_key
         else:
-            # Use a unique identifier to help avoid global rate limits for unauthenticated users
+            # Use a unique identifier to help avoid global rate limits for
+            # unauthenticated users.
             try:
                 params["quotaUser"] = socket.gethostname()
-            except Exception:
-                pass
+            except OSError:
+                logger.debug("Could not determine hostname for quotaUser.")
 
         with httpx.Client(timeout=self.timeout) as client:
             for attempt in range(self.max_retries + 1):

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -10,6 +10,7 @@ from .config import get_api_key
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class Book:
     title: str
@@ -22,6 +23,7 @@ class Book:
     genres: List[str]
     description: Optional[str]
 
+
 class GoogleBooksClient:
     BASE_URL = "https://www.googleapis.com/books/v1/volumes"
 
@@ -31,7 +33,7 @@ class GoogleBooksClient:
 
     def search(self, query: str) -> List[Book]:
         params = {"q": query, "maxResults": 10}
-        
+
         api_key = get_api_key()
         if api_key:
             params["key"] = api_key
@@ -47,24 +49,31 @@ class GoogleBooksClient:
             for attempt in range(self.max_retries + 1):
                 try:
                     response = client.get(self.BASE_URL, params=params)
-                    
+
                     if response.status_code == 429:
                         if attempt < self.max_retries:
-                            wait_time = 2 ** attempt
-                            logger.warning(f"Rate limited (429). Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})")
+                            wait_time = 2**attempt
+                            logger.warning(
+                                f"Rate limited (429). Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})"
+                            )
                             time.sleep(wait_time)
                             continue
-                    
+
                     response.raise_for_status()
                     data = response.json()
                     break
                 except (httpx.HTTPStatusError, httpx.RequestError) as e:
                     if attempt < self.max_retries and (
-                        isinstance(e, httpx.RequestError) or 
-                        (isinstance(e, httpx.HTTPStatusError) and e.response.status_code in [429, 500, 502, 503, 504])
+                        isinstance(e, httpx.RequestError)
+                        or (
+                            isinstance(e, httpx.HTTPStatusError)
+                            and e.response.status_code in [429, 500, 502, 503, 504]
+                        )
                     ):
-                        wait_time = 2 ** attempt
-                        logger.warning(f"Request failed: {e}. Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})")
+                        wait_time = 2**attempt
+                        logger.warning(
+                            f"Request failed: {e}. Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})"
+                        )
                         time.sleep(wait_time)
                         continue
                     raise
@@ -77,7 +86,7 @@ class GoogleBooksClient:
         books = []
         for item in items:
             volume_info = item.get("volumeInfo", {})
-            
+
             # Extract ISBN
             isbn = None
             for ident in volume_info.get("industryIdentifiers", []):
@@ -96,7 +105,7 @@ class GoogleBooksClient:
                 google_books_id=item.get("id"),
                 thumbnail=volume_info.get("imageLinks", {}).get("thumbnail"),
                 genres=volume_info.get("categories", []),
-                description=volume_info.get("description")
+                description=volume_info.get("description"),
             )
             books.append(book)
         return books

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -446,7 +446,9 @@ def _enrich_auto(file_path: Path, unmatched_log: list[str]) -> bool:
         if update_frontmatter_from_book(file_path, first):
             # Append a note to the body indicating this was an automatic match
             _append_auto_enrich_note(file_path, first.title, query)
-            typer.echo(f"Auto-enriched: {file_path.name} → \"{first.title}\" by {', '.join(first.authors)}")
+            typer.echo(
+                f'Auto-enriched: {file_path.name} → "{first.title}" by {", ".join(first.authors)}'
+            )
             return True
         return False
     else:
@@ -558,8 +560,13 @@ def _needs_enrichment(fm: dict) -> bool:
 
 # Fields counted when ranking which edition has the most complete metadata.
 _COMPLETENESS_FIELDS = (
-    "isbn", "page_count", "published_date", "google_books_id",
-    "thumbnail", "genres", "description",
+    "isbn",
+    "page_count",
+    "published_date",
+    "google_books_id",
+    "thumbnail",
+    "genres",
+    "description",
 )
 
 
@@ -673,11 +680,13 @@ def autoenrich(
 
         # Auto-apply when there's a single result, or all confident matches
         # share the same title (i.e. different editions of the same book).
-        unique_titles = {_normalize_for_match(b.title) for b in confident} if confident else set()
+        unique_titles = (
+            {_normalize_for_match(b.title) for b in confident} if confident else set()
+        )
         if len(results) == 1 or (confident and len(unique_titles) == 1):
             pick = _best_match(confident) if confident else results[0]
             if update_frontmatter_from_book(book_file, pick):
-                typer.echo(f" — auto-enriched → \"{pick.title}\"")
+                typer.echo(f' — auto-enriched → "{pick.title}"')
                 enriched_auto += 1
             else:
                 typer.echo(" — already up to date")
@@ -697,7 +706,9 @@ def autoenrich(
     # Summary
     typer.echo("")
     if dry_run:
-        typer.echo(f"Dry run: {action_count} book(s) would be enriched, {skipped} already complete.")
+        typer.echo(
+            f"Dry run: {action_count} book(s) would be enriched, {skipped} already complete."
+        )
         return
 
     typer.echo(f"Enriched (auto): {enriched_auto}")
@@ -713,9 +724,7 @@ def autoenrich(
             typer.echo(f"  • {name}")
 
     if unmatched:
-        typer.echo(
-            f"\n--- {len(unmatched)} book(s) had no results ---"
-        )
+        typer.echo(f"\n--- {len(unmatched)} book(s) had no results ---")
         for name in unmatched:
             typer.echo(f"  • {name}")
 
@@ -752,7 +761,6 @@ def enrich(
         raise typer.Exit(code=1)
 
     _enrich_interactive(selected_file)
-
 
 
 @app.command()
@@ -897,9 +905,15 @@ def merge(
 @app.command(name="import")
 def import_cmd(
     file: str = typer.Argument(..., help="Path to the import file (JSON or CSV)"),
-    fmt: str | None = typer.Option(None, "--format", "-f", help=f"Import format ({', '.join(SUPPORTED_FORMATS)})"),
-    apply: bool = typer.Option(False, "--apply", help="Actually create/update notes (default is dry-run)"),
-    limit: int = typer.Option(0, "--limit", "-n", help="Process only the first N entries (0 = all)"),
+    fmt: str | None = typer.Option(
+        None, "--format", "-f", help=f"Import format ({', '.join(SUPPORTED_FORMATS)})"
+    ),
+    apply: bool = typer.Option(
+        False, "--apply", help="Actually create/update notes (default is dry-run)"
+    ),
+    limit: int = typer.Option(
+        0, "--limit", "-n", help="Process only the first N entries (0 = all)"
+    ),
 ):
     """Import books from a JSON or CSV file into your vault.
 
@@ -917,20 +931,30 @@ def import_cmd(
         raise typer.Exit(code=1)
 
     try:
-        result = run_import(file_path, vault_path, apply=apply, format_name=fmt, limit=limit)
+        result = run_import(
+            file_path, vault_path, apply=apply, format_name=fmt, limit=limit
+        )
     except (ValueError, FileNotFoundError) as e:
         typer.echo(f"Error: {e}")
         raise typer.Exit(code=1)
 
     mode_label = "Import" if apply else "Dry run"
     typer.echo(f"\n{mode_label} complete:")
-    typer.echo(f"  {len(result.new_books)} new book(s) {'added' if apply else 'would be added'}")
-    typer.echo(f"  {len(result.updated_books)} existing book(s) {'updated' if apply else 'would be updated'}")
-    typer.echo(f"  {len(result.skipped_books)} duplicate(s) already up-to-date (skipped)")
+    typer.echo(
+        f"  {len(result.new_books)} new book(s) {'added' if apply else 'would be added'}"
+    )
+    typer.echo(
+        f"  {len(result.updated_books)} existing book(s) {'updated' if apply else 'would be updated'}"
+    )
+    typer.echo(
+        f"  {len(result.skipped_books)} duplicate(s) already up-to-date (skipped)"
+    )
 
     if result.new_books:
         preview_count = min(len(result.new_books), 20)
-        typer.echo(f"\n{'Added' if apply else 'New'} books (showing {preview_count} of {len(result.new_books)}):")
+        typer.echo(
+            f"\n{'Added' if apply else 'New'} books (showing {preview_count} of {len(result.new_books)}):"
+        )
         for book in result.new_books[:preview_count]:
             authors_str = ", ".join(book.authors)
             typer.echo(f"  + {book.title} by {authors_str}")

--- a/src/libris/config.py
+++ b/src/libris/config.py
@@ -8,14 +8,17 @@ from typing import Optional
 LEGACY_VAULT_KEY = "vault_path"
 BOOK_VAULT_KEY = "book_vault"
 
+
 def get_config_dir() -> Path:
     env_config_dir = os.environ.get("LIBRIS_CONFIG_DIR")
     if env_config_dir:
         return Path(env_config_dir).expanduser().resolve()
     return Path.home() / ".config" / "libris"
 
+
 def get_config_file() -> Path:
     return get_config_dir() / "config.yaml"
+
 
 def get_config() -> dict:
     config_file = get_config_file()
@@ -23,6 +26,7 @@ def get_config() -> dict:
         return {}
     with open(config_file, "r") as f:
         return yaml.safe_load(f) or {}
+
 
 def set_config(key: str, value: str):
     config_dir = get_config_dir()
@@ -32,11 +36,13 @@ def set_config(key: str, value: str):
     with open(get_config_file(), "w") as f:
         yaml.dump(config, f)
 
+
 def set_book_vault_path(path: Path):
     resolved = str(path.expanduser().resolve())
     set_config(BOOK_VAULT_KEY, resolved)
     # Keep legacy key for backward compatibility with existing configs.
     set_config(LEGACY_VAULT_KEY, resolved)
+
 
 def get_vault_path() -> Path:
     config = get_config()
@@ -45,9 +51,11 @@ def get_vault_path() -> Path:
         return Path(".").resolve()
     return Path(path_str).expanduser().resolve()
 
+
 def get_api_key() -> Optional[str]:
     config = get_config()
     return config.get("google_books_api_key")
+
 
 def get_obsidian_vault_root() -> Optional[Path]:
     """Get the Obsidian vault root path, or None if not configured."""

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -15,15 +15,17 @@ from .markdown import (
     update_book_status,
 )
 
+
 def normalize_for_match(text: str) -> str:
     """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""
-    text = re.sub(r'[^\w\s]', ' ', text.lower())
-    return re.sub(r'\s+', ' ', text).strip()
+    text = re.sub(r"[^\w\s]", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
 
 
 @dataclass
 class ImportBook:
     """Common representation for a book from any import source."""
+
     title: str
     authors: List[str]
     status: str  # "Read", "To Read", "Reading"
@@ -55,18 +57,24 @@ def parse_audible_json(path: Path) -> List[ImportBook]:
             continue
 
         author_str = entry.get("author", "").strip()
-        authors = [a.strip() for a in author_str.split(",") if a.strip()] if author_str else ["Unknown Author"]
+        authors = (
+            [a.strip() for a in author_str.split(",") if a.strip()]
+            if author_str
+            else ["Unknown Author"]
+        )
 
         finished = entry.get("finished", "").strip().lower() == "yes"
         status = "Read" if finished else "To Read"
 
-        books.append(ImportBook(
-            title=title,
-            authors=authors,
-            status=status,
-            format="Audiobook",
-            source_format="audible-json",
-        ))
+        books.append(
+            ImportBook(
+                title=title,
+                authors=authors,
+                status=status,
+                format="Audiobook",
+                source_format="audible-json",
+            )
+        )
 
     return books
 
@@ -85,7 +93,9 @@ def detect_format(path: Path) -> Optional[str]:
     return None
 
 
-def parse_import_file(path: Path, format_name: Optional[str] = None) -> List[ImportBook]:
+def parse_import_file(
+    path: Path, format_name: Optional[str] = None
+) -> List[ImportBook]:
     """Parse an import file, auto-detecting format if not specified."""
     if not path.exists():
         raise FileNotFoundError(f"Import file not found: {path}")
@@ -102,8 +112,7 @@ def parse_import_file(path: Path, format_name: Optional[str] = None) -> List[Imp
     parser = SUPPORTED_FORMATS.get(format_name)
     if parser is None:
         raise ValueError(
-            f"Unknown format: {format_name}. "
-            f"Supported: {', '.join(SUPPORTED_FORMATS)}"
+            f"Unknown format: {format_name}. Supported: {', '.join(SUPPORTED_FORMATS)}"
         )
 
     return parser(path)
@@ -144,8 +153,11 @@ def _build_vault_index(vault_path: Path) -> Dict[Tuple[str, str], Tuple[Path, Di
 @dataclass
 class ImportResult:
     """Tracks the outcome of an import operation."""
+
     new_books: List[ImportBook] = field(default_factory=list)
-    updated_books: List[Tuple[ImportBook, Path, List[str]]] = field(default_factory=list)
+    updated_books: List[Tuple[ImportBook, Path, List[str]]] = field(
+        default_factory=list
+    )
     skipped_books: List[ImportBook] = field(default_factory=list)
 
 
@@ -191,20 +203,22 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
         content = path.read_text(encoding="utf-8")
         # Parse frontmatter using YAML to properly handle missing fields
         match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-        
+
         if match:
             frontmatter_yaml = match.group(1)
             rest_of_content = match.group(2)
-            
+
             try:
                 data = yaml.safe_load(frontmatter_yaml)
                 if isinstance(data, dict):
                     # Update the format field
                     data["format"] = book.format
                     # Write back the updated frontmatter
-                    new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
+                    new_frontmatter = yaml.dump(
+                        data, sort_keys=False, allow_unicode=True
+                    ).strip()
                     # Preserve content structure: remove only leading newlines
-                    content_part = rest_of_content.lstrip('\n')
+                    content_part = rest_of_content.lstrip("\n")
                     new_content = f"---\n{new_frontmatter}\n---\n{content_part}"
                     path.write_text(new_content, encoding="utf-8")
             except yaml.YAMLError:
@@ -213,7 +227,9 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
                 new_content = re.sub(pattern, f"\\1{book.format}", content)
                 if new_content == content:
                     # format field might be null — replace the null value
-                    new_content = content.replace("format: null", f"format: {book.format}")
+                    new_content = content.replace(
+                        "format: null", f"format: {book.format}"
+                    )
                 path.write_text(new_content, encoding="utf-8")
 
 
@@ -257,11 +273,15 @@ def run_import(
             result.new_books.append(book)
             if apply:
                 api_book = _to_api_book(book)
-                created_path = create_book_note(api_book, vault_path, status=book.status)
+                created_path = create_book_note(
+                    api_book, vault_path, status=book.status
+                )
                 # Update format in the newly created note if specified
                 if book.format:
                     content = created_path.read_text(encoding="utf-8")
-                    new_content = content.replace("format: null", f"format: {book.format}")
+                    new_content = content.replace(
+                        "format: null", f"format: {book.format}"
+                    )
                     created_path.write_text(new_content, encoding="utf-8")
         else:
             dup_path, _, updates = dup

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -40,16 +40,17 @@ FIELD_MIGRATIONS = {
     "Author": "author",
 }
 
+
 def sanitize_filename(name: str) -> str:
     """Removes invalid characters for a filename and collapses whitespace."""
     name = re.sub(r'[\\/*?:"<>|]', "", name)
-    name = re.sub(r'\s+', ' ', name)
+    name = re.sub(r"\s+", " ", name)
     return name.strip()
 
 
 # Patterns for publisher/format annotations (not genuine title content)
-_BRACKET_ANNOTATION_PAT = re.compile(r'\s*[\[\{][^\[\]\{\}]*[\]\}]')
-_WHITESPACE_PAT = re.compile(r'\s+')
+_BRACKET_ANNOTATION_PAT = re.compile(r"\s*[\[\{][^\[\]\{\}]*[\]\}]")
+_WHITESPACE_PAT = re.compile(r"\s+")
 
 
 def standardize_title(raw: Optional[str]) -> Optional[str]:
@@ -58,18 +59,19 @@ def standardize_title(raw: Optional[str]) -> Optional[str]:
         return raw
     title = raw.strip()
     # Remove bracket annotations like [Illustrated], {Kindle Edition}
-    title = _BRACKET_ANNOTATION_PAT.sub('', title)
+    title = _BRACKET_ANNOTATION_PAT.sub("", title)
     # Collapse multiple whitespace to single space
-    title = _WHITESPACE_PAT.sub(' ', title).strip()
+    title = _WHITESPACE_PAT.sub(" ", title).strip()
     # Apply title case (NYT Manual of Style rules)
     title = titlecase(title)
     return title
+
 
 def create_book_note(book: Book, vault_path: Path, status: str = "To Read") -> Path:
     """Creates a Markdown note for a book in the specified vault path."""
     filename = sanitize_filename(f"{book.title} - {', '.join(book.authors[:1])}.md")
     file_path = vault_path / filename
-    
+
     frontmatter = {
         **DEFAULT_FRONTMATTER,
         "title": book.title,
@@ -83,26 +85,28 @@ def create_book_note(book: Book, vault_path: Path, status: str = "To Read") -> P
         "status": status,
         "date_added": date.today().isoformat(),
     }
-    
+
     yaml_content = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True)
-    
+
     content = f"---\n{yaml_content}---\n\n## Notes\n\n"
     if book.description:
         content += f"### Description\n{book.description}\n"
-    
+
     file_path.write_text(content, encoding="utf-8")
     return file_path
+
 
 def update_book_status(file_path: Path, new_status: str):
     """Updates the status in the book's frontmatter."""
     content = file_path.read_text(encoding="utf-8")
-    
+
     # Simple regex to find and replace status
     # This is safer than full YAML re-dumping if there are complex structures or custom user notes
     pattern = r"(status:\s*)(.*)"
     new_content = re.sub(pattern, f"\\1{new_status}", content)
-    
+
     file_path.write_text(new_content, encoding="utf-8")
+
 
 def list_books(vault_path: Path):
     """Lists all markdown files in the vault, assuming each is a book note."""
@@ -112,6 +116,7 @@ def list_books(vault_path: Path):
         if entry.is_file() and entry.name.endswith(".md")
     ]
 
+
 def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str, Any]]]:
     """Ensures that all current fields exist in the note's frontmatter.
 
@@ -120,7 +125,7 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
     frontmatter could not be parsed.
     """
     content = file_path.read_text(encoding="utf-8")
-    
+
     # Use a more robust regex to find the frontmatter block
     # Matches --- at start of file, then content, then --- on its own line
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
@@ -129,17 +134,17 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
         if not match:
             return False, None
-        
+
     frontmatter_yaml = match.group(1)
     rest_of_content = match.group(2)
-    
+
     try:
         data = yaml.safe_load(frontmatter_yaml)
         if not isinstance(data, dict):
             return False, None
     except Exception:
         return False, None
-        
+
     updated = False
 
     # Migrate legacy field names to canonical ones.
@@ -172,15 +177,16 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         if standardized != title_val:
             data["title"] = standardized
             updated = True
-            
+
     if updated:
         # Use dump but ensure we don't add unnecessary trailing newlines or spaces
         new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
         # Ensure there is exactly one newline before and after the rest of the content
         new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content.lstrip()}"
         file_path.write_text(new_content, encoding="utf-8")
-    
+
     return updated, data
+
 
 # Maps Book dataclass fields to frontmatter field names.
 _BOOK_TO_FRONTMATTER = {
@@ -195,7 +201,11 @@ _BOOK_TO_FRONTMATTER = {
     "description": None,  # handled separately (body, not frontmatter)
 }
 
-EXCLUDED_GOOGLE_BOOKS_IDS = {"_not_found_in_google_books_api", "_not_a_book", }
+EXCLUDED_GOOGLE_BOOKS_IDS = {
+    "_not_found_in_google_books_api",
+    "_not_a_book",
+}
+
 
 def find_duplicates(vault_path: Path) -> list[list[Path]]:
     """Find groups of duplicate book notes by title, ISBN, or Google Books ID.
@@ -213,7 +223,9 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
     def _author_key(fm: Dict[str, Any]) -> tuple[str, ...]:
         author = fm.get("author")
         if isinstance(author, list):
-            return tuple(sorted(a.strip().lower() for a in author if isinstance(a, str)))
+            return tuple(
+                sorted(a.strip().lower() for a in author if isinstance(a, str))
+            )
         elif isinstance(author, str):
             return (author.strip().lower(),)
         return ()
@@ -342,7 +354,9 @@ def update_frontmatter_from_book(file_path: Path, book: Book) -> bool:
 
     # Add description to body if missing
     if book.description and "### Description" not in rest_of_content:
-        rest_of_content = rest_of_content.rstrip() + f"\n\n### Description\n{book.description}\n"
+        rest_of_content = (
+            rest_of_content.rstrip() + f"\n\n### Description\n{book.description}\n"
+        )
         updated = True
 
     if updated:
@@ -372,7 +386,11 @@ def compute_canonical_filename(file_path: Path) -> Optional[str]:
         return None
 
     first_author = next(
-        (candidate.strip() for candidate in author_candidates if isinstance(candidate, str) and candidate.strip()),
+        (
+            candidate.strip()
+            for candidate in author_candidates
+            if isinstance(candidate, str) and candidate.strip()
+        ),
         None,
     )
     if first_author is None:
@@ -381,7 +399,9 @@ def compute_canonical_filename(file_path: Path) -> Optional[str]:
     return sanitize_filename(f"{title} - {first_author}.md")
 
 
-def update_wikilinks_in_vault(vault_root: Path, old_stem: str, new_stem: str, exclude: Optional[Path] = None) -> int:
+def update_wikilinks_in_vault(
+    vault_root: Path, old_stem: str, new_stem: str, exclude: Optional[Path] = None
+) -> int:
     """Update all wikilinks from old_stem to new_stem across the vault. Returns count of files updated."""
     updated_count = 0
     exclude_resolved = exclude.resolve() if exclude else None
@@ -406,18 +426,30 @@ def update_wikilinks_in_vault(vault_root: Path, old_stem: str, new_stem: str, ex
     return updated_count
 
 
-RenameStatus = Literal["renamed", "already_canonical", "missing_title", "missing_author", "invalid_frontmatter", "collision"]
+RenameStatus = Literal[
+    "renamed",
+    "already_canonical",
+    "missing_title",
+    "missing_author",
+    "invalid_frontmatter",
+    "collision",
+]
 
 
 @dataclass(frozen=True)
 class RenameResult:
     """Result of a rename attempt with diagnostic information."""
+
     status: RenameStatus
     new_path: Optional[Path] = None
     detail: Optional[str] = None
 
 
-def rename_book_file(file_path: Path, vault_root: Optional[Path] = None, frontmatter: Optional[Dict[str, Any]] = None) -> RenameResult:
+def rename_book_file(
+    file_path: Path,
+    vault_root: Optional[Path] = None,
+    frontmatter: Optional[Dict[str, Any]] = None,
+) -> RenameResult:
     """Rename a book file to canonical format and update wikilinks.
 
     If frontmatter is provided, it is used directly instead of re-reading

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def mock_config_dir(tmp_path, monkeypatch):
     """Automatically mock the configuration directory for all tests in the project."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock
 from libris.api import GoogleBooksClient
 
+
 def test_search_gatsby():
     client = GoogleBooksClient()
-    
+
     # Mock response
     mock_data = {
         "items": [
@@ -12,26 +13,28 @@ def test_search_gatsby():
                 "volumeInfo": {
                     "title": "The Great Gatsby",
                     "authors": ["F. Scott Fitzgerald"],
-                    "industryIdentifiers": [{"type": "ISBN_13", "identifier": "1234567890123"}],
+                    "industryIdentifiers": [
+                        {"type": "ISBN_13", "identifier": "1234567890123"}
+                    ],
                     "pageCount": 180,
                     "publishedDate": "1925",
                     "imageLinks": {"thumbnail": "http://example.com/thumb.jpg"},
                     "categories": ["Classic"],
-                    "description": "A novel about Jay Gatsby"
-                }
+                    "description": "A novel about Jay Gatsby",
+                },
             }
         ]
     }
-    
+
     from unittest.mock import patch
-    
+
     with patch("httpx.Client.get") as mock_get:
         mock_response = MagicMock()
         mock_response.json.return_value = mock_data
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
-        
+
         books = client.search("The Great Gatsby")
         assert len(books) == 1
         assert books[0].title == "The Great Gatsby"

--- a/tests/test_api_retry.py
+++ b/tests/test_api_retry.py
@@ -3,9 +3,10 @@ import pytest
 from unittest.mock import MagicMock, patch
 from libris.api import GoogleBooksClient
 
+
 def test_search_retry_on_429():
     client = GoogleBooksClient(max_retries=2)
-    
+
     mock_response_429 = MagicMock()
     mock_response_429.status_code = 429
     mock_response_429.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -15,34 +16,35 @@ def test_search_retry_on_429():
     mock_response_200 = MagicMock()
     mock_response_200.status_code = 200
     mock_response_200.json.return_value = {"items": []}
-    
+
     with patch("httpx.Client.get") as mock_get:
         # First call returns 429, second returns 200
         mock_get.side_effect = [mock_response_429, mock_response_200]
-        
+
         with patch("time.sleep") as mock_sleep:
             books = client.search("test")
-            
+
             assert mock_get.call_count == 2
             assert mock_sleep.call_count == 1
-            mock_sleep.assert_called_with(1) # 2^0
+            mock_sleep.assert_called_with(1)  # 2^0
             assert books == []
+
 
 def test_search_max_retries_exceeded():
     client = GoogleBooksClient(max_retries=1)
-    
+
     mock_response_429 = MagicMock()
     mock_response_429.status_code = 429
     mock_response_429.raise_for_status.side_effect = httpx.HTTPStatusError(
         "Rate Limit", request=MagicMock(), response=mock_response_429
     )
-    
+
     with patch("httpx.Client.get") as mock_get:
         mock_get.return_value = mock_response_429
-        
+
         with patch("time.sleep") as mock_sleep:
             with pytest.raises(httpx.HTTPStatusError):
                 client.search("test")
-            
-            assert mock_get.call_count == 2 # Initial + 1 retry
+
+            assert mock_get.call_count == 2  # Initial + 1 retry
             assert mock_sleep.call_count == 1

--- a/tests/test_autoenrich.py
+++ b/tests/test_autoenrich.py
@@ -43,7 +43,9 @@ def _write_book(vault, name, fm_overrides=None):
     }
     if fm_overrides:
         fm.update(fm_overrides)
-    content = f"---\n{yaml.dump(fm, sort_keys=False, allow_unicode=True)}---\n\n## Notes\n"
+    content = (
+        f"---\n{yaml.dump(fm, sort_keys=False, allow_unicode=True)}---\n\n## Notes\n"
+    )
     path = vault / name
     path.write_text(content, encoding="utf-8")
     return path
@@ -53,11 +55,13 @@ def _setup_vault(tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()
     from libris.config import set_config
+
     set_config("vault_path", str(vault))
     return vault
 
 
 # ── Single match → auto-enriched ────────────────────────────────────
+
 
 def test_autoenrich_single_match(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
@@ -84,15 +88,24 @@ def test_autoenrich_single_match(tmp_path, monkeypatch):
 
 # ── Multiple results, one confident title match → auto-enriched ─────
 
+
 def test_autoenrich_multiple_results_one_confident(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]})
+    _write_book(
+        vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]}
+    )
 
     dune = _make_book(
-        title="Dune", authors=["Frank Herbert"], google_books_id="dune1", isbn="9780441013593"
+        title="Dune",
+        authors=["Frank Herbert"],
+        google_books_id="dune1",
+        isbn="9780441013593",
     )
     other = _make_book(
-        title="Dune Messiah", authors=["Frank Herbert"], google_books_id="dune2", isbn="9780441172696"
+        title="Dune Messiah",
+        authors=["Frank Herbert"],
+        google_books_id="dune2",
+        isbn="9780441172696",
     )
 
     monkeypatch.setattr(
@@ -108,18 +121,32 @@ def test_autoenrich_multiple_results_one_confident(tmp_path, monkeypatch):
 
 # ── Multiple title matches → picks most complete metadata ───────────
 
+
 def test_autoenrich_prefers_most_complete_edition(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]})
+    _write_book(
+        vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]}
+    )
 
     sparse = _make_book(
-        title="Dune", authors=["Frank Herbert"], google_books_id="dune_sparse",
-        isbn=None, page_count=None, thumbnail=None, genres=[], description=None,
+        title="Dune",
+        authors=["Frank Herbert"],
+        google_books_id="dune_sparse",
+        isbn=None,
+        page_count=None,
+        thumbnail=None,
+        genres=[],
+        description=None,
     )
     complete = _make_book(
-        title="Dune", authors=["Frank Herbert"], google_books_id="dune_complete",
-        isbn="9780441013593", page_count=412, thumbnail="http://img.example.com/dune.jpg",
-        genres=["Science Fiction"], description="A science fiction masterpiece.",
+        title="Dune",
+        authors=["Frank Herbert"],
+        google_books_id="dune_complete",
+        isbn="9780441013593",
+        page_count=412,
+        thumbnail="http://img.example.com/dune.jpg",
+        genres=["Science Fiction"],
+        description="A science fiction masterpiece.",
     )
 
     monkeypatch.setattr(
@@ -132,9 +159,7 @@ def test_autoenrich_prefers_most_complete_edition(tmp_path, monkeypatch):
     assert "auto-enriched" in result.output
 
     fm = yaml.safe_load(
-        (vault / "Dune - Frank Herbert.md")
-        .read_text(encoding="utf-8")
-        .split("---")[1]
+        (vault / "Dune - Frank Herbert.md").read_text(encoding="utf-8").split("---")[1]
     )
     assert fm["google_books_id"] == "dune_complete"
     assert fm["isbn"] == "9780441013593"
@@ -142,9 +167,14 @@ def test_autoenrich_prefers_most_complete_edition(tmp_path, monkeypatch):
 
 # ── Multiple plausible results without --interactive → logged ────────
 
+
 def test_autoenrich_multiple_no_interactive_logs(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Ambiguous Book.md", {"title": "Ambiguous Book", "author": ["Some Author"]})
+    _write_book(
+        vault,
+        "Ambiguous Book.md",
+        {"title": "Ambiguous Book", "author": ["Some Author"]},
+    )
 
     book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1")
     book_b = _make_book(title="Ambiguous Book Vol 2", google_books_id="a2")
@@ -163,9 +193,14 @@ def test_autoenrich_multiple_no_interactive_logs(tmp_path, monkeypatch):
 
 # ── Multiple plausible results with --interactive → user selects ─────
 
+
 def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Ambiguous Book.md", {"title": "Ambiguous Book", "author": ["Some Author"]})
+    _write_book(
+        vault,
+        "Ambiguous Book.md",
+        {"title": "Ambiguous Book", "author": ["Some Author"]},
+    )
 
     book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1", isbn="111")
     book_b = _make_book(title="Ambiguous Book Vol 2", google_books_id="a2", isbn="222")
@@ -178,7 +213,11 @@ def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
     # Simulate questionary.select choosing the second option
     monkeypatch.setattr(
         "libris.cli.questionary.select",
-        lambda *a, **kw: type("Ask", (), {"ask": lambda self: f"Ambiguous Book Vol 2 by F. Scott Fitzgerald"})(),
+        lambda *a, **kw: type(
+            "Ask",
+            (),
+            {"ask": lambda self: "Ambiguous Book Vol 2 by F. Scott Fitzgerald"},
+        )(),
     )
 
     result = runner.invoke(app, ["autoenrich", "--interactive"])
@@ -186,18 +225,19 @@ def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
     assert "Enriched (interactive): 1" in result.output
 
     fm = yaml.safe_load(
-        (vault / "Ambiguous Book.md")
-        .read_text(encoding="utf-8")
-        .split("---")[1]
+        (vault / "Ambiguous Book.md").read_text(encoding="utf-8").split("---")[1]
     )
     assert fm["isbn"] == "222"
 
 
 # ── Interactive skip → book left unchanged ──────────────────────────
 
+
 def test_autoenrich_interactive_skip(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    book_path = _write_book(vault, "Skip Me.md", {"title": "Skip Me", "author": ["Author"]})
+    book_path = _write_book(
+        vault, "Skip Me.md", {"title": "Skip Me", "author": ["Author"]}
+    )
     original_content = book_path.read_text(encoding="utf-8")
 
     book_a = _make_book(title="Skip Me Vol 1", google_books_id="s1", isbn="111")
@@ -216,15 +256,21 @@ def test_autoenrich_interactive_skip(tmp_path, monkeypatch):
 
     result = runner.invoke(app, ["autoenrich", "--interactive"])
     assert result.exit_code == 0
-    assert "Enriched (interactive): 0" not in result.output or "Enriched (auto): 0" in result.output
+    assert (
+        "Enriched (interactive): 0" not in result.output
+        or "Enriched (auto): 0" in result.output
+    )
     assert book_path.read_text(encoding="utf-8") == original_content
 
 
 # ── Zero results → unmatched ────────────────────────────────────────
 
+
 def test_autoenrich_no_results(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Obscure Book.md", {"title": "Obscure Book", "author": ["Nobody"]})
+    _write_book(
+        vault, "Obscure Book.md", {"title": "Obscure Book", "author": ["Nobody"]}
+    )
 
     monkeypatch.setattr(
         "libris.cli.GoogleBooksClient.search",
@@ -240,18 +286,23 @@ def test_autoenrich_no_results(tmp_path, monkeypatch):
 
 # ── Already enriched → skipped ──────────────────────────────────────
 
+
 def test_autoenrich_skips_complete_books(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Complete Book.md", {
-        "title": "Complete Book",
-        "author": ["Author"],
-        "isbn": "123",
-        "page_count": 300,
-        "published_date": "2020",
-        "google_books_id": "gid1",
-        "genres": ["Fiction"],
-        "thumbnail": "http://img.example.com/thumb.jpg",
-    })
+    _write_book(
+        vault,
+        "Complete Book.md",
+        {
+            "title": "Complete Book",
+            "author": ["Author"],
+            "isbn": "123",
+            "page_count": 300,
+            "published_date": "2020",
+            "google_books_id": "gid1",
+            "genres": ["Fiction"],
+            "thumbnail": "http://img.example.com/thumb.jpg",
+        },
+    )
 
     search_called = []
     monkeypatch.setattr(
@@ -268,13 +319,17 @@ def test_autoenrich_skips_complete_books(tmp_path, monkeypatch):
 def test_autoenrich_skips_book_with_google_id_but_missing_fields(tmp_path, monkeypatch):
     """A book with google_books_id but missing thumbnail/genres should still be skipped."""
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Partial Book.md", {
-        "title": "Partial Book",
-        "author": ["Author"],
-        "google_books_id": "gid2",
-        "isbn": None,
-        "thumbnail": None,
-    })
+    _write_book(
+        vault,
+        "Partial Book.md",
+        {
+            "title": "Partial Book",
+            "author": ["Author"],
+            "google_books_id": "gid2",
+            "isbn": None,
+            "thumbnail": None,
+        },
+    )
 
     search_called = []
     monkeypatch.setattr(
@@ -284,21 +339,29 @@ def test_autoenrich_skips_book_with_google_id_but_missing_fields(tmp_path, monke
 
     result = runner.invoke(app, ["autoenrich"])
     assert result.exit_code == 0
-    assert len(search_called) == 0, "Should not re-enrich a book that already has a google_books_id"
+    assert len(search_called) == 0, (
+        "Should not re-enrich a book that already has a google_books_id"
+    )
 
 
-def test_autoenrich_skips_book_with_empty_google_id_but_thumbnail(tmp_path, monkeypatch):
+def test_autoenrich_skips_book_with_empty_google_id_but_thumbnail(
+    tmp_path, monkeypatch
+):
     """A book with empty google_books_id but populated thumbnail should be skipped."""
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "1776 - David McCullough.md", {
-        "title": "1776",
-        "author": ["David McCullough"],
-        "google_books_id": "",
-        "isbn": None,
-        "thumbnail": "http://books.google.com/books/content?id=yIIbAQAAMAAJ",
-        "published_date": "2007-10-02",
-        "page_count": 294,
-    })
+    _write_book(
+        vault,
+        "1776 - David McCullough.md",
+        {
+            "title": "1776",
+            "author": ["David McCullough"],
+            "google_books_id": "",
+            "isbn": None,
+            "thumbnail": "http://books.google.com/books/content?id=yIIbAQAAMAAJ",
+            "published_date": "2007-10-02",
+            "page_count": 294,
+        },
+    )
 
     search_called = []
     monkeypatch.setattr(
@@ -308,25 +371,36 @@ def test_autoenrich_skips_book_with_empty_google_id_but_thumbnail(tmp_path, monk
 
     result = runner.invoke(app, ["autoenrich"])
     assert result.exit_code == 0
-    assert len(search_called) == 0, "Should not re-enrich a book that has thumbnail/published_date"
+    assert len(search_called) == 0, (
+        "Should not re-enrich a book that has thumbnail/published_date"
+    )
 
 
 # ── ISBN fallback when title/author search fails ────────────────────
 
+
 def test_autoenrich_isbn_fallback(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "ISBN Book.md", {
-        "title": "ISBN Book",
-        "author": ["Author"],
-        "isbn": "9780451524935",
-    })
+    _write_book(
+        vault,
+        "ISBN Book.md",
+        {
+            "title": "ISBN Book",
+            "author": ["Author"],
+            "isbn": "9780451524935",
+        },
+    )
 
     queries = []
 
     def fake_search(self, q):
         queries.append(q)
         if q.startswith("isbn:"):
-            return [_make_book(title="ISBN Book", isbn="9780451524935", google_books_id="isbn1")]
+            return [
+                _make_book(
+                    title="ISBN Book", isbn="9780451524935", google_books_id="isbn1"
+                )
+            ]
         return []
 
     monkeypatch.setattr("libris.cli.GoogleBooksClient.search", fake_search)
@@ -359,9 +433,12 @@ def test_autoenrich_no_isbn_no_fallback(tmp_path, monkeypatch):
 
 # ── --dry-run does not modify files ─────────────────────────────────
 
+
 def test_autoenrich_dry_run(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    book_path = _write_book(vault, "Dry Run Book.md", {"title": "Dry Run Book", "author": ["Author"]})
+    book_path = _write_book(
+        vault, "Dry Run Book.md", {"title": "Dry Run Book", "author": ["Author"]}
+    )
     original_content = book_path.read_text(encoding="utf-8")
 
     result = runner.invoke(app, ["autoenrich", "--dry-run"])
@@ -372,6 +449,7 @@ def test_autoenrich_dry_run(tmp_path, monkeypatch):
 
 
 # ── --limit stops after N actions ───────────────────────────────────
+
 
 def test_autoenrich_limit(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
@@ -392,15 +470,24 @@ def test_autoenrich_limit(tmp_path, monkeypatch):
 
 # ── Query uses frontmatter title+author when available ──────────────
 
+
 def test_autoenrich_query_from_frontmatter(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "renamed-file.md", {"title": "The Hobbit", "author": ["J.R.R. Tolkien"]})
+    _write_book(
+        vault, "renamed-file.md", {"title": "The Hobbit", "author": ["J.R.R. Tolkien"]}
+    )
 
     captured = {}
 
     def fake_search(self, q):
         captured["query"] = q
-        return [_make_book(title="The Hobbit", authors=["J.R.R. Tolkien"], google_books_id="hobbit1")]
+        return [
+            _make_book(
+                title="The Hobbit",
+                authors=["J.R.R. Tolkien"],
+                google_books_id="hobbit1",
+            )
+        ]
 
     monkeypatch.setattr("libris.cli.GoogleBooksClient.search", fake_search)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import yaml
 
 runner = CliRunner()
 
+
 def test_config_vault_path(tmp_path):
     # Test getting current vault path (should not fail)
     result = runner.invoke(app, ["config"])
@@ -21,11 +22,12 @@ def test_config_vault_path(tmp_path):
     result = runner.invoke(app, ["config", "--api-key", "my-secret-key"])
     assert result.exit_code == 0
     assert "API key set successfully." in result.output
-    
+
     # Test getting current config
     result = runner.invoke(app, ["config"])
     assert result.exit_code == 0
     assert "API key: *********-key" in result.output
+
 
 def test_config_vault_path_writes_legacy_and_new_keys(tmp_path):
     from libris.config import get_config_file
@@ -54,29 +56,33 @@ def test_config_command_reads_legacy_vault_key(tmp_path):
     assert result.exit_code == 0
     assert f"Current vault path: {legacy_vault.resolve()}" in result.output
 
+
 def test_cleanup_command(tmp_path):
     # Mock vault path
     vault_path = tmp_path / "my_vault"
     vault_path.mkdir()
-    
+
     # Create a legacy file
     legacy_file = vault_path / "Legacy.md"
-    legacy_file.write_text("---\ntitle: Legacy\nstatus: To Read\ngoogle_books_id: 123\n---\n")
-    
+    legacy_file.write_text(
+        "---\ntitle: Legacy\nstatus: To Read\ngoogle_books_id: 123\n---\n"
+    )
+
     # Run cleanup via CLI
     # We need to ensure the config uses this vault path
     from libris.config import set_config
+
     set_config("vault_path", str(vault_path))
-    
+
     result = runner.invoke(app, ["cleanup"])
     assert result.exit_code == 0
     assert "Updated: Legacy.md" in result.output
     assert "Finished. Updated 1 books." in result.output
-    
+
     # Verify file content
     content = legacy_file.read_text()
     assert "tags: Book" in content
-    
+
     # Run again
     result = runner.invoke(app, ["cleanup"])
     assert result.exit_code == 0
@@ -86,6 +92,7 @@ def test_cleanup_command(tmp_path):
 def test_search_command_generic(monkeypatch):
     """Search with no flags performs a generic query."""
     from libris.api import Book
+
     mock_books = [
         Book(
             title="The Great Gatsby",
@@ -99,7 +106,9 @@ def test_search_command_generic(monkeypatch):
             description="A novel about Jay Gatsby",
         )
     ]
-    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", lambda self, q: mock_books)
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search", lambda self, q: mock_books
+    )
 
     result = runner.invoke(app, ["search", "gatsby"])
     assert result.exit_code == 0
@@ -114,6 +123,7 @@ def test_search_command_generic(monkeypatch):
 def test_search_command_by_author(monkeypatch):
     """Search with --author prepends inauthor: prefix."""
     from libris.api import Book
+
     captured = {}
 
     def fake_search(self, q):
@@ -144,6 +154,7 @@ def test_search_command_by_author(monkeypatch):
 def test_search_command_by_title(monkeypatch):
     """Search with --title prepends intitle: prefix."""
     from libris.api import Book
+
     captured = {}
 
     def fake_search(self, q):
@@ -173,6 +184,7 @@ def test_search_command_by_title(monkeypatch):
 def test_search_command_by_isbn(monkeypatch):
     """Search with --isbn prepends isbn: prefix."""
     from libris.api import Book
+
     captured = {}
 
     def fake_search(self, q):
@@ -214,9 +226,12 @@ def test_list_command_timing_flag(tmp_path):
 
     # Valid book note (should be listed)
     book_file = vault_path / "Book.md"
-    book_file.write_text("---\nstatus: To Read\ngoogle_books_id: 123\n---\n", encoding="utf-8")
+    book_file.write_text(
+        "---\nstatus: To Read\ngoogle_books_id: 123\n---\n", encoding="utf-8"
+    )
 
     from libris.config import set_config
+
     set_config("vault_path", str(vault_path))
 
     result = runner.invoke(app, ["list", "--timing"])
@@ -230,20 +245,29 @@ class TestBuildSearchQuery:
 
     def test_title_with_author_separator(self):
         from libris.cli import _build_search_query
-        result = _build_search_query("The First Rule of Mastery Stop Worrying about What People Think of You - Michael Gervais")
-        assert result == "intitle:The First Rule of Mastery Stop Worrying about What People Think of You inauthor:Michael Gervais"
+
+        result = _build_search_query(
+            "The First Rule of Mastery Stop Worrying about What People Think of You - Michael Gervais"
+        )
+        assert (
+            result
+            == "intitle:The First Rule of Mastery Stop Worrying about What People Think of You inauthor:Michael Gervais"
+        )
 
     def test_plain_title_no_separator(self):
         from libris.cli import _build_search_query
+
         result = _build_search_query("Atomic Habits")
         assert result == "Atomic Habits"
 
     def test_multiple_separators_splits_on_first(self):
         from libris.cli import _build_search_query
+
         result = _build_search_query("Title - Subtitle - Author")
         assert result == "intitle:Title inauthor:Subtitle - Author"
 
     def test_empty_string(self):
         from libris.cli import _build_search_query
+
         result = _build_search_query("")
         assert result == ""

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -32,8 +32,22 @@ def test_no_duplicates(tmp_path):
 
 
 def test_duplicate_by_title(tmp_path):
-    _write_book(tmp_path, "A.md", title="Same Title", isbn="111", google_books_id="a1", author=["Author A"])
-    _write_book(tmp_path, "B.md", title="same title", isbn="222", google_books_id="b2", author=["Author A"])
+    _write_book(
+        tmp_path,
+        "A.md",
+        title="Same Title",
+        isbn="111",
+        google_books_id="a1",
+        author=["Author A"],
+    )
+    _write_book(
+        tmp_path,
+        "B.md",
+        title="same title",
+        isbn="222",
+        google_books_id="b2",
+        author=["Author A"],
+    )
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
     names = {p.name for p in groups[0]}
@@ -58,7 +72,9 @@ def test_same_title_missing_author_is_duplicate(tmp_path):
 
 def test_duplicate_by_isbn(tmp_path):
     _write_book(tmp_path, "A.md", title="First Title", isbn="111", google_books_id="a1")
-    _write_book(tmp_path, "B.md", title="Second Title", isbn="111", google_books_id="b2")
+    _write_book(
+        tmp_path, "B.md", title="Second Title", isbn="111", google_books_id="b2"
+    )
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
 
@@ -72,8 +88,22 @@ def test_duplicate_by_google_books_id(tmp_path):
 
 def test_transitive_duplicates_merged(tmp_path):
     """A shares title with B, B shares ISBN with C => all three in one group."""
-    _write_book(tmp_path, "A.md", title="Shared Title", isbn="111", google_books_id="a1", author=["Same Author"])
-    _write_book(tmp_path, "B.md", title="Shared Title", isbn="222", google_books_id="b2", author=["Same Author"])
+    _write_book(
+        tmp_path,
+        "A.md",
+        title="Shared Title",
+        isbn="111",
+        google_books_id="a1",
+        author=["Same Author"],
+    )
+    _write_book(
+        tmp_path,
+        "B.md",
+        title="Shared Title",
+        isbn="222",
+        google_books_id="b2",
+        author=["Same Author"],
+    )
     _write_book(tmp_path, "C.md", title="Other Title", isbn="222", google_books_id="c3")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
@@ -110,8 +140,22 @@ def test_null_fields_not_matched(tmp_path):
 def test_cli_duplicates_command_reports(tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()
-    _write_book(vault, "A.md", title="Dup Book", isbn="111", google_books_id="g1", author=["Author"])
-    _write_book(vault, "B.md", title="Dup Book", isbn="222", google_books_id="g2", author=["Author"])
+    _write_book(
+        vault,
+        "A.md",
+        title="Dup Book",
+        isbn="111",
+        google_books_id="g1",
+        author=["Author"],
+    )
+    _write_book(
+        vault,
+        "B.md",
+        title="Dup Book",
+        isbn="222",
+        google_books_id="g2",
+        author=["Author"],
+    )
     set_config("vault_path", str(vault))
 
     result = runner.invoke(app, ["duplicates"])

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -182,9 +182,14 @@ def test_import_detects_duplicates(tmp_path):
     set_config("book_vault", str(vault))
 
     # Pre-existing book in vault
-    _write_book(vault, "Existing Book - Author A.md",
-                title="Existing Book", author=["Author A"],
-                status="Read", format="Audiobook")
+    _write_book(
+        vault,
+        "Existing Book - Author A.md",
+        title="Existing Book",
+        author=["Author A"],
+        status="Read",
+        format="Audiobook",
+    )
 
     data = [
         {"title": "Existing Book", "author": "Author A", "finished": "Yes"},
@@ -204,9 +209,14 @@ def test_import_updates_status_on_duplicate(tmp_path):
     set_config("book_vault", str(vault))
 
     # Existing book with "To Read" status
-    existing = _write_book(vault, "My Book - Author A.md",
-                           title="My Book", author=["Author A"],
-                           status="To Read", format=None)
+    existing = _write_book(
+        vault,
+        "My Book - Author A.md",
+        title="My Book",
+        author=["Author A"],
+        status="To Read",
+        format=None,
+    )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
     json_file = _write_audible_json(tmp_path / "library.json", data)
@@ -225,9 +235,14 @@ def test_import_updates_format_on_duplicate(tmp_path):
     set_config("book_vault", str(vault))
 
     # Existing book with no format
-    existing = _write_book(vault, "My Book - Author A.md",
-                           title="My Book", author=["Author A"],
-                           status="Read", format=None)
+    existing = _write_book(
+        vault,
+        "My Book - Author A.md",
+        title="My Book",
+        author=["Author A"],
+        status="Read",
+        format=None,
+    )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
     json_file = _write_audible_json(tmp_path / "library.json", data)
@@ -249,13 +264,8 @@ def test_import_updates_format_when_field_missing(tmp_path):
     # Create a book note without a format field at all
     existing = vault / "My Book - Author A.md"
     existing.write_text(
-        "---\n"
-        "title: My Book\n"
-        "author:\n"
-        "- Author A\n"
-        "status: Read\n"
-        "---\n",
-        encoding="utf-8"
+        "---\ntitle: My Book\nauthor:\n- Author A\nstatus: Read\n---\n",
+        encoding="utf-8",
     )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
@@ -274,9 +284,14 @@ def test_import_updates_both_status_and_format(tmp_path):
     vault.mkdir()
     set_config("book_vault", str(vault))
 
-    existing = _write_book(vault, "My Book - Author A.md",
-                           title="My Book", author=["Author A"],
-                           status="To Read", format=None)
+    existing = _write_book(
+        vault,
+        "My Book - Author A.md",
+        title="My Book",
+        author=["Author A"],
+        status="To Read",
+        format=None,
+    )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
     json_file = _write_audible_json(tmp_path / "library.json", data)
@@ -297,9 +312,14 @@ def test_import_skips_up_to_date_duplicate(tmp_path):
     vault.mkdir()
     set_config("book_vault", str(vault))
 
-    _write_book(vault, "My Book - Author A.md",
-                title="My Book", author=["Author A"],
-                status="Read", format="Audiobook")
+    _write_book(
+        vault,
+        "My Book - Author A.md",
+        title="My Book",
+        author=["Author A"],
+        status="Read",
+        format="Audiobook",
+    )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
     json_file = _write_audible_json(tmp_path / "library.json", data)
@@ -330,9 +350,14 @@ def test_import_case_insensitive_duplicate(tmp_path):
     vault.mkdir()
     set_config("book_vault", str(vault))
 
-    _write_book(vault, "The Great Book - Jane Smith.md",
-                title="The Great Book", author=["Jane Smith"],
-                status="Read", format="Audiobook")
+    _write_book(
+        vault,
+        "The Great Book - Jane Smith.md",
+        title="The Great Book",
+        author=["Jane Smith"],
+        status="Read",
+        format="Audiobook",
+    )
 
     # Same book with different casing
     data = [{"title": "the great book", "author": "jane smith", "finished": "Yes"}]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,11 +2,23 @@ from pathlib import Path
 import time
 from statistics import median
 from libris.api import Book
-from libris.markdown import create_book_note, sanitize_filename, standardize_title, list_books, read_frontmatter, update_frontmatter_from_book, compute_canonical_filename, update_wikilinks_in_vault, rename_book_file
+from libris.markdown import (
+    create_book_note,
+    sanitize_filename,
+    standardize_title,
+    list_books,
+    read_frontmatter,
+    update_frontmatter_from_book,
+    compute_canonical_filename,
+    update_wikilinks_in_vault,
+    rename_book_file,
+)
+
 
 def test_sanitize_filename():
     assert sanitize_filename("Title: With Colon") == "Title With Colon"
     assert sanitize_filename("Title / With / Slash") == "Title With Slash"
+
 
 def test_create_book_note(tmp_path):
     book = Book(
@@ -18,29 +30,32 @@ def test_create_book_note(tmp_path):
         google_books_id="xyz",
         thumbnail="http://example.com/thumb.jpg",
         genres=["Test"],
-        description="A test description"
+        description="A test description",
     )
-    
+
     file_path = create_book_note(book, tmp_path)
     assert file_path.exists()
     assert "Test Book - Author One.md" in file_path.name
-    
+
     content = file_path.read_text()
     assert "title: Test Book" in content
     assert "author:\n- Author One" in content
     assert "### Description" in content
     assert "A test description" in content
 
+
 def test_update_book_status(tmp_path):
     file_path = tmp_path / "test.md"
     file_path.write_text("---\ntitle: Test\nstatus: To Read\n---\n")
-    
+
     from libris.markdown import update_book_status
+
     update_book_status(file_path, "Reading")
-    
+
     content = file_path.read_text()
     assert "status: Reading" in content
     assert "status: To Read" not in content
+
 
 def test_ensure_frontmatter_fields(tmp_path):
     file_path = tmp_path / "legacy_book.md"
@@ -53,20 +68,20 @@ google_books_id: 123
 ## Notes
 Some existing notes here.
 """)
-    
+
     from libris.markdown import ensure_frontmatter_fields
-    
+
     # Run cleanup
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
-    
+
     content = file_path.read_text()
     assert "tags: Book" in content
     assert "format: null" in content
     assert "date_added:" in content
     assert "status: Finished" in content
     assert "Some existing notes here." in content
-    
+
     # Run again, should not update
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is False
@@ -80,6 +95,7 @@ def test_ensure_frontmatter_sets_status_read_when_date_finished(tmp_path):
     )
 
     from libris.markdown import ensure_frontmatter_fields
+
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
 
@@ -94,6 +110,7 @@ def test_ensure_frontmatter_converts_author_string_to_list(tmp_path):
     )
 
     from libris.markdown import ensure_frontmatter_fields
+
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
 
@@ -104,12 +121,15 @@ def test_ensure_frontmatter_converts_author_string_to_list(tmp_path):
 def test_ensure_frontmatter_fields_tricky_spacing(tmp_path):
     # Test with extra spaces after --- and no newline after second ---
     file_path = tmp_path / "tricky_book.md"
-    file_path.write_text("--- \ntitle: Tricky\ngoogle_books_id: 456\n--- \nSome content")
-    
+    file_path.write_text(
+        "--- \ntitle: Tricky\ngoogle_books_id: 456\n--- \nSome content"
+    )
+
     from libris.markdown import ensure_frontmatter_fields
+
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
-    
+
     content = file_path.read_text()
     assert "tags: Book" in content
     assert "Some content" in content
@@ -132,6 +152,7 @@ Rating out of 5: 4
 """)
 
     from libris.markdown import ensure_frontmatter_fields
+
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
 
@@ -159,6 +180,7 @@ rating: 5
 """)
 
     from libris.markdown import ensure_frontmatter_fields
+
     updated, _ = ensure_frontmatter_fields(file_path)
     assert updated is True
 
@@ -186,7 +208,9 @@ def test_read_frontmatter_returns_none_for_non_frontmatter(tmp_path):
 
 def test_update_frontmatter_from_book_fills_nulls(tmp_path):
     f = tmp_path / "book.md"
-    f.write_text("---\ntitle: null\nisbn: null\ngoogle_books_id: null\nstatus: Reading\n---\n")
+    f.write_text(
+        "---\ntitle: null\nisbn: null\ngoogle_books_id: null\nstatus: Reading\n---\n"
+    )
 
     book = Book(
         title="Real Title",
@@ -327,6 +351,7 @@ def test_list_books_benchmark_against_legacy_read_pattern(tmp_path):
 
 # --- Title Standardizer Tests ---
 
+
 def test_standardize_title_basic():
     assert standardize_title("the great gatsby") == "The Great Gatsby"
     assert standardize_title("THE GREAT GATSBY") == "The Great Gatsby"
@@ -335,13 +360,19 @@ def test_standardize_title_basic():
 
 def test_standardize_title_preserves_subtitle():
     assert standardize_title("dune: the machine crusade") == "Dune: The Machine Crusade"
-    assert standardize_title("clean code: a handbook of agile software craftsmanship") == "Clean Code: A Handbook of Agile Software Craftsmanship"
+    assert (
+        standardize_title("clean code: a handbook of agile software craftsmanship")
+        == "Clean Code: A Handbook of Agile Software Craftsmanship"
+    )
 
 
 def test_standardize_title_strips_brackets():
     assert standardize_title("Dune [Illustrated]") == "Dune"
     assert standardize_title("Python {Kindle Edition}") == "Python"
-    assert standardize_title("The Art of War [Annotated] [Illustrated]") == "The Art of War"
+    assert (
+        standardize_title("The Art of War [Annotated] [Illustrated]")
+        == "The Art of War"
+    )
 
 
 def test_standardize_title_collapses_whitespace():
@@ -362,6 +393,7 @@ def test_standardize_title_preserves_mixed_case():
 
 def test_ensure_frontmatter_standardizes_title(tmp_path):
     from libris.markdown import ensure_frontmatter_fields
+
     file_path = tmp_path / "caps_book.md"
     file_path.write_text("---\ntitle: THE GREAT GATSBY\ngoogle_books_id: abc\n---\n")
 
@@ -374,6 +406,7 @@ def test_ensure_frontmatter_standardizes_title(tmp_path):
 
 def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
     from libris.markdown import ensure_frontmatter_fields
+
     file_path = tmp_path / "good_book.md"
     # Write a file with all fields present and title already standardized
     file_path.write_text(
@@ -389,6 +422,7 @@ def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
 
 
 # --- File Rename Tests ---
+
 
 def test_compute_canonical_filename(tmp_path):
     f = tmp_path / "old name.md"


### PR DESCRIPTION
## Summary

Adds CI/CD infrastructure for the project per #30.

### Changes

- **CI Workflow** (`.github/workflows/ci.yml`):
  - **test** job: runs `uv run pytest` on Python 3.12 and 3.13
  - **lint** job: runs `ruff format --check` and `ruff check`
  - **security** job: audits dependencies via `pip-audit`
  - Triggers on push to main and pull requests

- **Dependabot** (`.github/dependabot.yml`):
  - Weekly updates for pip and github-actions ecosystems

- **Ruff security rules** (`pyproject.toml`):
  - Enabled flake8-bandit (`S`) rule set for security linting
  - Suppressed S101 (assert) in test files

### Pre-existing violations (tracked separately)

- #32 — S110 try-except-pass in api.py
- #33 — E501 line too long violations

Closes #30