### PR TITLE
fix: remove duplicate dependabot config entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
 updates:
-version: 2
-updates:
   # Dependabot does not currently update `uv.lock` for uv-managed projects; keep Python deps updated via a dedicated workflow or a tool that supports uv.
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes the validation error about overlapping directories. The file had a duplicated header and two identical github-actions entries for /, causing the conflict. Collapsed to a single valid entry.