### PR TITLE
feat: add CLI options to 'add' command for specifying book properties

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -155,7 +155,7 @@ def search(
 def add(
     query: str = typer.Argument(..., help="Title, author, or ISBN to search for"),
     status: str = typer.Option("To Read", "--status", "-s", help="Reading status"),
-    format: str | None = typer.Option(
+    medium: str | None = typer.Option(
         None, "--format", "-f", help="Reading format (e.g., paperback, kindle, audiobook)"
     ),
     rating: int | None = typer.Option(
@@ -196,8 +196,8 @@ def add(
 
     # Build overrides from CLI options
     overrides = {"status": status}
-    if format is not None:
-        overrides["format"] = format
+    if medium is not None:
+        overrides["format"] = medium
     if rating is not None:
         overrides["rating"] = rating
     if referred_by is not None:

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -195,7 +195,7 @@ def add(
         return
 
     # Build overrides from CLI options
-    overrides = {}
+    overrides = {"status": status}
     if format is not None:
         overrides["format"] = format
     if rating is not None:

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -156,7 +156,10 @@ def add(
     query: str = typer.Argument(..., help="Title, author, or ISBN to search for"),
     status: str = typer.Option("To Read", "--status", "-s", help="Reading status"),
     medium: str | None = typer.Option(
-        None, "--format", "-f", help="Reading format (e.g., paperback, kindle, audiobook)"
+        None,
+        "--format",
+        "-f",
+        help="Reading format (e.g., paperback, kindle, audiobook)",
     ),
     rating: int | None = typer.Option(
         None, "--rating", "-r", help="Rating (1-5)", min=1, max=5

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -152,7 +152,26 @@ def search(
 
 
 @app.command()
-def add(query: str = typer.Argument(..., help="Title, author, or ISBN to search for")):
+def add(
+    query: str = typer.Argument(..., help="Title, author, or ISBN to search for"),
+    status: str = typer.Option("To Read", "--status", "-s", help="Reading status"),
+    format: str | None = typer.Option(
+        None, "--format", "-f", help="Reading format (e.g., paperback, kindle, audiobook)"
+    ),
+    rating: int | None = typer.Option(
+        None, "--rating", "-r", help="Rating (1-5)", min=1, max=5
+    ),
+    referred_by: str | None = typer.Option(
+        None, "--referred-by", help="Who recommended this book"
+    ),
+    tags: str | None = typer.Option(None, "--tags", help="Tags (default: Book)"),
+    date_started: str | None = typer.Option(
+        None, "--date-started", help="Date started reading (YYYY-MM-DD)"
+    ),
+    date_finished: str | None = typer.Option(
+        None, "--date-finished", help="Date finished reading (YYYY-MM-DD)"
+    ),
+):
     """Search for a book and add it to your Obsidian vault."""
     client = GoogleBooksClient()
     books = client.search(query)
@@ -175,8 +194,25 @@ def add(query: str = typer.Argument(..., help="Title, author, or ISBN to search 
         typer.echo(f"Vault path does not exist: {vault_path}")
         return
 
+    # Build overrides from CLI options
+    overrides = {}
+    if format is not None:
+        overrides["format"] = format
+    if rating is not None:
+        overrides["rating"] = rating
+    if referred_by is not None:
+        overrides["referred_by"] = referred_by
+    if tags is not None:
+        overrides["tags"] = tags
+    if date_started is not None:
+        overrides["date_started"] = date_started
+    if date_finished is not None:
+        overrides["date_finished"] = date_finished
+
     # Create the book note
-    file_path = create_book_note(selected_book, vault_path)
+    file_path = create_book_note(
+        selected_book, vault_path, status=status, overrides=overrides or None
+    )
     typer.echo(f"Added: {file_path}")
 
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -67,8 +67,21 @@ def standardize_title(raw: Optional[str]) -> Optional[str]:
     return title
 
 
-def create_book_note(book: Book, vault_path: Path, status: str = "To Read") -> Path:
-    """Creates a Markdown note for a book in the specified vault path."""
+def create_book_note(
+    book: Book,
+    vault_path: Path,
+    status: str = "To Read",
+    overrides: Dict[str, Any] | None = None,
+) -> Path:
+    """Creates a Markdown note for a book in the specified vault path.
+
+    Args:
+        book: The Book dataclass with data from Google Books API.
+        vault_path: Directory where the note will be written.
+        status: Default reading status (overridden if 'status' is in overrides).
+        overrides: Optional dict of frontmatter fields to set/override.
+            Keys must exist in DEFAULT_FRONTMATTER.
+    """
     filename = sanitize_filename(f"{book.title} - {', '.join(book.authors[:1])}.md")
     file_path = vault_path / filename
 
@@ -85,6 +98,15 @@ def create_book_note(book: Book, vault_path: Path, status: str = "To Read") -> P
         "status": status,
         "date_added": date.today().isoformat(),
     }
+
+    if overrides:
+        for key, value in overrides.items():
+            if key not in DEFAULT_FRONTMATTER:
+                raise ValueError(
+                    f"Unknown frontmatter field: '{key}'. "
+                    f"Valid fields: {', '.join(DEFAULT_FRONTMATTER.keys())}"
+                )
+            frontmatter[key] = value
 
     yaml_content = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,7 +236,9 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
             description=None,
         )
     ]
-    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", lambda self, q: mock_books)
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search", lambda self, q: mock_books
+    )
 
     choice = "Dune by Frank Herbert"
 
@@ -244,7 +246,9 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
         def ask(self):
             return choice
 
-    monkeypatch.setattr("libris.cli.questionary.select", lambda *args, **kwargs: _Selection())
+    monkeypatch.setattr(
+        "libris.cli.questionary.select", lambda *args, **kwargs: _Selection()
+    )
     monkeypatch.setattr("libris.cli.get_vault_path", lambda: tmp_path)
 
     captured = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,6 +220,82 @@ def test_search_command_no_results(monkeypatch):
     assert "No books found." in result.output
 
 
+def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
+    from libris.api import Book
+
+    mock_books = [
+        Book(
+            title="Dune",
+            authors=["Frank Herbert"],
+            isbn="9780441013593",
+            page_count=412,
+            published_date="1965",
+            google_books_id="dune1",
+            thumbnail=None,
+            genres=["Science Fiction"],
+            description=None,
+        )
+    ]
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", lambda self, q: mock_books)
+
+    choice = "Dune by Frank Herbert"
+
+    class _Selection:
+        def ask(self):
+            return choice
+
+    monkeypatch.setattr("libris.cli.questionary.select", lambda *args, **kwargs: _Selection())
+    monkeypatch.setattr("libris.cli.get_vault_path", lambda: tmp_path)
+
+    captured = {}
+
+    def fake_create_book_note(book, vault_path, status, overrides):
+        captured["book"] = book
+        captured["vault_path"] = vault_path
+        captured["status"] = status
+        captured["overrides"] = overrides
+        return vault_path / "Dune.md"
+
+    monkeypatch.setattr("libris.cli.create_book_note", fake_create_book_note)
+
+    result = runner.invoke(
+        app,
+        [
+            "add",
+            "dune",
+            "--status",
+            "Finished",
+            "--format",
+            "kindle",
+            "--rating",
+            "5",
+            "--referred-by",
+            "Alice",
+            "--tags",
+            "Sci-Fi,Classic",
+            "--date-started",
+            "2026-01-01",
+            "--date-finished",
+            "2026-01-10",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["book"] == mock_books[0]
+    assert captured["vault_path"] == tmp_path
+    assert captured["status"] == "Finished"
+    assert captured["overrides"] == {
+        "status": "Finished",
+        "format": "kindle",
+        "rating": 5,
+        "referred_by": "Alice",
+        "tags": "Sci-Fi,Classic",
+        "date_started": "2026-01-01",
+        "date_finished": "2026-01-10",
+    }
+    assert "Added:" in result.output
+
+
 def test_list_command_timing_flag(tmp_path):
     vault_path = tmp_path / "my_vault"
     vault_path.mkdir()

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -44,6 +44,84 @@ def test_create_book_note(tmp_path):
     assert "A test description" in content
 
 
+def test_create_book_note_with_overrides(tmp_path):
+    """Test that overrides dict sets frontmatter fields."""
+    book = Book(
+        title="Override Book",
+        authors=["Author Two"],
+        isbn="0987654321",
+        page_count=200,
+        published_date="2024",
+        google_books_id="abc",
+        thumbnail=None,
+        genres=["Fiction"],
+        description=None,
+    )
+
+    # Given overrides for format, rating, and referred_by
+    overrides = {
+        "format": "kindle",
+        "rating": 4,
+        "referred_by": "A Friend",
+    }
+
+    # When creating a book note with overrides
+    file_path = create_book_note(book, tmp_path, overrides=overrides)
+
+    # Then the overrides appear in frontmatter
+    content = file_path.read_text()
+    assert "format: kindle" in content
+    assert "rating: 4" in content
+    assert "referred_by: A Friend" in content
+
+
+def test_create_book_note_overrides_status(tmp_path):
+    """Test that status in overrides takes precedence over the status parameter."""
+    book = Book(
+        title="Status Book",
+        authors=["Author Three"],
+        isbn="1111111111",
+        page_count=150,
+        published_date="2025",
+        google_books_id="def",
+        thumbnail=None,
+        genres=[],
+        description=None,
+    )
+
+    # Given status override that differs from default
+    overrides = {"status": "Reading"}
+
+    # When creating with default status but an override
+    file_path = create_book_note(book, tmp_path, status="To Read", overrides=overrides)
+
+    # Then the override wins
+    content = file_path.read_text()
+    assert "status: Reading" in content
+
+
+def test_create_book_note_invalid_override_raises(tmp_path):
+    """Test that an unknown override key raises ValueError."""
+    import pytest
+
+    book = Book(
+        title="Bad Override",
+        authors=["Author Four"],
+        isbn="2222222222",
+        page_count=50,
+        published_date="2020",
+        google_books_id="ghi",
+        thumbnail=None,
+        genres=[],
+        description=None,
+    )
+
+    # When passing an invalid frontmatter key
+    # Then a ValueError is raised
+    with pytest.raises(ValueError, match="Unknown frontmatter field"):
+        create_book_note(book, tmp_path, overrides={"nonexistent_field": "value"})
+
+
 def test_update_book_status(tmp_path):
     file_path = tmp_path / "test.md"
     file_path.write_text("---\ntitle: Test\nstatus: To Read\n---\n")


### PR DESCRIPTION
Add --status, --format, --rating, --referred-by, --tags, --date-started, and --date-finished options to the dd command. These are passed as an overrides dict to create_book_note(), which validates keys against DEFAULT_FRONTMATTER before merging.

## New CLI options

| Option | Short | Description |
|--------|-------|-------------|
| \--status\ | \-s\ | Reading status (default: To Read) |
| \--format\ | \-f\ | Reading format (e.g., paperback, kindle, audiobook) |
| \--rating\ | \-r\ | Rating (1-5) |
| \--referred-by\ | | Who recommended this book |
| \--tags\ | | Tags (default: Book) |
| \--date-started\ | | Date started reading (YYYY-MM-DD) |
| \--date-finished\ | | Date finished reading (YYYY-MM-DD) |

Closes #13