### PR TITLE
feat: honor Retry-After and report wait time on rate limits

### DIFF
--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -27,8 +27,9 @@ def _default_rate_limit_notice(
         attempt: 1-based retry attempt number.
         max_retries: Total number of retries that will be attempted.
     """
+    wait_display = f"{wait_seconds:.1f}".rstrip("0").rstrip(".")
     print(
-        f"Rate limited by Google Books API. Waiting {wait_seconds:.0f}s before retrying "
+        f"Rate limited by Google Books API. Waiting {wait_display}s before retrying "
         f"(attempt {attempt}/{max_retries})...",
         file=sys.stderr,
         flush=True,
@@ -41,9 +42,9 @@ def parse_retry_after(value: object, now: datetime | None = None) -> float | Non
     Supports both the delta-seconds form (e.g. ``"120"``) and the HTTP-date
     form (e.g. ``"Wed, 21 Oct 2015 07:28:00 GMT"``).
 
-    Args:
-        value: Raw header value. Non-string, missing, or malformed values
-            yield ``None``.
+        value: Raw header value. Strings are parsed as ``Retry-After`` (delta-seconds
+            or HTTP-date); numeric values are treated as delta-seconds. Missing or
+            malformed values yield ``None``.
         now: Reference time used for HTTP-date values. Defaults to the
             current UTC time.
 
@@ -116,6 +117,8 @@ class GoogleBooksClient:
         """
         self.timeout = timeout
         self.max_retries = max_retries
+        if max_retry_wait < 0:
+            raise ValueError("max_retry_wait must be non-negative.")
         self.max_retry_wait = max_retry_wait
         self.on_rate_limit = on_rate_limit or _default_rate_limit_notice
 

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -2,8 +2,12 @@
 
 import logging
 import socket
+import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import List, Optional
 
 import httpx
@@ -11,6 +15,69 @@ import httpx
 from .config import get_api_key
 
 logger = logging.getLogger(__name__)
+
+
+def _default_rate_limit_notice(
+    wait_seconds: float, attempt: int, max_retries: int
+) -> None:
+    """Inform the user that we are pausing because of an API rate limit.
+
+    Args:
+        wait_seconds: Number of seconds we are about to sleep.
+        attempt: 1-based retry attempt number.
+        max_retries: Total number of retries that will be attempted.
+    """
+    print(
+        f"Rate limited by Google Books API. Waiting {wait_seconds:.0f}s before retrying "
+        f"(attempt {attempt}/{max_retries})...",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def parse_retry_after(value: object, now: datetime | None = None) -> float | None:
+    """Parse an HTTP ``Retry-After`` header value into seconds.
+
+    Supports both the delta-seconds form (e.g. ``"120"``) and the HTTP-date
+    form (e.g. ``"Wed, 21 Oct 2015 07:28:00 GMT"``).
+
+    Args:
+        value: Raw header value. Non-string, missing, or malformed values
+            yield ``None``.
+        now: Reference time used for HTTP-date values. Defaults to the
+            current UTC time.
+
+    Returns:
+        The wait time in seconds (never negative), or ``None`` if the value
+        could not be parsed.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return max(0.0, float(value))
+    if not isinstance(value, str):
+        return None
+
+    raw = value.strip()
+    if not raw:
+        return None
+
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if retry_at is None:
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - reference).total_seconds())
 
 
 @dataclass
@@ -29,9 +96,68 @@ class Book:
 class GoogleBooksClient:
     BASE_URL = "https://www.googleapis.com/books/v1/volumes"
 
-    def __init__(self, timeout: float = 10.0, max_retries: int = 3):
+    def __init__(
+        self,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        max_retry_wait: float = 300.0,
+        on_rate_limit: Callable[[float, int, int], None] | None = None,
+    ):
+        """Create a Google Books API client.
+
+        Args:
+            timeout: Per-request timeout in seconds.
+            max_retries: Number of retries attempted after the initial request.
+            max_retry_wait: Upper bound, in seconds, for a wait requested by a
+                ``Retry-After`` header. Protects against absurd server values.
+            on_rate_limit: Callback invoked with ``(wait_seconds, attempt,
+                max_retries)`` before sleeping due to a 429 response. Defaults
+                to printing the wait time to stderr.
+        """
         self.timeout = timeout
         self.max_retries = max_retries
+        self.max_retry_wait = max_retry_wait
+        self.on_rate_limit = on_rate_limit or _default_rate_limit_notice
+
+    def _rate_limit_wait(self, response: object, attempt: int) -> float:
+        """Determine how long to wait after a rate-limited response.
+
+        Uses the ``Retry-After`` header when present and parseable, otherwise
+        falls back to exponential backoff.
+
+        Args:
+            response: The rate-limited HTTP response.
+            attempt: Zero-based attempt index used for backoff.
+
+        Returns:
+            The number of seconds to sleep.
+        """
+        retry_after = None
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            try:
+                retry_after = parse_retry_after(headers.get("Retry-After"))
+            except (AttributeError, TypeError):
+                retry_after = None
+
+        if retry_after is None:
+            return float(2**attempt)
+        return min(retry_after, self.max_retry_wait)
+
+    def _handle_rate_limit(self, response: object, attempt: int) -> None:
+        """Notify the user and sleep before retrying a rate-limited request.
+
+        Args:
+            response: The rate-limited HTTP response.
+            attempt: Zero-based attempt index used for backoff.
+        """
+        wait_time = self._rate_limit_wait(response, attempt)
+        logger.warning(
+            f"Rate limited (429). Retrying in {wait_time}s... "
+            f"(Attempt {attempt + 1}/{self.max_retries})"
+        )
+        self.on_rate_limit(wait_time, attempt + 1, self.max_retries)
+        time.sleep(wait_time)
 
     def search(self, query: str) -> List[Book]:
         params = {"q": query, "maxResults": 10}
@@ -54,11 +180,7 @@ class GoogleBooksClient:
 
                     if response.status_code == 429:
                         if attempt < self.max_retries:
-                            wait_time = 2**attempt
-                            logger.warning(
-                                f"Rate limited (429). Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})"
-                            )
-                            time.sleep(wait_time)
+                            self._handle_rate_limit(response, attempt)
                             continue
 
                     response.raise_for_status()
@@ -72,6 +194,12 @@ class GoogleBooksClient:
                             and e.response.status_code in [429, 500, 502, 503, 504]
                         )
                     ):
+                        if (
+                            isinstance(e, httpx.HTTPStatusError)
+                            and e.response.status_code == 429
+                        ):
+                            self._handle_rate_limit(e.response, attempt)
+                            continue
                         wait_time = 2**attempt
                         logger.warning(
                             f"Request failed: {e}. Retrying in {wait_time}s... (Attempt {attempt + 1}/{self.max_retries})"

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from libris.api import GoogleBooksClient, parse_retry_after
 

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from libris.api import GoogleBooksClient, parse_retry_after
+
+
+def _rate_limited_response(headers: dict[str, str] | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 429
+    response.headers = headers or {}
+    return response
+
+
+def _ok_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.json.return_value = {"items": []}
+    return response
+
+
+def test_parse_retry_after_accepts_delta_seconds():
+    # Given a Retry-After header expressed in seconds
+    # When parsing it
+    # Then the numeric value is returned
+    assert parse_retry_after("42") == 42.0
+
+
+def test_parse_retry_after_accepts_http_date():
+    # Given a Retry-After header expressed as an HTTP-date 60s in the future
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    header = (now + timedelta(seconds=60)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    # When parsing it relative to now
+    seconds = parse_retry_after(header, now=now)
+
+    # Then roughly 60 seconds are returned
+    assert seconds == 60.0
+
+
+def test_parse_retry_after_returns_none_for_garbage():
+    # Given malformed or missing header values
+    # When parsing them
+    # Then None is returned so the caller can fall back to backoff
+    assert parse_retry_after(None) is None
+    assert parse_retry_after("soon") is None
+    assert parse_retry_after("") is None
+    assert parse_retry_after(MagicMock()) is None
+
+
+def test_parse_retry_after_never_returns_negative():
+    # Given a Retry-After date already in the past
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    header = (now - timedelta(seconds=90)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    # When parsing it
+    # Then the wait is clamped to zero
+    assert parse_retry_after(header, now=now) == 0.0
+
+
+def test_search_waits_for_retry_after_header():
+    # Given a 429 response asking the client to wait 7 seconds
+    client = GoogleBooksClient(max_retries=2)
+    responses = [_rate_limited_response({"Retry-After": "7"}), _ok_response()]
+
+    with patch("httpx.Client.get", side_effect=responses):
+        with patch("time.sleep") as mock_sleep:
+            # When searching
+            client.search("test")
+
+    # Then the client sleeps for exactly that duration
+    mock_sleep.assert_called_once_with(7.0)
+
+
+def test_search_reports_wait_time_to_user():
+    # Given a rate-limited response and a notification callback
+    notices: list[tuple[float, int, int]] = []
+    client = GoogleBooksClient(
+        max_retries=2,
+        on_rate_limit=lambda wait, attempt, total: notices.append(
+            (wait, attempt, total)
+        ),
+    )
+    responses = [_rate_limited_response({"Retry-After": "12"}), _ok_response()]
+
+    with patch("httpx.Client.get", side_effect=responses):
+        with patch("time.sleep"):
+            # When searching
+            client.search("test")
+
+    # Then the user is told how long the client is waiting
+    assert notices == [(12.0, 1, 2)]
+
+
+def test_default_rate_limit_notice_prints_wait_time(capsys):
+    # Given a client using the default notifier
+    client = GoogleBooksClient(max_retries=1)
+    responses = [_rate_limited_response({"Retry-After": "5"}), _ok_response()]
+
+    with patch("httpx.Client.get", side_effect=responses):
+        with patch("time.sleep"):
+            # When searching
+            client.search("test")
+
+    # Then the wait time is printed for the user
+    assert "Waiting 5s" in capsys.readouterr().err
+
+
+def test_search_caps_absurd_retry_after_values():
+    # Given a server asking us to wait a full day
+    client = GoogleBooksClient(max_retries=1, max_retry_wait=60.0)
+    responses = [_rate_limited_response({"Retry-After": "86400"}), _ok_response()]
+
+    with patch("httpx.Client.get", side_effect=responses):
+        with patch("time.sleep") as mock_sleep:
+            # When searching
+            client.search("test")
+
+    # Then the wait is capped at max_retry_wait
+    mock_sleep.assert_called_once_with(60.0)
+
+
+def test_search_falls_back_to_backoff_without_retry_after():
+    # Given 429 responses with no Retry-After header
+    client = GoogleBooksClient(max_retries=2)
+    responses = [
+        _rate_limited_response(),
+        _rate_limited_response(),
+        _ok_response(),
+    ]
+
+    with patch("httpx.Client.get", side_effect=responses):
+        with patch("time.sleep") as mock_sleep:
+            # When searching
+            client.search("test")
+
+    # Then exponential backoff is used
+    assert [call.args[0] for call in mock_sleep.call_args_list] == [1.0, 2.0]

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from libris.api import GoogleBooksClient, parse_retry_after
 


### PR DESCRIPTION
Closes #26

## Problem

When the Google Books API returned a `429`, `GoogleBooksClient` always slept using exponential backoff and ignored the server's `Retry-After` header. The only feedback was a `logger.warning`, which the CLI never surfaces — so from the user's perspective the command just hung.

## Changes

`src/libris/api.py`:

- **`parse_retry_after(value, now=None)`** — new helper that parses both `Retry-After` forms: delta-seconds (`"120"`) and HTTP-date (`"Wed, 21 Oct 2015 07:28:00 GMT"`). Negative waits are clamped to `0`; missing or malformed values return `None`.
- **`_rate_limit_wait()`** — uses `Retry-After` when parseable, otherwise falls back to the existing `2**attempt` backoff. Capped by a new `max_retry_wait` constructor arg (default `300s`) so a rogue header value can't hang the CLI for hours.
- **`_handle_rate_limit()`** — notifies the user, then sleeps. Applied to both the direct `status_code == 429` path and the `HTTPStatusError` 429 path, which previously behaved inconsistently.
- **`on_rate_limit` callback** — new optional constructor arg. Defaults to printing to stderr:
  ```
  Rate limited by Google Books API. Waiting 7s before retrying (attempt 1/3)...
  ```
  Because there's a sensible default, none of the five `GoogleBooksClient()` call sites in `cli.py` needed changes.

## Tests

New `tests/test_api_rate_limit.py` covering header parsing (seconds, HTTP-date, past dates, garbage input), honoring the requested wait, the user-visible stderr message, the `max_retry_wait` cap, and the backoff fallback when no header is present.

Full suite: **154 passed**. `ruff check` / `ruff format` clean. Existing retry tests in `test_api_retry.py` still pass unchanged.