### PR TITLE
chore: bump click to 8.4.2 to fix PYSEC-2026-2132

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -44,14 +44,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The `CI / security` job is failing on `main` (and therefore on every open PR). Its `pip-audit` step reports:

```
Found 1 known vulnerability in 1 package
Name  Version ID              Fix Versions
----- ------- --------------- ------------
click 8.3.2   PYSEC-2026-2132 8.3.3
```

`click` is a transitive dependency pulled in by Typer, so it's only pinned in `uv.lock`.

## Change

Minimal lockfile-only bump via `uv lock --upgrade-package click` — no `pyproject.toml` change was needed (nothing upper-bounds `click`). uv resolved to the latest compatible release, 8.4.2, which is >= the 8.3.3 fix version.

```diff
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
```

The CI workflow was **not** modified — no `--ignore-vuln`, `|| true`, or `continue-on-error`. The advisory is actually resolved.

## Validation

Ran the exact security-job commands locally:

```
uv sync --frozen
uv export --no-hashes --frozen --no-dev > runtime-requirements.txt
uv tool run pip-audit --skip-editable -r runtime-requirements.txt
```

→ `No known vulnerabilities found` (exit 0; `libris` itself skipped as a local package, as before).

Also passing:
- `uv run pytest` — 145 passed
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 17 files already formatted

Closes #49