### PR TITLE
refactor: introduce BookNote, fix the frontmatter drift, and migrate the vault

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,90 @@
+# Libris
+
+Libris keeps a catalogue of the books Tim has read, is reading, or intends to read. The
+catalogue lives as Markdown notes inside an Obsidian vault, enriched from public book
+metadata, and is being extended to a remote replica so it can be added to and queried from
+devices that do not hold the notes.
+
+## Language
+
+### The collection
+
+**Library**:
+The logical collection of books Tim tracks, independent of where it is stored. The Shelf
+and the remote replica are two copies of one Library, not two libraries.
+
+**Shelf**:
+The local replica of the Library — a directory of Book Notes sitting inside the Vault.
+_Avoid_: book vault, vault path
+
+**Vault**:
+The Obsidian vault that the Shelf sits inside. Reserved for Obsidian's own meaning; never
+used for the Shelf.
+_Avoid_: using "vault" to mean the Shelf
+
+**Book**:
+The work itself — what an author wrote. Not a file and not a record. Dune is a Book; the
+note about it is a Book Note, and a Google Books result describing it is a Book Candidate.
+
+**Book Candidate**:
+Metadata about a Book proposed by an external source — a Google Books search result, a row
+from an Audible export. A candidate has not been accepted into the Library and may describe
+a Book already held, a different edition, or the wrong Book entirely.
+_Avoid_: Book (the bare word, for this meaning), search result, volume
+
+**Book Note**:
+One Markdown file representing one book: frontmatter fields plus a body.
+_Avoid_: book file, note, record
+
+### Identity
+
+**Libris ID**:
+The ULID stamped into a Book Note's frontmatter that identifies it across every replica.
+Stable across renames, title standardisation, and merges.
+_Avoid_: uid, book id, key
+
+**Matching**:
+Deciding whether two Book Notes describe the same book — the judgement behind duplicate
+detection and import de-duplication. Deliberately separate from identity, and allowed to be
+fuzzy because it is not a key.
+_Avoid_: dedupe key, book key
+
+### Surfaces
+
+**Surface**:
+Anything that reads or changes the Library: the CLI, Obsidian, a mobile app, or an LLM
+agent. Only the CLI writes to the Shelf; every other Surface reaches the Library through
+the remote replica.
+_Avoid_: client, front end
+
+**Intent**:
+A change to the Library recorded by a Surface and applied to the Shelf later by the CLI —
+either adding a Book Note or setting named fields on an existing one. An Intent names only
+the fields it changes, so it can never overwrite a field it knows nothing about.
+_Avoid_: delta, patch, command, event
+
+**Resolution**:
+Turning a person's reference to a book ("that Sanderson one I just finished") into a Libris
+ID. Always performed while the person is still present to disambiguate.
+_Avoid_: lookup, matching (Matching is the separate duplicate-detection judgement)
+
+**Publishing**:
+Exposing a read-only view of the Library to someone else. A rendering of existing data, not
+a grant of access — distinct from multi-user, which Libris does not support.
+_Avoid_: sharing
+
+### Book fields
+
+**Status**:
+Where a book sits in the reading cycle: To Read, Reading, Read, or Not To Read.
+
+**Priority**: 
+How much a To Read book is wanted: Low, Medium, or High. Absent on books never triaged.
+
+**Series**:
+A link to the note for the series a book belongs to. A relationship within the Vault, not a
+text label, and meaningless outside it.
+
+**Enrichment**:
+Filling a Book Note's metadata from a public book source. A note is unenriched when no
+API-sourced field has a value, whatever else it holds.

--- a/docs/adr/0001-libris-id-as-book-identity.md
+++ b/docs/adr/0001-libris-id-as-book-identity.md
@@ -1,0 +1,18 @@
+# Book identity is a minted `libris_id`
+
+Syncing book notes to a remote store requires a key that survives the things Libris
+already does to notes: `clean --rename` rewrites filenames to canonical form, `merge`
+collapses duplicate notes, and `standardize_title` rewrites titles. Filenames and titles
+are therefore unusable as identity. The natural keys do not cover the library either — of
+3,137 notes in the vault, 1,231 (39%) have an empty `google_books_id` and 371 (12%) have
+an empty `isbn`, and both are edition-specific rather than work-specific.
+
+We mint a ULID into each note's frontmatter as `libris_id`, via a one-time migration over
+the existing vault. It is the primary key everywhere: local notes, remote records, and any
+future client. ULIDs sort lexicographically by creation time, which also gives sync a
+usable cursor.
+
+This keeps **identity** (which note this *is*) separate from **matching** (which notes
+describe the same book). Matching stays where it is today — normalized title and author in
+`merge.py` and `importer.py` — and is now free to be fuzzy, because it no longer has to
+double as a key.

--- a/docs/adr/0002-shelf-stays-source-of-truth.md
+++ b/docs/adr/0002-shelf-stays-source-of-truth.md
@@ -1,0 +1,21 @@
+# The Shelf stays the source of truth; the remote serves other surfaces
+
+We considered making a remote store the source of truth for the Library, with the Shelf as
+a rendered projection. Investigating the vault showed that most of what such a move would
+buy is already in place: Obsidian mobile plus file sync give multi-device access and
+backup, and `autoenrich` already turns a bare note into an enriched Book Note using the
+filename as its query. Capture and multi-device editing are solved problems here.
+
+What is not solved is reaching the Library from a surface that has no vault — a mobile app,
+or an LLM agent asked "I just finished Oathbringer." That, and not synchronisation, is why
+a remote exists.
+
+So the Shelf remains authoritative. The remote holds a replica so other surfaces can read
+it, and accepts changes from them as field-level intents rather than whole records. Whole
+Book Notes travel Shelf-to-remote; only intents travel remote-to-Shelf. This asymmetry is
+deliberate: it removes conflict resolution from the design entirely, because nothing except
+the Shelf ever asserts a value for a field it did not change.
+
+It also matches how the clients actually behave. An agent saying "I finished this book"
+knows one field. Letting it send a whole record would let it silently erase the ones it
+never knew about.

--- a/docs/adr/0003-resolution-happens-in-conversation.md
+++ b/docs/adr/0003-resolution-happens-in-conversation.md
@@ -1,0 +1,20 @@
+# Book resolution happens in conversation, never at apply time
+
+When a Surface says "I finished Oathbringer", something has to decide which Book Note that
+is. The Shelf makes this genuinely hard: it holds 3,137 notes, of which nineteen are titled
+"Poems" and ten "Selected Poems", and a series like Mistborn is three separate notes that
+all match the word "Mistborn".
+
+Resolution therefore happens while the person is still in the conversation. The API exposes
+a search that returns candidates carrying their Libris IDs, and a separate update that takes
+an ID. Ambiguity goes back to the calling Surface, which asks the person there and then.
+Deferring resolution to the CLI would mean asking "which Mistborn did you mean?" days later,
+when the person who knew is gone.
+
+We rejected single-call fuzzy resolution with a confidence threshold. Its failure mode is
+silent: a confident-but-wrong match marks the wrong book Read and nothing surfaces the
+error, possibly for years.
+
+A miss is a miss. If nothing matches, the API says so; it never creates a Book Note as a
+side effect of a failed update. Adding is a separate, deliberate call, held to the same
+rule — the Surface confirms which book and which edition before anything is written.

--- a/docs/adr/0004-single-tenant-one-identity.md
+++ b/docs/adr/0004-single-tenant-one-identity.md
@@ -1,0 +1,15 @@
+# Libris is single-tenant: one identity, no ownership model
+
+Libris serves one person. There is no owner column on a Book, no per-record authorization,
+and no user table. Authorization is a single question: is this Tim.
+
+We separated two things that sound alike. *Publishing* — showing someone a read-only view of
+the Library — is a static render of data we already hold, and can be added at any time
+without touching the model. *Multi-user* — other people holding their own Libraries, or
+writing to this one — would put an owner on every record and an authorization check on every
+endpoint. Only the second is expensive to retrofit, and only the second is being declined.
+
+Microsoft Entra is the identity plane, since the service is hosted in Azure anyway. Sign-in
+uses a Gmail address via Google federation, which Entra External ID supports for Gmail
+accounts specifically. Should sharing ever mean real multi-user access, this decision is the
+one to revisit first.

--- a/docs/adr/0005-vault-vocabulary-is-canonical.md
+++ b/docs/adr/0005-vault-vocabulary-is-canonical.md
@@ -1,0 +1,20 @@
+# The vault's frontmatter vocabulary is canonical
+
+Three vocabularies had drifted apart: the code's `DEFAULT_FRONTMATTER`, the frontmatter
+actually present in the 3,137 Book Notes, and the field names in `Reading List.base`. The
+Bases view was silently broken as a result, sorting on `author`, `genre` and `Status` when
+the notes hold `authors`, `genres` and `status`.
+
+The notes win. They are the data; the code and the view drifted from them. Canonical names
+are `authors`, `date_published`, `cover_thumbnail`, `genres`, `status`. Three of the four
+are also the better name: `authors` and `genres` are lists, and `date_published` matches
+the existing `date_added`, `date_started`, `date_finished`.
+
+`priority` and `series` are promoted to modelled fields. Every Book Note carries every
+modelled key, null where unset — an invariant the Shelf already satisfies, and one worth
+keeping because it makes the schema and the Bases columns predictable.
+
+Fields Libris does not model — `date_created`, `date_modified`, `aliases`, and anything a
+plugin adds later — are carried through verbatim and never rewritten. Dropping them would
+not make them go away: the linter re-adds them on the next edit, producing an edit loop
+that Obsidian Sync would replicate to every device.

--- a/docs/adr/0006-remote-is-a-document-store.md
+++ b/docs/adr/0006-remote-is-a-document-store.md
@@ -1,0 +1,16 @@
+# The remote replica is a document store
+
+ADR 0005 requires the remote to carry frontmatter keys Libris does not model, verbatim and
+unmodified. That requirement chooses the storage shape: in a relational store, "arbitrary
+keys I have never seen" becomes a JSON column that cannot be queried usefully, which pays
+the flexibility penalty without buying the flexibility.
+
+Cosmos DB serverless, with two containers. `books` holds one document per Book Note —
+modelled frontmatter, passthrough keys, and the note body — partitioned by Libris ID.
+`intents` holds pending and applied Intents, so applied ones remain as a record of what each
+Surface did.
+
+The whole Book Note goes up, body included. The entire Shelf is about 4.3 MB of content, so
+storing the descriptions costs nothing and leaves a published view able to show them.
+
+Access is via managed identity. No connection string is issued, so none can leak.

--- a/docs/adr/0007-one-mcp-server-two-transports.md
+++ b/docs/adr/0007-one-mcp-server-two-transports.md
@@ -1,0 +1,17 @@
+# One MCP server, two transports, on Container Apps via Terraform
+
+The tool surface is the risky part of this design and the infrastructure is not. So the same
+MCP server runs two ways: over stdio on the PC, where it needs no Azure, no auth and no
+deployment, and later over Streamable HTTP behind Entra for agents that are not on this
+machine. The tool definitions do not change between them. Streamable HTTP without an SSE
+requirement serves both Claude custom connectors and Gemini.
+
+That constraint favours Azure Container Apps over Functions. The server is an ASGI app, and
+Container Apps runs the same `uvicorn` command locally and in Azure rather than adding the
+Functions host as a third runtime shape. The price is a container registry and an image
+build in the deploy path, accepted knowingly. Functions would have been cheaper to operate
+and quicker to cold-start.
+
+Terraform provisions it, not Bicep. Beyond preference, the `azuread` provider makes the
+Entra application registration a first-class resource, which Bicep cannot do without a
+preview Graph extension. The bootstrap step that would otherwise sit outside IaC disappears.

--- a/docs/adr/0008-two-adapters-over-one-service-layer.md
+++ b/docs/adr/0008-two-adapters-over-one-service-layer.md
@@ -1,0 +1,19 @@
+# MCP and REST are two adapters over one service layer
+
+The MCP tools are not the only client. `libris sync` drains pending Intents, pushes Book
+Note state and acknowledges what applied — bulk work with no language model in the loop and
+no ambiguity to hand back. Expressing that as agent tool calls would be a poor fit, so a
+plain HTTP API is required from the start rather than being a later addition.
+
+Both live in one ASGI app: `/mcp/*` and `/api/v1/*` are thin adapters over a single service
+layer that owns resolution, creation, Intent recording and querying. Logic never lives in a
+tool handler; if it did, the REST surface would have to reimplement matching.
+
+The two adapters deliberately differ in shape. MCP tools are coarse and tolerant, taking
+fuzzy input and handing ambiguity back as candidates for a person to settle. REST is fine
+grained and exact, taking Libris IDs and returning 404 on a miss. A mobile app should speak
+REST: MCP's tool discovery exists to help a language model choose, and an app already knows
+what it wants.
+
+Only the endpoints sync needs are built now. Query endpoints for a mobile app or a published
+view are additive over the same service layer.

--- a/docs/adr/0008-two-adapters-over-one-service-layer.md
+++ b/docs/adr/0008-two-adapters-over-one-service-layer.md
@@ -17,3 +17,7 @@ what it wants.
 
 Only the endpoints sync needs are built now. Query endpoints for a mobile app or a published
 view are additive over the same service layer.
+
+Extended by ADR 0010: there are three adapters, not two. The Edge extension (#51) reaches
+the same service layer over a local daemon, and the count here was taken before that plan
+was known.

--- a/docs/adr/0009-note-body-leads-with-your-notes.md
+++ b/docs/adr/0009-note-body-leads-with-your-notes.md
@@ -10,9 +10,22 @@ notes and missing from 1,751.
 So a machine-generated blurb, occasionally in the wrong language, was the dominant content
 of every note, sitting above the 8% of notes holding something irreplaceable.
 
-`## Notes` is normalised onto every Book Note and comes first. The description moves below it
-into a collapsed `> [!abstract]-` callout: still indexed by Omnisearch, no longer dominating
-the read view. Frontmatter is grouped rather than arbitrary — identity, bibliographic,
+A Book Note opens with an `# Title` H1, then `## Notes`, then the description in a collapsed
+`> [!abstract]-` callout: still indexed by Omnisearch, no longer dominating the read view.
+`## Notes` is normalised onto every note; it is currently present on only 1,386 of 3,137.
+
+The H1 is load-bearing and must not be tidied away. Obsidian Linter's `yaml-title-alias`
+rule is enabled with `keep-alias-that-matches-the-filename: false`, so it derives an alias
+from the first heading. With no H1 it took `## Notes` or `### Description`, which is how
+eleven notes came to be aliased "Notes" and three "Description" — those notes carry a
+corrupted `# Notes` or `# Description` heading too, and the migration repairs both. With a
+correct H1 it mints the title as an alias, which is what lets `[[Dune]]` resolve against a
+file named `Dune - Frank Herbert.md`.
+
+Aliases are left to the linter rather than written by the migration. It owns the rule and
+its own formatting conventions, and hand-writing them invites a fight the next time it runs.
+The consequence is accepted: aliases exist on 240 notes today and will spread only as notes
+are edited. Frontmatter is grouped rather than arbitrary — identity, bibliographic,
 reading state, then dates — because nineteen fields in no order is unreadable in Obsidian's
 Properties panel.
 

--- a/docs/adr/0009-note-body-leads-with-your-notes.md
+++ b/docs/adr/0009-note-body-leads-with-your-notes.md
@@ -1,0 +1,25 @@
+# The note body leads with your notes, not the blurb
+
+Measured across the Shelf: the median Book Note is 1,329 bytes and the median Google Books
+description inside it is 1,031. The blurb is roughly three quarters of the average note, and
+it is the one part fully re-derivable from an API call. Of 3,137 notes, 2,411 carry a
+description, at least 15 of those are not in English, and only 248 contain a single sentence
+the reader wrote. The `## Notes` heading meant to hold that writing is present in 1,386
+notes and missing from 1,751.
+
+So a machine-generated blurb, occasionally in the wrong language, was the dominant content
+of every note, sitting above the 8% of notes holding something irreplaceable.
+
+`## Notes` is normalised onto every Book Note and comes first. The description moves below it
+into a collapsed `> [!abstract]-` callout: still indexed by Omnisearch, no longer dominating
+the read view. Frontmatter is grouped rather than arbitrary — identity, bibliographic,
+reading state, then dates — because nineteen fields in no order is unreadable in Obsidian's
+Properties panel.
+
+Dropping descriptions outright was tempting and would have shrunk the vault by about three
+quarters. It was rejected only because it would end full-text search over blurbs in Obsidian.
+They remain available remotely regardless (ADR 0006).
+
+This changes the risk profile of the migration. It previously touched frontmatter alone; it
+now rewrites bodies, including the 248 notes that hold real writing and one that runs to
+26 KB. The dry run must be reviewed by eye before anything is written.

--- a/docs/adr/0010-extension-endpoint-is-configurable.md
+++ b/docs/adr/0010-extension-endpoint-is-configurable.md
@@ -1,0 +1,25 @@
+# The extension's endpoint is configurable, and duplicate checks declare their authority
+
+Extends ADR 0008.
+
+The Edge extension (#51) could talk to a localhost daemon or to the remote service. Routing
+it only through Azure would gate a capture surface that needs no infrastructure on four
+workstreams that do, and would break capture whenever the machine is offline — for a task
+performed in a browser three feet from the Shelf. Routing it only through localhost would
+give up adding books from a work laptop or a phone browser, which is the stated reason the
+remote exists at all.
+
+So the service layer is built once and both adapters sit over it: `libris serve` on
+loopback now, the Container App later. The extension stores a base URL and a credential, so
+moving it to the remote is configuration rather than a rewrite.
+
+The two adapters are not equivalent, and the difference is behavioural rather than
+transport. A local daemon checks for duplicates against the live Shelf and can promise "this
+Book was not in your Library, and now it is." The remote checks against a replica no fresher
+than the last sync, and can only promise "not as far as I knew, and it will be soon."
+Responses therefore state which guarantee was given, so a Surface can say "added" or
+"queued" truthfully rather than guessing.
+
+This makes the deferred question of what happens to an Intent that cannot apply urgent
+rather than theoretical: a duplicate caught at apply time is now the common case, and it
+needs a path back to the person who clicked the button.

--- a/docs/adr/0011-libris-ids-are-minted-from-date-added.md
+++ b/docs/adr/0011-libris-ids-are-minted-from-date-added.md
@@ -1,0 +1,16 @@
+# Libris IDs are minted from each note's `date_added`
+
+ADR 0001 chose ULIDs partly because they sort lexicographically by creation time, which gives
+sync a usable cursor. Minting all 3,137 existing IDs at migration time would have given them
+near-identical timestamps, making that order meaningless for the entire library we already
+hold and useful only for books added afterwards.
+
+So the timestamp component comes from each note's own `date_added` rather than from the
+moment the migration runs. The library then sorts in the order it was actually acquired.
+Notes with no `date_added` fall back to the migration time; the randomness component keeps
+IDs distinct where dates collide, which they will, since `date_added` has day resolution and
+books were often added in batches.
+
+`python-ulid` provides the encoding. Hand-rolling Crockford base32 was considered and
+rejected: it is a small amount of code but not a small amount of correctness, and the
+project can carry a sixth dependency.

--- a/docs/adr/0012-libris-owns-the-title-field.md
+++ b/docs/adr/0012-libris-owns-the-title-field.md
@@ -1,0 +1,24 @@
+# Libris owns `title`; the linter's `yaml-title` rule is disabled
+
+Obsidian Linter's `yaml-title` rule was configured with `mode: filename`. Book Notes are
+named `Title - Author.md`, so every time the linter touched a note it wrote `Title - Author`
+into the `title` field — putting the author inside the title.
+
+That is not historical damage like the corrupted headings and aliases. It recurs on every
+edit, so repairing titles without changing the rule would achieve nothing. It also made a
+newly working feature dangerous: `clean --rename` had been a no-op for the life of this
+vault because it read a key no note carried, and once that was fixed it would have renamed
+156 files, some into `Title - Author - Author.md`.
+
+The rule is therefore disabled vault-wide and Libris owns `title`, which it already sets
+from Google Books. Nothing is deleted; existing titles remain and simply stop being
+rewritten. The cost is that renaming a non-book note no longer updates its title
+automatically. That cost is small: of 1,350 non-book notes, 809 carry no `title` at all and
+work fine, and of the 383 that do, 272 merely repeat their filename. `Reading List.base` is
+the only Bases view in the vault and it queries Book Notes.
+
+`yaml-title-alias` stays enabled. It is the rule doing useful work, and ADR 0009 depends on
+it.
+
+Scoping the change to the Book List folder via `foldersToIgnore` was rejected: it is
+all-or-nothing per folder and would have disabled `yaml-title-alias` there too.

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -29,8 +29,15 @@ Scope:
 - Introduce a `BookNote` type: `libris_id`, path, typed frontmatter, body
 - Rename `Book` to `BookCandidate`; collapse `ImportBook` into it with a `source` field
 - Move `cli.py` off raw `fm.get(...)` dict access
-- Restructure the note body: `## Notes` first on every note, description into a collapsed
+- Restructure the note body: `# Title` then `## Notes` then the description in a collapsed
   callout, frontmatter grouped (ADR 0009, closes #57)
+- Repair four flavours of Obsidian Linter damage: 4 notes whose `title` is "Notes", 18+
+  whose `title` carries the author, 14 with a corrupted `# Notes` or `# Description`
+  heading, and 14 aliased "Notes" or "Description" (ADR 0012)
+
+**Do not run `clean --rename` before the migration.** It was a no-op for the life of this
+vault and is now live; against today's titles it would rename 156 files and rewrite
+wikilinks, some into `Title - Author - Author.md`.
 
 The last three are the reason the first four were needed. There is no type for a book in the
 Library: `list_books` returns `list[Path]`, `read_frontmatter` returns `Dict[str, Any]`,

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -1,0 +1,70 @@
+# Workstreams
+
+Ordered by dependency. Workstream 1 needs no Azure and blocks everything after it.
+
+## 1. Vault migration and typing
+
+Done as a single pass: the note migration and the typing ship together, so the 3,137 notes
+are rewritten once rather than reasoned about in a half-migrated state. This blocks
+workstreams 2-5 for its duration, accepted knowingly.
+
+Order within the pass:
+
+1. Put the repository under version control (see note below)
+2. Introduce `BookNote` and `BookCandidate`; collapse `ImportBook` into the latter
+3. Point `markdown.py`, `cli.py`, `merge.py` and `importer.py` at the types, fixing the
+   field names as part of the move rather than as a separate edit
+4. Update the tests that assert on dict shape; the 78 text assertions should pass untouched
+5. Write the migration with `--dry-run` and run it against a copy
+6. Take a fresh vault backup, apply, spot-check
+7. Fix `Reading List.base`
+
+Scope:
+
+- Mint `libris_id` into all 3,137 Book Notes
+- Add `priority` and `series` as modelled fields, null where unset
+- Fix `DEFAULT_FRONTMATTER` and `_BOOK_TO_FRONTMATTER` to match the vault (ADR 0005)
+- Fix `Reading List.base`, which sorts on `author`, `genre`, `Genre` and `Status` — none of
+  which exist in any note
+- Introduce a `BookNote` type: `libris_id`, path, typed frontmatter, body
+- Rename `Book` to `BookCandidate`; collapse `ImportBook` into it with a `source` field
+- Move `cli.py` off raw `fm.get(...)` dict access
+- Restructure the note body: `## Notes` first on every note, description into a collapsed
+  callout, frontmatter grouped (ADR 0009, closes #57)
+
+The last three are the reason the first four were needed. There is no type for a book in the
+Library: `list_books` returns `list[Path]`, `read_frontmatter` returns `Dict[str, Any]`,
+`find_duplicates` returns `list[list[Path]]`, and `_build_vault_index` expresses the missing
+concept anonymously as `Tuple[Path, Dict]`. Every field read is `fm.get("name")` against an
+untyped dict, so `DEFAULT_FRONTMATTER` disagreeing with all 3,137 notes produced silent
+nulls rather than an error.
+
+Two live consequences, both caused by that:
+
+- `fm.get("author")` is read at five sites — `cli.py:635`, `importer.py:134` and
+  `markdown.py:259`, `:423`, `:512` — and is `None` at every one of them, because the notes
+  hold `authors`. In `_build_query_from_frontmatter` that means every autoenrich query is
+  title-only, with `inauthor:` never applied. Nineteen notes are titled "Poems".
+- `_API_SOURCED_FIELDS` names `thumbnail` and `published_date`, neither of which exists.
+  `_needs_enrichment` therefore tests two fields instead of four, and reports 152 notes as
+  unenriched when only 5 are — a 97% false-positive rate on every run.
+
+## 2. MCP tool surface
+
+`search_books`, `add_book`, `update_book` over stdio, driven from Claude Code locally. No
+Azure. This is where the design risk lives (ADR 0003).
+
+## 3. Sync
+
+`libris sync`, the Intent protocol, the Scheduled Task (ADR 0002).
+
+Open: what happens to an Intent that cannot apply, and how sync detects changed notes.
+
+## 4. Infrastructure
+
+Terraform: Container Apps, ACR, Cosmos serverless, managed identity, `azuread_application`
+(ADR 0006, ADR 0007).
+
+## 5. Authentication
+
+Entra, Streamable HTTP, OAuth with manually registered clients (ADR 0004).

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -49,10 +49,15 @@ Two live consequences, both caused by that:
   `_needs_enrichment` therefore tests two fields instead of four, and reports 152 notes as
   unenriched when only 5 are — a 97% false-positive rate on every run.
 
-## 2. MCP tool surface
+## 2. Service layer and its first adapters
 
-`search_books`, `add_book`, `update_book` over stdio, driven from Claude Code locally. No
-Azure. This is where the design risk lives (ADR 0003).
+Extract matching and note-writing into a shared service layer (#53), then put adapters over
+it. Two candidates, both needing no infrastructure, ordering not yet settled:
+
+- `libris serve` on loopback plus the Edge extension (#51, #52, #53) — already specified,
+  and the adapter with the stronger duplicate guarantee (ADR 0010)
+- `search_books` / `add_book` / `update_book` over stdio MCP, driven from Claude Code — where
+  the resolution design risk lives (ADR 0003, ADR 0007)
 
 ## 3. Sync
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
+    "python-ulid>=4.0.1",
     "pyyaml>=6.0.3",
     "questionary>=2.1.1",
     "titlecase>=2.4",

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -5,10 +5,9 @@ import socket
 import sys
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import List, Optional
 
 import httpx
 
@@ -82,16 +81,24 @@ def parse_retry_after(value: object, now: datetime | None = None) -> float | Non
 
 
 @dataclass
-class Book:
+class BookCandidate:
+    """Metadata about a book proposed by an external source.
+
+    A candidate has not been accepted into the Library. It may describe a book
+    already held, a different edition, or the wrong book entirely. Reading state
+    is deliberately absent: a rating is not metadata about the book.
+    """
+
     title: str
-    authors: List[str]
-    isbn: Optional[str]
-    page_count: Optional[int]
-    published_date: Optional[str]
-    google_books_id: str
-    thumbnail: Optional[str]
-    genres: List[str]
-    description: Optional[str]
+    authors: list[str]
+    isbn: str | None = None
+    page_count: int | None = None
+    published_date: str | None = None
+    google_books_id: str = ""
+    thumbnail: str | None = None
+    genres: list[str] = field(default_factory=list)
+    description: str | None = None
+    source: str = "google_books"
 
 
 class GoogleBooksClient:
@@ -162,7 +169,7 @@ class GoogleBooksClient:
         self.on_rate_limit(wait_time, attempt + 1, self.max_retries)
         time.sleep(wait_time)
 
-    def search(self, query: str) -> List[Book]:
+    def search(self, query: str) -> list[BookCandidate]:
         params = {"q": query, "maxResults": 10}
 
         api_key = get_api_key()
@@ -229,7 +236,7 @@ class GoogleBooksClient:
                 if ident.get("type") == "ISBN_10" and not isbn:
                     isbn = ident.get("identifier")
 
-            book = Book(
+            book = BookCandidate(
                 title=volume_info.get("title", "Unknown Title"),
                 authors=volume_info.get("authors", ["Unknown Author"]),
                 isbn=isbn,

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -585,7 +585,12 @@ def _enrich_interactive(file_path: Path, results: list | None = None) -> bool:
 
 
 # Fields that are only populated via Google Books enrichment.
-_API_SOURCED_FIELDS = ("google_books_id", "thumbnail", "published_date", "page_count")
+_API_SOURCED_FIELDS = (
+    "google_books_id",
+    "cover_thumbnail",
+    "date_published",
+    "page_count",
+)
 
 
 def _needs_enrichment(fm: dict) -> bool:

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -14,6 +14,7 @@ from .config import (
 )
 from .importer import SUPPORTED_FORMATS, normalize_for_match, run_import
 from .markdown import (
+    BookNote,
     RenameResult,
     create_book_note,
     ensure_frontmatter_fields,
@@ -636,15 +637,14 @@ def _best_match(candidates: list) -> object:
 
 def _build_query_from_frontmatter(fm: dict, file_path: Path) -> str:
     """Build a Google Books search query preferring frontmatter over filename."""
-    title = fm.get("title")
-    author = fm.get("author")
-    if title and isinstance(title, str):
-        parts = [f"intitle:{title}"]
-        if author:
-            first_author = author[0] if isinstance(author, list) else author
-            parts.append(f"inauthor:{first_author}")
-        return " ".join(parts)
-    return _build_search_query(file_path.stem)
+    note = BookNote(path=file_path, frontmatter=fm)
+    if note.title is None:
+        return _build_search_query(file_path.stem)
+
+    parts = [f"intitle:{note.title}"]
+    if note.first_author is not None:
+        parts.append(f"inauthor:{note.first_author}")
+    return " ".join(parts)
 
 
 @app.command()

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -32,6 +32,7 @@ from .merge import (
     merge_two_books,
     write_merged_book,
 )
+from .migrate import apply_migration, plan_migration
 
 app = typer.Typer()
 
@@ -1015,6 +1016,80 @@ def import_cmd(
 
     if not apply and (result.new_books or result.updated_books):
         typer.echo("\nRun with --apply to execute these changes.")
+
+
+@app.command()
+def migrate(
+    apply: bool = typer.Option(
+        False, "--apply", help="Write the changes (a dry run by default)"
+    ),
+    limit: int = typer.Option(
+        3, "--limit", "-n", help="How many diffs to print (0 for all)"
+    ),
+    out: str | None = typer.Option(
+        None, "--out", help="Write the full diff to this file for review"
+    ),
+):
+    """Migrate the Shelf to the canonical Book Note shape.
+
+    A dry run by default: summarises what would change, prints a sample of
+    diffs, and writes nothing. Review the diff before using --apply.
+    """
+    vault_path = get_vault_path()
+    if not vault_path.exists():
+        typer.echo(f"Shelf does not exist: {vault_path}")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Planning migration for {vault_path}...")
+    plans = plan_migration(vault_path)
+    changing = [plan for plan in plans if plan.changed]
+
+    change_counts: dict[str, int] = {}
+    for plan in plans:
+        for change in plan.changes:
+            label = change.split(";")[0]
+            change_counts[label] = change_counts.get(label, 0) + 1
+
+    typer.echo(f"\n{len(plans)} notes planned, {len(changing)} would change.\n")
+    for label, count in sorted(change_counts.items(), key=lambda kv: -kv[1]):
+        typer.echo(f"  {count:5d}  {label}")
+
+    flagged = [plan for plan in plans if plan.warnings]
+    if flagged:
+        typer.echo(f"\n{len(flagged)} notes need a look:")
+        for plan in flagged[:20]:
+            typer.echo(f"  {plan.path.name}: {'; '.join(plan.warnings)}")
+
+    if out:
+        out_path = Path(out).expanduser()
+        out_path.write_text("".join(plan.diff() for plan in changing), encoding="utf-8")
+        typer.echo(f"\nFull diff written to {out_path}")
+
+    shown = changing if limit == 0 else changing[:limit]
+    for plan in shown:
+        typer.echo("")
+        typer.echo(plan.diff())
+
+    if not apply:
+        typer.echo(
+            f"\nDry run. Nothing written. Re-run with --apply to migrate "
+            f"{len(changing)} notes."
+        )
+        return
+
+    if not flagged and not changing:
+        typer.echo("Nothing to do.")
+        return
+
+    confirm = questionary.confirm(
+        f"Rewrite {len(changing)} notes in {vault_path}?", default=False
+    ).ask()
+    if not confirm:
+        typer.echo("Cancelled. Nothing written.")
+        return
+
+    written = apply_migration(plans)
+    typer.echo(f"Migrated {written} notes.")
 
 
 if __name__ == "__main__":

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -618,7 +618,7 @@ _COMPLETENESS_FIELDS = (
 
 
 def _metadata_score(book) -> int:
-    """Count how many metadata fields are non-empty on a Book."""
+    """Count how many metadata fields are non-empty on a BookCandidate."""
     score = 0
     for field in _COMPLETENESS_FIELDS:
         val = getattr(book, field, None)

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -10,9 +10,9 @@ import yaml
 
 from .api import Book
 from .markdown import (
+    BookNote,
     create_book_note,
     list_books,
-    read_frontmatter,
     update_book_status,
 )
 
@@ -119,34 +119,24 @@ def parse_import_file(
     return parser(path)
 
 
-def _build_vault_index(vault_path: Path) -> Dict[Tuple[str, str], Tuple[Path, Dict]]:
-    """Build an index of existing vault books keyed by normalized (title, first_author)."""
-    index: Dict[Tuple[str, str], Tuple[Path, Dict]] = {}
+def _build_vault_index(vault_path: Path) -> dict[tuple[str, str], BookNote]:
+    """Build an index of Book Notes keyed by normalized (title, first_author).
+
+    Args:
+        vault_path: The Shelf to index.
+
+    Returns:
+        A mapping from normalized title and first author to the Book Note. Notes
+        without a title or an author cannot be matched and are left out.
+    """
+    index: dict[tuple[str, str], BookNote] = {}
     for book_path in list_books(vault_path):
-        fm = read_frontmatter(book_path)
-        if fm is None:
+        note = BookNote.read(book_path)
+        if note is None or note.title is None or note.first_author is None:
             continue
 
-        title = fm.get("title")
-        if not isinstance(title, str) or not title.strip():
-            continue
-
-        author = fm.get("author")
-        if isinstance(author, list):
-            first_author = next(
-                (a.strip() for a in author if isinstance(a, str) and a.strip()),
-                None,
-            )
-        elif isinstance(author, str):
-            first_author = author.strip() or None
-        else:
-            first_author = None
-
-        if first_author is None:
-            continue
-
-        key = (normalize_for_match(title), normalize_for_match(first_author))
-        index[key] = (book_path, fm)
+        key = (normalize_for_match(note.title), normalize_for_match(note.first_author))
+        index[key] = note
 
     return index
 
@@ -164,7 +154,7 @@ class ImportResult:
 
 def _check_duplicate(
     book: ImportBook,
-    vault_index: Dict[Tuple[str, str], Tuple[Path, Dict]],
+    vault_index: dict[tuple[str, str], BookNote],
 ) -> Optional[Tuple[Path, Dict, List[str]]]:
     """Check if an import book matches an existing vault entry.
 
@@ -177,11 +167,11 @@ def _check_duplicate(
         return None
 
     key = (normalize_for_match(book.title), normalize_for_match(first_author))
-    match = vault_index.get(key)
-    if match is None:
+    note = vault_index.get(key)
+    if note is None:
         return None
 
-    path, fm = match
+    fm = note.frontmatter
     updates: List[str] = []
 
     existing_status = fm.get("status", "")
@@ -192,7 +182,7 @@ def _check_duplicate(
     if not existing_format and book.format:
         updates.append("format")
 
-    return (path, fm, updates)
+    return (note.path, fm, updates)
 
 
 def _apply_updates(path: Path, book: ImportBook, updates: List[str]):

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 import yaml
 
-from .api import Book
+from .api import BookCandidate
 from .markdown import (
     BookNote,
     create_book_note,
@@ -25,22 +25,27 @@ def normalize_for_match(text: str) -> str:
 
 @dataclass
 class ImportBook:
-    """Common representation for a book from any import source."""
+    """A book from an import source, paired with how that source says it was read.
 
-    title: str
-    authors: List[str]
+    The candidate carries what the source knows about the book; status and format
+    are reading state and travel separately, because they are not metadata about
+    the book itself.
+    """
+
+    candidate: BookCandidate
     status: str  # "Read", "To Read", "Reading"
-    format: Optional[str] = None  # "Audiobook", "Hardcover", "Paperback", "eBook"
-    isbn: Optional[str] = None
-    page_count: Optional[int] = None
-    published_date: Optional[str] = None
-    rating: Optional[float] = None
-    date_added: Optional[str] = None
-    date_finished: Optional[str] = None
-    genres: List[str] = field(default_factory=list)
-    description: Optional[str] = None
-    source_id: Optional[str] = None
+    format: str | None = None  # "Audiobook", "Hardcover", "Paperback", "eBook"
     source_format: str = ""
+
+    @property
+    def title(self) -> str:
+        """The candidate's title."""
+        return self.candidate.title
+
+    @property
+    def authors(self) -> list[str]:
+        """The candidate's authors."""
+        return self.candidate.authors
 
 
 def parse_audible_json(path: Path) -> List[ImportBook]:
@@ -69,8 +74,7 @@ def parse_audible_json(path: Path) -> List[ImportBook]:
 
         books.append(
             ImportBook(
-                title=title,
-                authors=authors,
+                candidate=BookCandidate(title=title, authors=authors, source="audible"),
                 status=status,
                 format="Audiobook",
                 source_format="audible-json",
@@ -224,21 +228,6 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
                 path.write_text(new_content, encoding="utf-8")
 
 
-def _to_api_book(import_book: ImportBook) -> Book:
-    """Convert an ImportBook to an api.Book for note creation."""
-    return Book(
-        title=import_book.title,
-        authors=import_book.authors,
-        isbn=import_book.isbn,
-        page_count=import_book.page_count,
-        published_date=import_book.published_date,
-        google_books_id="",
-        thumbnail=None,
-        genres=import_book.genres,
-        description=import_book.description,
-    )
-
-
 def run_import(
     path: Path,
     vault_path: Path,
@@ -263,17 +252,13 @@ def run_import(
         if dup is None:
             result.new_books.append(book)
             if apply:
-                api_book = _to_api_book(book)
-                created_path = create_book_note(
-                    api_book, vault_path, status=book.status
+                overrides = {"format": book.format} if book.format else None
+                create_book_note(
+                    book.candidate,
+                    vault_path,
+                    status=book.status,
+                    overrides=overrides,
                 )
-                # Update format in the newly created note if specified
-                if book.format:
-                    content = created_path.read_text(encoding="utf-8")
-                    new_content = content.replace(
-                        "format: null", f"format: {book.format}"
-                    )
-                    created_path.write_text(new_content, encoding="utf-8")
         else:
             dup_path, _, updates = dup
             if updates:

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -47,6 +47,81 @@ FIELD_MIGRATIONS = {
 }
 
 
+@dataclass
+class BookNote:
+    """A book on the Shelf: the file it lives in, its frontmatter, and its body.
+
+    Frontmatter arrives from YAML and may hold any shape, so the accessors
+    normalise rather than trusting what is on disk. Callers should read fields
+    through them instead of reaching into the dict, which is how this code came
+    to read a key that no note has ever carried.
+    """
+
+    path: Path
+    frontmatter: dict[str, Any]
+    body: str = ""
+
+    @classmethod
+    def read(cls, path: Path) -> "BookNote | None":
+        """Read a Book Note from disk.
+
+        Args:
+            path: Path to the Markdown file.
+
+        Returns:
+            The Book Note, or None if the file has no parseable frontmatter.
+        """
+        frontmatter = read_frontmatter(path)
+        if frontmatter is None:
+            return None
+        return cls(path=path, frontmatter=frontmatter)
+
+    @property
+    def libris_id(self) -> str | None:
+        """The note's stable identity, or None until the vault is migrated."""
+        value = self.frontmatter.get("libris_id")
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    @property
+    def title(self) -> str | None:
+        """The book's title, or None when absent or blank."""
+        value = self.frontmatter.get("title")
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    @property
+    def authors(self) -> list[str]:
+        """The book's authors as a list of non-empty names.
+
+        Accepts the list every note in the vault carries and the bare string that
+        older notes used. Anything else counts as naming no author at all.
+        """
+        value = self.frontmatter.get("authors")
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list):
+            return []
+        return [
+            name.strip() for name in value if isinstance(name, str) and name.strip()
+        ]
+
+    @property
+    def first_author(self) -> str | None:
+        """The first named author, or None when the note names none."""
+        authors = self.authors
+        return authors[0] if authors else None
+
+    @property
+    def canonical_filename(self) -> str | None:
+        """The 'Title - Author.md' filename this note should have.
+
+        Returns:
+            The filename, or None when the note lacks a title or an author.
+        """
+        if self.title is None or self.first_author is None:
+            return None
+        return sanitize_filename(f"{self.title} - {self.first_author}.md")
+
+
 def sanitize_filename(name: str) -> str:
     """Removes invalid characters for a filename and collapses whitespace."""
     name = re.sub(r'[\\/*?:"<>|]', "", name)
@@ -252,22 +327,14 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
     Returns a list of groups where each group contains two or more paths
     that share at least one matching identifier.
     """
-    books = list_books(vault_path)
-    file_data: list[tuple[Path, Dict[str, Any]]] = []
-    for p in books:
-        fm = read_frontmatter(p)
-        if fm is not None:
-            file_data.append((p, fm))
+    notes: list[BookNote] = []
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is not None:
+            notes.append(note)
 
-    def _author_key(fm: Dict[str, Any]) -> tuple[str, ...]:
-        author = fm.get("author")
-        if isinstance(author, list):
-            return tuple(
-                sorted(a.strip().lower() for a in author if isinstance(a, str))
-            )
-        elif isinstance(author, str):
-            return (author.strip().lower(),)
-        return ()
+    def _author_key(note: BookNote) -> tuple[str, ...]:
+        return tuple(sorted(name.lower() for name in note.authors))
 
     # Build groups keyed by each identifier type.
     # key -> set of indices into file_data
@@ -275,23 +342,22 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
     # Title groups need pairwise author comparison (missing author = wildcard)
     title_groups: Dict[str, list[int]] = {}
 
-    for idx, (path, fm) in enumerate(file_data):
-        title = fm.get("title")
-        if title and isinstance(title, str):
-            title_groups.setdefault(title.strip().lower(), []).append(idx)
+    for idx, note in enumerate(notes):
+        if note.title is not None:
+            title_groups.setdefault(note.title.lower(), []).append(idx)
 
-        isbn = fm.get("isbn")
+        isbn = note.frontmatter.get("isbn")
         if isbn:
             key = f"isbn:{str(isbn).strip()}"
             groups_by_key.setdefault(key, set()).add(idx)
 
-        gid = fm.get("google_books_id")
+        gid = note.frontmatter.get("google_books_id")
         if gid and gid not in EXCLUDED_GOOGLE_BOOKS_IDS:
             key = f"gid:{str(gid).strip()}"
             groups_by_key.setdefault(key, set()).add(idx)
 
     # Union-find to merge overlapping groups
-    parent = list(range(len(file_data)))
+    parent = list(range(len(notes)))
 
     def find(x: int) -> int:
         while parent[x] != x:
@@ -313,7 +379,7 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
         has_missing_author = False
 
         for idx in members:
-            author_key = _author_key(file_data[idx][1])
+            author_key = _author_key(notes[idx])
             if author_key:
                 author_buckets.setdefault(author_key, []).append(idx)
             else:
@@ -341,9 +407,9 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
 
     # Collect final groups with 2+ members
     clusters: Dict[int, list[Path]] = {}
-    for idx, (path, _) in enumerate(file_data):
+    for idx, note in enumerate(notes):
         root = find(idx)
-        clusters.setdefault(root, []).append(path)
+        clusters.setdefault(root, []).append(note.path)
 
     return [sorted(group) for group in clusters.values() if len(group) >= 2]
 
@@ -420,33 +486,8 @@ def update_frontmatter_from_book(file_path: Path, book: Book) -> bool:
 
 def compute_canonical_filename(file_path: Path) -> Optional[str]:
     """Compute the canonical 'Title - Author.md' filename from frontmatter."""
-    fm = read_frontmatter(file_path)
-    if not fm:
-        return None
-    title = fm.get("title")
-    author = fm.get("author")
-    if not title or not isinstance(title, str):
-        return None
-
-    if isinstance(author, list):
-        author_candidates = author
-    elif isinstance(author, str):
-        author_candidates = [author]
-    else:
-        return None
-
-    first_author = next(
-        (
-            candidate.strip()
-            for candidate in author_candidates
-            if isinstance(candidate, str) and candidate.strip()
-        ),
-        None,
-    )
-    if first_author is None:
-        return None
-
-    return sanitize_filename(f"{title} - {first_author}.md")
+    note = BookNote.read(file_path)
+    return note.canonical_filename if note is not None else None
 
 
 def update_wikilinks_in_vault(
@@ -505,30 +546,21 @@ def rename_book_file(
     If frontmatter is provided, it is used directly instead of re-reading
     the file. This avoids redundant I/O when called after ensure_frontmatter_fields.
     """
-    fm = frontmatter if frontmatter is not None else read_frontmatter(file_path)
-    if not fm:
+    note = (
+        BookNote(path=file_path, frontmatter=frontmatter)
+        if frontmatter is not None
+        else BookNote.read(file_path)
+    )
+    if note is None or not note.frontmatter:
         return RenameResult(status="invalid_frontmatter")
 
-    title = fm.get("title")
-    if not isinstance(title, str) or not title.strip():
+    if note.title is None:
         return RenameResult(status="missing_title")
 
-    author = fm.get("author")
-    if isinstance(author, list):
-        author_candidates = author
-    elif isinstance(author, str):
-        author_candidates = [author]
-    else:
+    if note.first_author is None:
         return RenameResult(status="missing_author")
 
-    first_author = next(
-        (c.strip() for c in author_candidates if isinstance(c, str) and c.strip()),
-        None,
-    )
-    if first_author is None:
-        return RenameResult(status="missing_author")
-
-    canonical_name = sanitize_filename(f"{title.strip()} - {first_author}.md")
+    canonical_name = note.canonical_filename
     if canonical_name == file_path.name:
         return RenameResult(status="already_canonical")
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Literal, Optional
 import yaml
 from titlecase import titlecase
 
-from .api import Book
+from .api import BookCandidate
 
 DEFAULT_FRONTMATTER = {
     "title": None,
@@ -149,7 +149,7 @@ def standardize_title(raw: Optional[str]) -> Optional[str]:
 
 
 def create_book_note(
-    book: Book,
+    book: BookCandidate,
     vault_path: Path,
     status: str = "To Read",
     overrides: Dict[str, Any] | None = None,
@@ -157,7 +157,7 @@ def create_book_note(
     """Creates a Markdown note for a book in the specified vault path.
 
     Args:
-        book: The Book dataclass with data from Google Books API.
+        book: The candidate whose metadata seeds the note.
         vault_path: Directory where the note will be written.
         status: Default reading status (overridden if 'status' is in overrides).
         overrides: Optional dict of frontmatter fields to set/override.
@@ -302,7 +302,7 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
     return updated, data
 
 
-# Maps Book dataclass fields to frontmatter field names.
+# Maps BookCandidate fields to frontmatter field names.
 _BOOK_TO_FRONTMATTER = {
     "title": "title",
     "authors": "authors",
@@ -429,8 +429,8 @@ def read_frontmatter(file_path: Path) -> Optional[Dict[str, Any]]:
         return None
 
 
-def update_frontmatter_from_book(file_path: Path, book: Book) -> bool:
-    """Fill null frontmatter fields with data from a Book. Returns True if changed."""
+def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
+    """Fill null frontmatter fields from a candidate. Returns True if changed."""
     content = file_path.read_text(encoding="utf-8")
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
     if not match:

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -14,12 +14,12 @@ from .api import Book
 
 DEFAULT_FRONTMATTER = {
     "title": None,
-    "author": None,
+    "authors": None,
     "isbn": None,
     "page_count": None,
-    "published_date": None,
+    "date_published": None,
     "google_books_id": None,
-    "thumbnail": None,
+    "cover_thumbnail": None,
     "genres": None,
     "tags": "Book",
     "format": None,
@@ -39,7 +39,11 @@ FIELD_MIGRATIONS = {
     "Date Read": "date_finished",
     "Date Added": "date_added",
     "Status": "status",
-    "Author": "author",
+    "Author": "authors",
+    # Names this code wrote before ADR 0005 settled the canonical vocabulary.
+    "author": "authors",
+    "published_date": "date_published",
+    "thumbnail": "cover_thumbnail",
 }
 
 
@@ -90,12 +94,12 @@ def create_book_note(
     frontmatter = {
         **DEFAULT_FRONTMATTER,
         "title": book.title,
-        "author": book.authors,
+        "authors": book.authors,
         "isbn": book.isbn,
         "page_count": book.page_count,
-        "published_date": book.published_date,
+        "date_published": book.published_date,
         "google_books_id": book.google_books_id,
-        "thumbnail": book.thumbnail,
+        "cover_thumbnail": book.thumbnail,
         "genres": book.genres,
         "status": status,
         "date_added": date.today().isoformat(),
@@ -189,9 +193,9 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         data["status"] = "Read"
         updated = True
 
-    # Ensure author is always a list
-    if isinstance(data.get("author"), str):
-        data["author"] = [data["author"]]
+    # Ensure authors is always a list
+    if isinstance(data.get("authors"), str):
+        data["authors"] = [data["authors"]]
         updated = True
 
     # Standardize title casing and strip annotations
@@ -226,12 +230,12 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
 # Maps Book dataclass fields to frontmatter field names.
 _BOOK_TO_FRONTMATTER = {
     "title": "title",
-    "authors": "author",
+    "authors": "authors",
     "isbn": "isbn",
     "page_count": "page_count",
-    "published_date": "published_date",
+    "published_date": "date_published",
     "google_books_id": "google_books_id",
-    "thumbnail": "thumbnail",
+    "thumbnail": "cover_thumbnail",
     "genres": "genres",
     "description": None,  # handled separately (body, not frontmatter)
 }

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -11,24 +11,21 @@ import yaml
 from titlecase import titlecase
 
 from .api import BookCandidate
+from .note_format import (
+    MODELLED_FIELDS,
+    has_description_callout,
+    mint_libris_id,
+    render_body,
+    render_description_callout,
+)
 
+# Values a Book Note starts with when nothing else supplies them.
+_FRONTMATTER_DEFAULTS = {"tags": "Book", "status": "To Read"}
+
+# Derived from the canonical field order so a note written today and a note
+# migrated from years ago cannot disagree about which fields exist.
 DEFAULT_FRONTMATTER = {
-    "title": None,
-    "authors": None,
-    "isbn": None,
-    "page_count": None,
-    "date_published": None,
-    "google_books_id": None,
-    "cover_thumbnail": None,
-    "genres": None,
-    "tags": "Book",
-    "format": None,
-    "status": "To Read",
-    "rating": None,
-    "referred_by": None,
-    "date_added": None,
-    "date_started": None,
-    "date_finished": None,
+    name: _FRONTMATTER_DEFAULTS.get(name) for name in MODELLED_FIELDS
 }
 
 # Maps legacy/extraneous field names to their canonical counterparts.
@@ -166,8 +163,10 @@ def create_book_note(
     filename = sanitize_filename(f"{book.title} - {', '.join(book.authors[:1])}.md")
     file_path = vault_path / filename
 
+    added = date.today()
     frontmatter = {
         **DEFAULT_FRONTMATTER,
+        "libris_id": mint_libris_id(added),
         "title": book.title,
         "authors": book.authors,
         "isbn": book.isbn,
@@ -177,7 +176,7 @@ def create_book_note(
         "cover_thumbnail": book.thumbnail,
         "genres": book.genres,
         "status": status,
-        "date_added": date.today().isoformat(),
+        "date_added": added.isoformat(),
     }
 
     if overrides:
@@ -191,11 +190,8 @@ def create_book_note(
 
     yaml_content = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True)
 
-    content = f"---\n{yaml_content}---\n\n# {book.title}\n\n## Notes\n\n"
-    if book.description:
-        content += f"### Description\n{book.description}\n"
-
-    file_path.write_text(content, encoding="utf-8")
+    body = render_body(book.title, "", book.description)
+    file_path.write_text(f"---\n{yaml_content}---\n\n{body}", encoding="utf-8")
     return file_path
 
 
@@ -262,6 +258,12 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         if field not in data:
             data[field] = default
             updated = True
+
+    # A note that reached us without an identity gets one here, so a book typed
+    # straight into Obsidian is not left unaddressable (ADR 0001, ADR 0011).
+    if not data.get("libris_id"):
+        data["libris_id"] = mint_libris_id(data.get("date_added"))
+        updated = True
 
     # If date_finished is set, status should be "Read"
     if data.get("date_finished") is not None and data.get("status") != "Read":
@@ -469,9 +471,12 @@ def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
         updated = True
 
     # Add description to body if missing
-    if book.description and "### Description" not in rest_of_content:
+    if book.description and not has_description_callout(rest_of_content):
         rest_of_content = (
-            rest_of_content.rstrip() + f"\n\n### Description\n{book.description}\n"
+            rest_of_content.rstrip()
+            + "\n\n"
+            + render_description_callout(book.description)
+            + "\n"
         )
         updated = True
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -44,6 +44,21 @@ FIELD_MIGRATIONS = {
 }
 
 
+def _normalize_author(name: str) -> str:
+    """Reduce an author name as written to the name itself.
+
+    Args:
+        name: The value as it appears in frontmatter, possibly a wikilink.
+
+    Returns:
+        The plain name, with runs of whitespace collapsed.
+    """
+    unlinked = re.sub(r"^\[\[(.+?)\]\]$", r"\1", name.strip())
+    if "|" in unlinked:
+        unlinked = unlinked.split("|", 1)[1]
+    return re.sub(r"\s+", " ", unlinked).strip()
+
+
 @dataclass
 class BookNote:
     """A book on the Shelf: the file it lives in, its frontmatter, and its body.
@@ -87,19 +102,23 @@ class BookNote:
 
     @property
     def authors(self) -> list[str]:
-        """The book's authors as a list of non-empty names.
+        """The book's authors as a list of plain, non-empty names.
 
         Accepts the list every note in the vault carries and the bare string that
         older notes used. Anything else counts as naming no author at all.
+
+        Names are normalised for use rather than taken literally: some notes hold
+        an author as a wikilink to their own note, and some carry stray inner
+        whitespace. Both would otherwise leak into filenames and defeat matching,
+        while the note itself keeps whatever it holds.
         """
         value = self.frontmatter.get("authors")
         if isinstance(value, str):
             value = [value]
         if not isinstance(value, list):
             return []
-        return [
-            name.strip() for name in value if isinstance(name, str) and name.strip()
-        ]
+        names = (_normalize_author(name) for name in value if isinstance(name, str))
+        return [name for name in names if name]
 
     @property
     def first_author(self) -> str | None:

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -177,7 +177,7 @@ def render_description_callout(description: str) -> str:
     return "\n".join(lines)
 
 
-def split_body(body: str) -> tuple[str, str | None]:
+def split_body(body: str, titles: tuple[str, ...] = ()) -> tuple[str, str | None]:
     """Separate the reader's own prose from the description supplied by an API.
 
     The description is the content under its own heading, ending at the next
@@ -191,6 +191,8 @@ def split_body(body: str) -> tuple[str, str | None]:
 
     Args:
         body: Everything after the closing frontmatter fence.
+        titles: Headings that count as the note's own title heading and may be
+            consumed. Any other leading H1 belongs to the reader and is kept.
 
     Returns:
         The reader's prose, and the description if the note carries one.
@@ -213,9 +215,35 @@ def split_body(body: str) -> tuple[str, str | None]:
         description = after[:end].strip()
         remainder = body[: heading.start()] + after[end:]
 
-    prose = _H1.sub("", remainder, count=1)
+    prose = _strip_title_heading(remainder, titles)
     prose = _NOTES_HEADING.sub("", prose)
     return prose.strip(), (description or None)
+
+
+def _strip_title_heading(text: str, titles: tuple[str, ...]) -> str:
+    """Remove a leading H1 only when it is the note's title heading.
+
+    A note may open with a heading the reader wrote - a contents list, or
+    "Notes from GetAbstract" - and removing it would destroy their writing. Only
+    a first-line H1 naming the title, or one of the headings the linter leaked
+    into the title, is the migration's to consume.
+
+    Args:
+        text: The note content with any description already removed.
+        titles: Headings that count as the note's own title heading.
+
+    Returns:
+        The text, with the title heading removed if it was there.
+    """
+    leading = text.lstrip("\n")
+    match = _H1.match(leading)
+    if match is None:
+        return text
+
+    heading = match.group(1).strip()
+    if heading in LEAKED_HEADINGS or heading in titles:
+        return leading[match.end() :]
+    return text
 
 
 def _take_callout(text: str) -> tuple[str, str]:
@@ -410,7 +438,8 @@ def plan_note_migration(path: Path) -> NoteMigration:
     if [k for k, _ in ordered] != [k for k, _ in blocks]:
         changes.append("regrouped frontmatter")
 
-    prose, description = split_body(body)
+    candidate_titles = tuple(value for value in (note.title, repaired_title) if value)
+    prose, description = split_body(body, candidate_titles)
     if title is None:
         warnings.append("no title; body left alone")
         new_body = body

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -14,42 +14,20 @@ See ADR 0001, ADR 0005, ADR 0009, ADR 0011 and ADR 0012.
 import difflib
 import re
 from dataclasses import dataclass, field
-from datetime import date, datetime, time, timezone
 from pathlib import Path
 
-from ulid import ULID
-
 from .markdown import BookNote, list_books
-
-# Frontmatter order, grouped so the Properties panel reads sensibly (ADR 0009).
-IDENTITY_FIELDS = ("libris_id", "title", "authors")
-BIBLIOGRAPHIC_FIELDS = (
-    "isbn",
-    "page_count",
-    "date_published",
-    "google_books_id",
-    "cover_thumbnail",
-    "genres",
-    "series",
+from .note_format import (
+    LEAKED_HEADINGS,
+    MODELLED_FIELDS,
+    has_description_callout,
+    has_title_heading,
+    mint_libris_id,
+    render_body,
+    split_body,
 )
-READING_FIELDS = ("status", "priority", "rating", "format", "tags", "referred_by")
-DATE_FIELDS = ("date_added", "date_started", "date_finished")
-
-MODELLED_FIELDS = IDENTITY_FIELDS + BIBLIOGRAPHIC_FIELDS + READING_FIELDS + DATE_FIELDS
-
-# Headings the linter mistook for a title, and the values that leaked from them.
-LEAKED_HEADINGS = ("Notes", "Description")
 
 _KEY_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_ \-]*):")
-_DESCRIPTION_HEADING = re.compile(r"^#{1,6}[ \t]*Description[ \t]*$", re.MULTILINE)
-_CALLOUT_HEADING = re.compile(
-    r"^>[ \t]*\[!abstract\]-?[ \t]*Description[ \t]*$", re.MULTILINE
-)
-_NOTES_HEADING = re.compile(r"^#{1,6}[ \t]*Notes[ \t]*$", re.MULTILINE)
-_H1 = re.compile(r"^#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
-# A section ends at the next heading or a thematic break. merge.py joins bodies
-# with a "---" divider, and the reader's writing must not be swept into a blurb.
-_SECTION_BREAK = re.compile(r"^(?:#{1,6}[ \t]+\S|-{3,}[ \t]*$)", re.MULTILINE)
 
 
 @dataclass
@@ -77,38 +55,6 @@ class NoteMigration:
                 tofile=f"b/{self.path.name}",
             )
         )
-
-
-def mint_libris_id(date_added: object) -> str:
-    """Mint a Libris ID whose timestamp comes from when the book was added.
-
-    ULIDs sort lexicographically by their timestamp, so deriving it from
-    `date_added` makes the Library sort in the order it was acquired rather than
-    the order the migration happened to visit it (ADR 0011).
-
-    Args:
-        date_added: The note's `date_added` value, as a date, a datetime, an
-            ISO-8601 string, or anything unparseable.
-
-    Returns:
-        A 26-character ULID string.
-    """
-    moment: datetime | None = None
-    if isinstance(date_added, datetime):
-        moment = date_added
-    elif isinstance(date_added, date):
-        moment = datetime.combine(date_added, time.min)
-    elif isinstance(date_added, str) and date_added.strip():
-        try:
-            moment = datetime.fromisoformat(date_added.strip())
-        except ValueError:
-            moment = None
-
-    if moment is None:
-        return str(ULID())
-    if moment.tzinfo is None:
-        moment = moment.replace(tzinfo=timezone.utc)
-    return str(ULID.from_datetime(moment))
 
 
 def split_frontmatter_blocks(frontmatter_text: str) -> list[tuple[str, str]]:
@@ -160,135 +106,6 @@ def reorder_frontmatter(blocks: list[tuple[str, str]]) -> list[tuple[str, str]]:
     ordered = [(key, by_key.get(key, f"{key}:")) for key in MODELLED_FIELDS]
     ordered.extend((key, raw) for key, raw in blocks if key not in MODELLED_FIELDS)
     return ordered
-
-
-def render_description_callout(description: str) -> str:
-    """Render a description as a collapsed Obsidian callout (ADR 0009).
-
-    Args:
-        description: The description text, without any callout markup.
-
-    Returns:
-        The callout block, with every line prefixed.
-    """
-    lines = ["> [!abstract]- Description"]
-    for line in description.strip().splitlines():
-        lines.append(f"> {line}" if line.strip() else ">")
-    return "\n".join(lines)
-
-
-def split_body(body: str, titles: tuple[str, ...] = ()) -> tuple[str, str | None]:
-    """Separate the reader's own prose from the description supplied by an API.
-
-    The description is the content under its own heading, ending at the next
-    heading rather than at the end of the note — some notes carry the description
-    above `## Notes` rather than below it, and running to the end would sweep the
-    reader's own writing into the blurb.
-
-    Understands the shapes this vault holds: with and without an H1, description
-    under a heading or already inside a callout, in either order. Headings the
-    reader added stay with their content in the prose.
-
-    Args:
-        body: Everything after the closing frontmatter fence.
-        titles: Headings that count as the note's own title heading and may be
-            consumed. Any other leading H1 belongs to the reader and is kept.
-
-    Returns:
-        The reader's prose, and the description if the note carries one.
-    """
-    description: str | None = None
-    remainder = body
-
-    callout = _CALLOUT_HEADING.search(body)
-    heading = _DESCRIPTION_HEADING.search(body)
-
-    if callout is not None:
-        after = body[callout.end() :]
-        quoted, rest = _take_callout(after)
-        description = quoted
-        remainder = body[: callout.start()] + rest
-    elif heading is not None:
-        after = body[heading.end() :]
-        section_break = _SECTION_BREAK.search(after)
-        end = section_break.start() if section_break else len(after)
-        description = after[:end].strip()
-        remainder = body[: heading.start()] + after[end:]
-
-    prose = _strip_title_heading(remainder, titles)
-    prose = _NOTES_HEADING.sub("", prose)
-    return prose.strip(), (description or None)
-
-
-def _strip_title_heading(text: str, titles: tuple[str, ...]) -> str:
-    """Remove a leading H1 only when it is the note's title heading.
-
-    A note may open with a heading the reader wrote - a contents list, or
-    "Notes from GetAbstract" - and removing it would destroy their writing. Only
-    a first-line H1 naming the title, or one of the headings the linter leaked
-    into the title, is the migration's to consume.
-
-    Args:
-        text: The note content with any description already removed.
-        titles: Headings that count as the note's own title heading.
-
-    Returns:
-        The text, with the title heading removed if it was there.
-    """
-    leading = text.lstrip("\n")
-    match = _H1.match(leading)
-    if match is None:
-        return text
-
-    heading = match.group(1).strip()
-    if heading in LEAKED_HEADINGS or heading in titles:
-        return leading[match.end() :]
-    return text
-
-
-def _take_callout(text: str) -> tuple[str, str]:
-    """Take the quoted lines of a callout, returning its content and what follows.
-
-    Args:
-        text: The note content immediately after a callout's heading line.
-
-    Returns:
-        The callout's text with its quote markers stripped, and the remainder of
-        the note.
-    """
-    quoted: list[str] = []
-    lines = text.splitlines(keepends=True)
-    consumed = 0
-    for line in lines:
-        stripped = line.rstrip("\n")
-        if stripped.startswith(">"):
-            quoted.append(stripped[2:] if stripped.startswith("> ") else stripped[1:])
-            consumed += 1
-        elif not stripped.strip() and not quoted:
-            consumed += 1
-        else:
-            break
-    return "\n".join(quoted).strip(), "".join(lines[consumed:])
-
-
-def render_body(title: str, prose: str, description: str | None) -> str:
-    """Render a Book Note body: title, then the reader's notes, then the blurb.
-
-    Args:
-        title: The book's title, which becomes the H1 the linter reads for an
-            alias (ADR 0012).
-        prose: Whatever the reader wrote.
-        description: The description from an external source, if any.
-
-    Returns:
-        The body, ending in a single newline.
-    """
-    sections = [f"# {title}", "## Notes"]
-    if prose:
-        sections.append(prose)
-    if description:
-        sections.append(render_description_callout(description))
-    return "\n\n".join(sections) + "\n"
 
 
 def _render_scalar(key: str, value: str) -> str:
@@ -445,9 +262,9 @@ def plan_note_migration(path: Path) -> NoteMigration:
         new_body = body
     else:
         new_body = render_body(title, prose, description)
-        if _H1.search(body) is None:
+        if not has_title_heading(body):
             changes.append("added H1")
-        if description and _CALLOUT_HEADING.search(body) is None:
+        if description and not has_description_callout(body):
             changes.append("description moved into a callout")
 
     if description and re.search(r"^#{1,6}\s", description, re.MULTILINE):

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -1,0 +1,463 @@
+"""One-time migration of the Shelf to the canonical Book Note shape.
+
+Mints a Libris ID into every note, adds the fields promoted to first class,
+regroups frontmatter, restructures the body, and repairs four flavours of damage
+left by Obsidian Linter reading headings it should not have.
+
+Frontmatter is manipulated as text blocks rather than round-tripped through YAML,
+so a value that did not change renders exactly as it did before. The diff a
+reader reviews then shows only what the migration actually decided to do.
+
+See ADR 0001, ADR 0005, ADR 0009, ADR 0011 and ADR 0012.
+"""
+
+import difflib
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+
+from ulid import ULID
+
+from .markdown import BookNote, list_books
+
+# Frontmatter order, grouped so the Properties panel reads sensibly (ADR 0009).
+IDENTITY_FIELDS = ("libris_id", "title", "authors")
+BIBLIOGRAPHIC_FIELDS = (
+    "isbn",
+    "page_count",
+    "date_published",
+    "google_books_id",
+    "cover_thumbnail",
+    "genres",
+    "series",
+)
+READING_FIELDS = ("status", "priority", "rating", "format", "tags", "referred_by")
+DATE_FIELDS = ("date_added", "date_started", "date_finished")
+
+MODELLED_FIELDS = IDENTITY_FIELDS + BIBLIOGRAPHIC_FIELDS + READING_FIELDS + DATE_FIELDS
+
+# Headings the linter mistook for a title, and the values that leaked from them.
+LEAKED_HEADINGS = ("Notes", "Description")
+
+_KEY_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_ \-]*):")
+_DESCRIPTION_HEADING = re.compile(r"^#{1,6}[ \t]*Description[ \t]*$", re.MULTILINE)
+_CALLOUT_HEADING = re.compile(
+    r"^>[ \t]*\[!abstract\]-?[ \t]*Description[ \t]*$", re.MULTILINE
+)
+_NOTES_HEADING = re.compile(r"^#{1,6}[ \t]*Notes[ \t]*$", re.MULTILINE)
+_H1 = re.compile(r"^#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
+# A section ends at the next heading or a thematic break. merge.py joins bodies
+# with a "---" divider, and the reader's writing must not be swept into a blurb.
+_SECTION_BREAK = re.compile(r"^(?:#{1,6}[ \t]+\S|-{3,}[ \t]*$)", re.MULTILINE)
+
+
+@dataclass
+class NoteMigration:
+    """What the migration would do to one Book Note."""
+
+    path: Path
+    original: str
+    migrated: str
+    changes: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        """Whether anything about the note would actually be rewritten."""
+        return self.original != self.migrated
+
+    def diff(self) -> str:
+        """A unified diff of the rewrite, for review before anything is written."""
+        return "".join(
+            difflib.unified_diff(
+                self.original.splitlines(keepends=True),
+                self.migrated.splitlines(keepends=True),
+                fromfile=f"a/{self.path.name}",
+                tofile=f"b/{self.path.name}",
+            )
+        )
+
+
+def mint_libris_id(date_added: object) -> str:
+    """Mint a Libris ID whose timestamp comes from when the book was added.
+
+    ULIDs sort lexicographically by their timestamp, so deriving it from
+    `date_added` makes the Library sort in the order it was acquired rather than
+    the order the migration happened to visit it (ADR 0011).
+
+    Args:
+        date_added: The note's `date_added` value, as a date, a datetime, an
+            ISO-8601 string, or anything unparseable.
+
+    Returns:
+        A 26-character ULID string.
+    """
+    moment: datetime | None = None
+    if isinstance(date_added, datetime):
+        moment = date_added
+    elif isinstance(date_added, date):
+        moment = datetime.combine(date_added, time.min)
+    elif isinstance(date_added, str) and date_added.strip():
+        try:
+            moment = datetime.fromisoformat(date_added.strip())
+        except ValueError:
+            moment = None
+
+    if moment is None:
+        return str(ULID())
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return str(ULID.from_datetime(moment))
+
+
+def split_frontmatter_blocks(frontmatter_text: str) -> list[tuple[str, str]]:
+    """Split raw frontmatter into (key, raw lines) pairs.
+
+    Continuation lines — the indented items of a sequence, or a wrapped scalar —
+    stay attached to the key above them, so a block can be moved without
+    disturbing how its value is written.
+
+    Args:
+        frontmatter_text: The text between the two `---` fences.
+
+    Returns:
+        One pair per key, in the order they appear.
+    """
+    blocks: list[tuple[str, str]] = []
+    key: str | None = None
+    lines: list[str] = []
+
+    for line in frontmatter_text.splitlines():
+        match = _KEY_LINE.match(line)
+        if match:
+            if key is not None:
+                blocks.append((key, "\n".join(lines)))
+            key = match.group(1)
+            lines = [line]
+        elif key is not None:
+            lines.append(line)
+
+    if key is not None:
+        blocks.append((key, "\n".join(lines)))
+    return blocks
+
+
+def reorder_frontmatter(blocks: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Group frontmatter blocks into identity, bibliographic, reading state, dates.
+
+    Modelled fields the note lacks are added empty. Anything Libris does not
+    model — fields a plugin added — keeps its relative order and follows the rest,
+    unrewritten (ADR 0005).
+
+    Args:
+        blocks: Pairs from `split_frontmatter_blocks`.
+
+    Returns:
+        The same blocks, reordered, plus any modelled field that was missing.
+    """
+    by_key = dict(blocks)
+    ordered = [(key, by_key.get(key, f"{key}:")) for key in MODELLED_FIELDS]
+    ordered.extend((key, raw) for key, raw in blocks if key not in MODELLED_FIELDS)
+    return ordered
+
+
+def render_description_callout(description: str) -> str:
+    """Render a description as a collapsed Obsidian callout (ADR 0009).
+
+    Args:
+        description: The description text, without any callout markup.
+
+    Returns:
+        The callout block, with every line prefixed.
+    """
+    lines = ["> [!abstract]- Description"]
+    for line in description.strip().splitlines():
+        lines.append(f"> {line}" if line.strip() else ">")
+    return "\n".join(lines)
+
+
+def split_body(body: str) -> tuple[str, str | None]:
+    """Separate the reader's own prose from the description supplied by an API.
+
+    The description is the content under its own heading, ending at the next
+    heading rather than at the end of the note — some notes carry the description
+    above `## Notes` rather than below it, and running to the end would sweep the
+    reader's own writing into the blurb.
+
+    Understands the shapes this vault holds: with and without an H1, description
+    under a heading or already inside a callout, in either order. Headings the
+    reader added stay with their content in the prose.
+
+    Args:
+        body: Everything after the closing frontmatter fence.
+
+    Returns:
+        The reader's prose, and the description if the note carries one.
+    """
+    description: str | None = None
+    remainder = body
+
+    callout = _CALLOUT_HEADING.search(body)
+    heading = _DESCRIPTION_HEADING.search(body)
+
+    if callout is not None:
+        after = body[callout.end() :]
+        quoted, rest = _take_callout(after)
+        description = quoted
+        remainder = body[: callout.start()] + rest
+    elif heading is not None:
+        after = body[heading.end() :]
+        section_break = _SECTION_BREAK.search(after)
+        end = section_break.start() if section_break else len(after)
+        description = after[:end].strip()
+        remainder = body[: heading.start()] + after[end:]
+
+    prose = _H1.sub("", remainder, count=1)
+    prose = _NOTES_HEADING.sub("", prose)
+    return prose.strip(), (description or None)
+
+
+def _take_callout(text: str) -> tuple[str, str]:
+    """Take the quoted lines of a callout, returning its content and what follows.
+
+    Args:
+        text: The note content immediately after a callout's heading line.
+
+    Returns:
+        The callout's text with its quote markers stripped, and the remainder of
+        the note.
+    """
+    quoted: list[str] = []
+    lines = text.splitlines(keepends=True)
+    consumed = 0
+    for line in lines:
+        stripped = line.rstrip("\n")
+        if stripped.startswith(">"):
+            quoted.append(stripped[2:] if stripped.startswith("> ") else stripped[1:])
+            consumed += 1
+        elif not stripped.strip() and not quoted:
+            consumed += 1
+        else:
+            break
+    return "\n".join(quoted).strip(), "".join(lines[consumed:])
+
+
+def render_body(title: str, prose: str, description: str | None) -> str:
+    """Render a Book Note body: title, then the reader's notes, then the blurb.
+
+    Args:
+        title: The book's title, which becomes the H1 the linter reads for an
+            alias (ADR 0012).
+        prose: Whatever the reader wrote.
+        description: The description from an external source, if any.
+
+    Returns:
+        The body, ending in a single newline.
+    """
+    sections = [f"# {title}", "## Notes"]
+    if prose:
+        sections.append(prose)
+    if description:
+        sections.append(render_description_callout(description))
+    return "\n\n".join(sections) + "\n"
+
+
+def _render_scalar(key: str, value: str) -> str:
+    """Render a scalar frontmatter line in the style the vault already uses.
+
+    Args:
+        key: The frontmatter key.
+        value: The value to write.
+
+    Returns:
+        A single `key: value` line, quoted only when YAML requires it.
+    """
+    needs_quote = (
+        not value
+        or value != value.strip()
+        or value[:1] in "#&*!|>%@`\"'-?{}[],"
+        or ": " in value
+        or value.endswith(":")
+        or value.lower() in {"true", "false", "null", "yes", "no", "on", "off", "~"}
+    )
+    if needs_quote:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'{key}: "{escaped}"'
+    return f"{key}: {value}"
+
+
+def recover_title(note: BookNote) -> tuple[str | None, str | None]:
+    """Recover a title Obsidian Linter overwrote or polluted with the author.
+
+    Two flavours of the same damage. Where there was no H1 the linter took the
+    `## Notes` heading as the title; where `yaml-title` ran with `mode: filename`
+    it wrote `Title - Author`, putting the author inside the title (ADR 0012).
+
+    Args:
+        note: The Book Note to inspect.
+
+    Returns:
+        The repaired title and a description of what was repaired, or
+        (None, None) when the title needs no repair.
+    """
+    title = note.title
+    author = note.first_author
+    stem = note.path.stem
+
+    if title in LEAKED_HEADINGS:
+        recovered = stem
+        if author and stem.endswith(f" - {author}"):
+            recovered = stem[: -len(f" - {author}")]
+        return recovered, f'title was "{title}"; recovered from filename'
+
+    if title and author and title.endswith(f" - {author}"):
+        return title[: -len(f" - {author}")].rstrip(), "removed author from title"
+
+    return None, None
+
+
+def leaked_alias_keys(blocks: list[tuple[str, str]]) -> list[str]:
+    """Find alias blocks whose every value came from a misread heading.
+
+    A block is only reported when all of its values leaked, so an alias the
+    reader added by hand is never discarded.
+
+    Args:
+        blocks: Pairs from `split_frontmatter_blocks`.
+
+    Returns:
+        The keys of blocks safe to drop.
+    """
+    leaked: list[str] = []
+    for key, raw in blocks:
+        if key not in ("aliases", "linter-yaml-title-alias"):
+            continue
+        values = [
+            part.strip().strip("-").strip().strip("\"'")
+            for part in raw.split(":", 1)[1].splitlines()
+        ]
+        values = [v for v in values if v]
+        if values and all(v in LEAKED_HEADINGS for v in values):
+            leaked.append(key)
+    return leaked
+
+
+def plan_note_migration(path: Path) -> NoteMigration:
+    """Work out what the migration would do to one Book Note, without writing.
+
+    Args:
+        path: The Book Note to plan for.
+
+    Returns:
+        The planned rewrite, the changes it represents, and anything about the
+        note that wants a human eye before it is written.
+    """
+    original = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", original, re.DOTALL)
+    if match is None:
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=["no parseable frontmatter; skipped"],
+        )
+
+    frontmatter_text, body = match.group(1), match.group(2)
+    note = BookNote.read(path)
+    if note is None:
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=["frontmatter is not a mapping; skipped"],
+        )
+
+    changes: list[str] = []
+    warnings: list[str] = []
+    blocks = split_frontmatter_blocks(frontmatter_text)
+
+    repaired_title, repair_note = recover_title(note)
+    title = repaired_title or note.title
+    if repaired_title is not None:
+        blocks = [
+            (key, _render_scalar("title", repaired_title) if key == "title" else raw)
+            for key, raw in blocks
+        ]
+        changes.append(repair_note)
+
+    for key in leaked_alias_keys(blocks):
+        blocks = [(k, raw) for k, raw in blocks if k != key]
+        changes.append(f"dropped leaked {key}")
+
+    if note.libris_id is None:
+        blocks.append(
+            (
+                "libris_id",
+                _render_scalar(
+                    "libris_id", mint_libris_id(note.frontmatter.get("date_added"))
+                ),
+            )
+        )
+        changes.append("minted libris_id")
+
+    existing_keys = {key for key, _ in blocks}
+    for key in MODELLED_FIELDS:
+        if key not in existing_keys:
+            changes.append(f"added {key}")
+
+    ordered = reorder_frontmatter(blocks)
+    if [k for k, _ in ordered] != [k for k, _ in blocks]:
+        changes.append("regrouped frontmatter")
+
+    prose, description = split_body(body)
+    if title is None:
+        warnings.append("no title; body left alone")
+        new_body = body
+    else:
+        new_body = render_body(title, prose, description)
+        if _H1.search(body) is None:
+            changes.append("added H1")
+        if description and _CALLOUT_HEADING.search(body) is None:
+            changes.append("description moved into a callout")
+
+    if description and re.search(r"^#{1,6}\s", description, re.MULTILINE):
+        warnings.append("heading found inside the description; check the split")
+
+    migrated = "---\n" + "\n".join(raw for _, raw in ordered) + "\n---\n\n" + new_body
+    return NoteMigration(
+        path=path,
+        original=original,
+        migrated=migrated,
+        changes=changes,
+        warnings=warnings,
+    )
+
+
+def plan_migration(vault_path: Path) -> list[NoteMigration]:
+    """Plan the migration for every Book Note on the Shelf.
+
+    Args:
+        vault_path: The Shelf to migrate.
+
+    Returns:
+        One plan per note, including notes that need no change.
+    """
+    return [plan_note_migration(path) for path in list_books(vault_path)]
+
+
+def apply_migration(plans: list[NoteMigration]) -> int:
+    """Write the planned rewrites to disk.
+
+    Args:
+        plans: Plans from `plan_migration`.
+
+    Returns:
+        How many notes were rewritten.
+    """
+    written = 0
+    for plan in plans:
+        if plan.changed:
+            plan.path.write_text(plan.migrated, encoding="utf-8")
+            written += 1
+    return written

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -1,0 +1,228 @@
+"""The canonical shape of a Book Note.
+
+One definition of what a Book Note looks like: which fields it carries and in
+what order, and how its body is written. Both note creation and the one-time
+migration render through here, so a note written today and a note migrated from
+2019 come out the same. The drift this project spent a refactor undoing began
+with two places disagreeing about a field name.
+
+See ADR 0005, ADR 0009, ADR 0011 and ADR 0012.
+"""
+
+import re
+from datetime import date, datetime, time, timezone
+
+from ulid import ULID
+
+IDENTITY_FIELDS = ("libris_id", "title", "authors")
+BIBLIOGRAPHIC_FIELDS = (
+    "isbn",
+    "page_count",
+    "date_published",
+    "google_books_id",
+    "cover_thumbnail",
+    "genres",
+    "series",
+)
+READING_FIELDS = ("status", "priority", "rating", "format", "tags", "referred_by")
+DATE_FIELDS = ("date_added", "date_started", "date_finished")
+
+MODELLED_FIELDS = IDENTITY_FIELDS + BIBLIOGRAPHIC_FIELDS + READING_FIELDS + DATE_FIELDS
+
+# Headings the linter mistook for a title, and the values that leaked from them.
+LEAKED_HEADINGS = ("Notes", "Description")
+
+_DESCRIPTION_HEADING = re.compile(r"^#{1,6}[ \t]*Description[ \t]*$", re.MULTILINE)
+_CALLOUT_HEADING = re.compile(
+    r"^>[ \t]*\[!abstract\]-?[ \t]*Description[ \t]*$", re.MULTILINE
+)
+_NOTES_HEADING = re.compile(r"^#{1,6}[ \t]*Notes[ \t]*$", re.MULTILINE)
+_H1 = re.compile(r"^#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
+# A section ends at the next heading or a thematic break. merge.py joins bodies
+# with a "---" divider, and the reader's writing must not be swept into a blurb.
+_SECTION_BREAK = re.compile(r"^(?:#{1,6}[ \t]+\S|-{3,}[ \t]*$)", re.MULTILINE)
+
+
+def mint_libris_id(date_added: object) -> str:
+    """Mint a Libris ID whose timestamp comes from when the book was added.
+
+    ULIDs sort lexicographically by their timestamp, so deriving it from
+    `date_added` makes the Library sort in the order it was acquired rather than
+    the order the migration happened to visit it (ADR 0011).
+
+    Args:
+        date_added: The note's `date_added` value, as a date, a datetime, an
+            ISO-8601 string, or anything unparseable.
+
+    Returns:
+        A 26-character ULID string.
+    """
+    moment: datetime | None = None
+    if isinstance(date_added, datetime):
+        moment = date_added
+    elif isinstance(date_added, date):
+        moment = datetime.combine(date_added, time.min)
+    elif isinstance(date_added, str) and date_added.strip():
+        try:
+            moment = datetime.fromisoformat(date_added.strip())
+        except ValueError:
+            moment = None
+
+    if moment is None:
+        return str(ULID())
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return str(ULID.from_datetime(moment))
+
+
+def render_description_callout(description: str) -> str:
+    """Render a description as a collapsed Obsidian callout (ADR 0009).
+
+    Args:
+        description: The description text, without any callout markup.
+
+    Returns:
+        The callout block, with every line prefixed.
+    """
+    lines = ["> [!abstract]- Description"]
+    for line in description.strip().splitlines():
+        lines.append(f"> {line}" if line.strip() else ">")
+    return "\n".join(lines)
+
+
+def split_body(body: str, titles: tuple[str, ...] = ()) -> tuple[str, str | None]:
+    """Separate the reader's own prose from the description supplied by an API.
+
+    The description is the content under its own heading, ending at the next
+    heading rather than at the end of the note — some notes carry the description
+    above `## Notes` rather than below it, and running to the end would sweep the
+    reader's own writing into the blurb.
+
+    Understands the shapes this vault holds: with and without an H1, description
+    under a heading or already inside a callout, in either order. Headings the
+    reader added stay with their content in the prose.
+
+    Args:
+        body: Everything after the closing frontmatter fence.
+        titles: Headings that count as the note's own title heading and may be
+            consumed. Any other leading H1 belongs to the reader and is kept.
+
+    Returns:
+        The reader's prose, and the description if the note carries one.
+    """
+    description: str | None = None
+    remainder = body
+
+    callout = _CALLOUT_HEADING.search(body)
+    heading = _DESCRIPTION_HEADING.search(body)
+
+    if callout is not None:
+        after = body[callout.end() :]
+        quoted, rest = _take_callout(after)
+        description = quoted
+        remainder = body[: callout.start()] + rest
+    elif heading is not None:
+        after = body[heading.end() :]
+        section_break = _SECTION_BREAK.search(after)
+        end = section_break.start() if section_break else len(after)
+        description = after[:end].strip()
+        remainder = body[: heading.start()] + after[end:]
+
+    prose = _strip_title_heading(remainder, titles)
+    prose = _NOTES_HEADING.sub("", prose)
+    return prose.strip(), (description or None)
+
+
+def _strip_title_heading(text: str, titles: tuple[str, ...]) -> str:
+    """Remove a leading H1 only when it is the note's title heading.
+
+    A note may open with a heading the reader wrote - a contents list, or
+    "Notes from GetAbstract" - and removing it would destroy their writing. Only
+    a first-line H1 naming the title, or one of the headings the linter leaked
+    into the title, is the migration's to consume.
+
+    Args:
+        text: The note content with any description already removed.
+        titles: Headings that count as the note's own title heading.
+
+    Returns:
+        The text, with the title heading removed if it was there.
+    """
+    leading = text.lstrip("\n")
+    match = _H1.match(leading)
+    if match is None:
+        return text
+
+    heading = match.group(1).strip()
+    if heading in LEAKED_HEADINGS or heading in titles:
+        return leading[match.end() :]
+    return text
+
+
+def _take_callout(text: str) -> tuple[str, str]:
+    """Take the quoted lines of a callout, returning its content and what follows.
+
+    Args:
+        text: The note content immediately after a callout's heading line.
+
+    Returns:
+        The callout's text with its quote markers stripped, and the remainder of
+        the note.
+    """
+    quoted: list[str] = []
+    lines = text.splitlines(keepends=True)
+    consumed = 0
+    for line in lines:
+        stripped = line.rstrip("\n")
+        if stripped.startswith(">"):
+            quoted.append(stripped[2:] if stripped.startswith("> ") else stripped[1:])
+            consumed += 1
+        elif not stripped.strip() and not quoted:
+            consumed += 1
+        else:
+            break
+    return "\n".join(quoted).strip(), "".join(lines[consumed:])
+
+
+def render_body(title: str, prose: str, description: str | None) -> str:
+    """Render a Book Note body: title, then the reader's notes, then the blurb.
+
+    Args:
+        title: The book's title, which becomes the H1 the linter reads for an
+            alias (ADR 0012).
+        prose: Whatever the reader wrote.
+        description: The description from an external source, if any.
+
+    Returns:
+        The body, ending in a single newline.
+    """
+    sections = [f"# {title}", "## Notes"]
+    if prose:
+        sections.append(prose)
+    if description:
+        sections.append(render_description_callout(description))
+    return "\n\n".join(sections) + "\n"
+
+
+def has_title_heading(body: str) -> bool:
+    """Whether a note body already opens with a heading.
+
+    Args:
+        body: Everything after the closing frontmatter fence.
+
+    Returns:
+        True when an H1 is present anywhere in the body.
+    """
+    return _H1.search(body) is not None
+
+
+def has_description_callout(body: str) -> bool:
+    """Whether a note's description already sits in a collapsed callout.
+
+    Args:
+        body: Everything after the closing frontmatter fence.
+
+    Returns:
+        True when the callout is present.
+    """
+    return _CALLOUT_HEADING.search(body) is not None

--- a/tests/test_autoenrich.py
+++ b/tests/test_autoenrich.py
@@ -1,7 +1,7 @@
 import yaml
 from typer.testing import CliRunner
 
-from libris.api import Book
+from libris.api import BookCandidate
 from libris.cli import app
 
 runner = CliRunner()
@@ -20,7 +20,7 @@ def _make_book(**overrides):
         description="A novel about the American dream.",
     )
     defaults.update(overrides)
-    return Book(**defaults)
+    return BookCandidate(**defaults)
 
 
 def _write_book(vault, name, fm_overrides=None):

--- a/tests/test_autoenrich.py
+++ b/tests/test_autoenrich.py
@@ -26,12 +26,12 @@ def _make_book(**overrides):
 def _write_book(vault, name, fm_overrides=None):
     fm = {
         "title": "The Great Gatsby",
-        "author": ["F. Scott Fitzgerald"],
+        "authors": ["F. Scott Fitzgerald"],
         "isbn": None,
         "page_count": None,
-        "published_date": None,
+        "date_published": None,
         "google_books_id": None,
-        "thumbnail": None,
+        "cover_thumbnail": None,
         "genres": None,
         "tags": "Book",
         "format": None,
@@ -93,7 +93,9 @@ def test_autoenrich_single_match(tmp_path, monkeypatch):
 def test_autoenrich_multiple_results_one_confident(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     _write_book(
-        vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]}
+        vault,
+        "Dune - Frank Herbert.md",
+        {"title": "Dune", "authors": ["Frank Herbert"]},
     )
 
     dune = _make_book(
@@ -126,7 +128,9 @@ def test_autoenrich_multiple_results_one_confident(tmp_path, monkeypatch):
 def test_autoenrich_prefers_most_complete_edition(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     _write_book(
-        vault, "Dune - Frank Herbert.md", {"title": "Dune", "author": ["Frank Herbert"]}
+        vault,
+        "Dune - Frank Herbert.md",
+        {"title": "Dune", "authors": ["Frank Herbert"]},
     )
 
     sparse = _make_book(
@@ -174,7 +178,7 @@ def test_autoenrich_multiple_no_interactive_logs(tmp_path, monkeypatch):
     _write_book(
         vault,
         "Ambiguous Book.md",
-        {"title": "Ambiguous Book", "author": ["Some Author"]},
+        {"title": "Ambiguous Book", "authors": ["Some Author"]},
     )
 
     book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1")
@@ -200,7 +204,7 @@ def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
     _write_book(
         vault,
         "Ambiguous Book.md",
-        {"title": "Ambiguous Book", "author": ["Some Author"]},
+        {"title": "Ambiguous Book", "authors": ["Some Author"]},
     )
 
     book_a = _make_book(title="Ambiguous Book Vol 1", google_books_id="a1", isbn="111")
@@ -237,7 +241,7 @@ def test_autoenrich_multiple_with_interactive(tmp_path, monkeypatch):
 def test_autoenrich_interactive_skip(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     book_path = _write_book(
-        vault, "Skip Me.md", {"title": "Skip Me", "author": ["Author"]}
+        vault, "Skip Me.md", {"title": "Skip Me", "authors": ["Author"]}
     )
     original_content = book_path.read_text(encoding="utf-8")
 
@@ -270,7 +274,7 @@ def test_autoenrich_interactive_skip(tmp_path, monkeypatch):
 def test_autoenrich_no_results(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     _write_book(
-        vault, "Obscure Book.md", {"title": "Obscure Book", "author": ["Nobody"]}
+        vault, "Obscure Book.md", {"title": "Obscure Book", "authors": ["Nobody"]}
     )
 
     monkeypatch.setattr(
@@ -295,13 +299,13 @@ def test_autoenrich_skips_complete_books(tmp_path, monkeypatch):
         "Complete Book.md",
         {
             "title": "Complete Book",
-            "author": ["Author"],
+            "authors": ["Author"],
             "isbn": "123",
             "page_count": 300,
-            "published_date": "2020",
+            "date_published": "2020",
             "google_books_id": "gid1",
             "genres": ["Fiction"],
-            "thumbnail": "http://img.example.com/thumb.jpg",
+            "cover_thumbnail": "http://img.example.com/thumb.jpg",
         },
     )
 
@@ -325,10 +329,10 @@ def test_autoenrich_skips_book_with_google_id_but_missing_fields(tmp_path, monke
         "Partial Book.md",
         {
             "title": "Partial Book",
-            "author": ["Author"],
+            "authors": ["Author"],
             "google_books_id": "gid2",
             "isbn": None,
-            "thumbnail": None,
+            "cover_thumbnail": None,
         },
     )
 
@@ -355,11 +359,11 @@ def test_autoenrich_skips_book_with_empty_google_id_but_thumbnail(
         "1776 - David McCullough.md",
         {
             "title": "1776",
-            "author": ["David McCullough"],
+            "authors": ["David McCullough"],
             "google_books_id": "",
             "isbn": None,
-            "thumbnail": "http://books.google.com/books/content?id=yIIbAQAAMAAJ",
-            "published_date": "2007-10-02",
+            "cover_thumbnail": "http://books.google.com/books/content?id=yIIbAQAAMAAJ",
+            "date_published": "2007-10-02",
             "page_count": 294,
         },
     )
@@ -387,7 +391,7 @@ def test_autoenrich_isbn_fallback(tmp_path, monkeypatch):
         "ISBN Book.md",
         {
             "title": "ISBN Book",
-            "author": ["Author"],
+            "authors": ["Author"],
             "isbn": "9780451524935",
         },
     )
@@ -416,7 +420,7 @@ def test_autoenrich_isbn_fallback(tmp_path, monkeypatch):
 def test_autoenrich_no_isbn_no_fallback(tmp_path, monkeypatch):
     """When ISBN is not in frontmatter, no fallback search occurs."""
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "No ISBN.md", {"title": "No ISBN", "author": ["Author"]})
+    _write_book(vault, "No ISBN.md", {"title": "No ISBN", "authors": ["Author"]})
 
     queries = []
 
@@ -438,7 +442,7 @@ def test_autoenrich_no_isbn_no_fallback(tmp_path, monkeypatch):
 def test_autoenrich_dry_run(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     book_path = _write_book(
-        vault, "Dry Run Book.md", {"title": "Dry Run Book", "author": ["Author"]}
+        vault, "Dry Run Book.md", {"title": "Dry Run Book", "authors": ["Author"]}
     )
     original_content = book_path.read_text(encoding="utf-8")
 
@@ -454,9 +458,9 @@ def test_autoenrich_dry_run(tmp_path, monkeypatch):
 
 def test_autoenrich_limit(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
-    _write_book(vault, "Book A.md", {"title": "Book A", "author": ["Author"]})
-    _write_book(vault, "Book B.md", {"title": "Book B", "author": ["Author"]})
-    _write_book(vault, "Book C.md", {"title": "Book C", "author": ["Author"]})
+    _write_book(vault, "Book A.md", {"title": "Book A", "authors": ["Author"]})
+    _write_book(vault, "Book B.md", {"title": "Book B", "authors": ["Author"]})
+    _write_book(vault, "Book C.md", {"title": "Book C", "authors": ["Author"]})
 
     monkeypatch.setattr(
         "libris.cli.GoogleBooksClient.search",
@@ -475,7 +479,7 @@ def test_autoenrich_limit(tmp_path, monkeypatch):
 def test_autoenrich_query_from_frontmatter(tmp_path, monkeypatch):
     vault = _setup_vault(tmp_path)
     _write_book(
-        vault, "renamed-file.md", {"title": "The Hobbit", "author": ["J.R.R. Tolkien"]}
+        vault, "renamed-file.md", {"title": "The Hobbit", "authors": ["J.R.R. Tolkien"]}
     )
 
     captured = {}

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -176,10 +176,6 @@ def test_enrichment_query_searches_by_author(vault):
     assert "inauthor:Catullus" in query
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#61: _API_SOURCED_FIELDS names thumbnail and published_date, which do not exist",
-)
 def test_already_enriched_note_is_not_re_enriched():
     # Given a note carrying metadata that only Google Books could have supplied
     fm = {

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -1,0 +1,227 @@
+"""Tests asserting the canonical frontmatter vocabulary from ADR 0005.
+
+Every note in the vault uses `authors`, `date_published` and `cover_thumbnail`. The code
+reads `author`, `published_date` and `thumbnail`, so every read returns None silently and
+six behaviours are broken in production while the rest of the suite stays green — because
+its fixtures use the code's schema rather than the vault's.
+
+These tests build notes shaped like real ones. See #61.
+"""
+
+import pytest
+
+from libris.api import Book
+from libris.cli import _build_query_from_frontmatter, _needs_enrichment
+from libris.importer import _build_vault_index
+from libris.markdown import (
+    compute_canonical_filename,
+    create_book_note,
+    find_duplicates,
+    rename_book_file,
+)
+
+# The exact key set present on all 3,137 notes in the vault.
+CANONICAL_FRONTMATTER = {
+    "title": None,
+    "authors": None,
+    "isbn": None,
+    "page_count": None,
+    "date_published": None,
+    "google_books_id": "",
+    "cover_thumbnail": None,
+    "genres": [],
+    "tags": "Book",
+    "format": None,
+    "status": "To Read",
+    "rating": None,
+    "referred_by": None,
+    "date_added": None,
+    "date_started": None,
+    "date_finished": None,
+}
+
+
+def write_note(vault, filename, **overrides):
+    """Write a Book Note shaped exactly like the ones in the vault.
+
+    Args:
+        vault: Directory to write into.
+        filename: Note filename, including the .md suffix.
+        **overrides: Frontmatter values to set, using canonical field names.
+
+    Returns:
+        Path to the written note.
+    """
+    fm = {**CANONICAL_FRONTMATTER, **overrides}
+    lines = []
+    for key, value in fm.items():
+        if value is None:
+            lines.append(f"{key}:")
+        elif isinstance(value, list):
+            if not value:
+                lines.append(f"{key}: []")
+            else:
+                lines.append(f"{key}:")
+                lines.extend(f"  - {item}" for item in value)
+        elif isinstance(value, str):
+            lines.append(f'{key}: "{value}"')
+        else:
+            lines.append(f"{key}: {value}")
+
+    path = vault / filename
+    path.write_text(
+        "---\n" + "\n".join(lines) + "\n---\n\n## Notes\n", encoding="utf-8"
+    )
+    return path
+
+
+@pytest.fixture
+def vault(tmp_path):
+    """A Shelf directory to write Book Notes into."""
+    shelf = tmp_path / "Book List"
+    shelf.mkdir()
+    return shelf
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#61: _build_vault_index reads fm['author'], so every note is skipped",
+)
+def test_vault_index_finds_notes_written_with_canonical_fields(vault):
+    # Given two Book Notes shaped like the ones in the vault
+    write_note(
+        vault, "Dune - Frank Herbert.md", title="Dune", authors=["Frank Herbert"]
+    )
+    write_note(
+        vault,
+        "Oathbringer - Brandon Sanderson.md",
+        title="Oathbringer",
+        authors=["Brandon Sanderson"],
+    )
+
+    # When the importer builds its duplicate-detection index
+    index = _build_vault_index(vault)
+
+    # Then both notes are indexed
+    # Currently 0: every note is skipped at importer.py:134 because fm.get("author")
+    # is None, so import duplicate detection has never matched anything.
+    assert len(index) == 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#61: _author_key reads fm['author'], making author a wildcard for every note",
+)
+def test_duplicates_does_not_group_books_by_different_authors(vault):
+    # Given two unrelated books that happen to share a title
+    write_note(vault, "Poems - Catullus.md", title="Poems", authors=["Catullus"])
+    write_note(
+        vault,
+        "Poems - Gerard Manley Hopkins.md",
+        title="Poems",
+        authors=["Gerard Manley Hopkins"],
+    )
+
+    # When duplicates are detected
+    groups = find_duplicates(vault)
+
+    # Then they are not duplicates of each other
+    # Currently one group of 2: _author_key returns () for every note, so a missing
+    # author is treated as a wildcard and grouping falls back to title alone.
+    assert groups == []
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#61: compute_canonical_filename reads fm['author']"
+)
+def test_canonical_filename_resolves_from_the_authors_field(vault):
+    # Given a Book Note with a misnamed file
+    note = write_note(vault, "wrong-name.md", title="Dune", authors=["Frank Herbert"])
+
+    # When the canonical filename is computed
+    result = compute_canonical_filename(note)
+
+    # Then it comes from the title and first author
+    # Currently None for every note in the vault, which makes clean --rename a no-op.
+    assert result == "Dune - Frank Herbert.md"
+
+
+@pytest.mark.xfail(strict=True, reason="#61: rename_book_file reads fm['author']")
+def test_rename_reads_the_authors_field(vault):
+    # Given a Book Note with a misnamed file
+    note = write_note(vault, "wrong-name.md", title="Dune", authors=["Frank Herbert"])
+
+    # When it is renamed
+    result = rename_book_file(note)
+
+    # Then the author was found
+    # Currently "missing_author" for every note in the vault.
+    assert result.status != "missing_author"
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#61: _build_query_from_frontmatter reads fm['author']"
+)
+def test_enrichment_query_searches_by_author(vault):
+    # Given frontmatter from a Book Note in the vault
+    fm = {**CANONICAL_FRONTMATTER, "title": "Poems", "authors": ["Catullus"]}
+    note = vault / "Poems - Catullus.md"
+
+    # When an enrichment query is built from it
+    query = _build_query_from_frontmatter(fm, note)
+
+    # Then it constrains the search by author
+    # Currently title-only, because fm.get("author") is None. Nineteen notes in the
+    # vault are titled "Poems", so a title-only query cannot resolve them.
+    assert "inauthor:Catullus" in query
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#61: _API_SOURCED_FIELDS names thumbnail and published_date, which do not exist",
+)
+def test_already_enriched_note_is_not_re_enriched():
+    # Given a note carrying metadata that only Google Books could have supplied
+    fm = {
+        **CANONICAL_FRONTMATTER,
+        "title": "Dune",
+        "authors": ["Frank Herbert"],
+        "cover_thumbnail": "http://books.google.com/books/content?id=abc",
+        "date_published": "1965-08-01",
+    }
+
+    # When it is checked for enrichment
+    # Then it is recognised as already enriched
+    # Currently True: _API_SOURCED_FIELDS names "thumbnail" and "published_date", neither
+    # of which exists, so it tests two fields instead of four. Measured against the
+    # vault it reports 152 unenriched notes when only 5 are.
+    assert _needs_enrichment(fm) is False
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#61: DEFAULT_FRONTMATTER uses author/published_date/thumbnail"
+)
+def test_created_notes_use_the_canonical_field_names(vault):
+    # Given a book resolved from Google Books
+    book = Book(
+        title="Dune",
+        authors=["Frank Herbert"],
+        isbn="9780441013593",
+        page_count=412,
+        published_date="1965-08-01",
+        google_books_id="dune1",
+        thumbnail="http://books.google.com/books/content?id=dune1",
+        genres=["Science Fiction"],
+        description="A novel about a desert planet.",
+    )
+
+    # When a note is created for it
+    note = create_book_note(book, vault)
+    content = note.read_text(encoding="utf-8")
+
+    # Then the frontmatter matches every other note in the vault
+    # Currently writes author/published_date/thumbnail, so newly created notes disagree
+    # with all 3,137 existing ones. This is the root cause of the five failures above.
+    assert "authors:" in content
+    assert "date_published:" in content
+    assert "cover_thumbnail:" in content

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -10,7 +10,7 @@ These tests build notes shaped like real ones. See #61.
 
 import pytest
 
-from libris.api import Book
+from libris.api import BookCandidate
 from libris.cli import _build_query_from_frontmatter, _needs_enrichment
 from libris.importer import _build_vault_index
 from libris.markdown import (
@@ -181,7 +181,7 @@ def test_already_enriched_note_is_not_re_enriched():
 
 def test_created_notes_use_the_canonical_field_names(vault):
     # Given a book resolved from Google Books
-    book = Book(
+    book = BookCandidate(
         title="Dune",
         authors=["Frank Herbert"],
         isbn="9780441013593",

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -198,9 +198,6 @@ def test_already_enriched_note_is_not_re_enriched():
     assert _needs_enrichment(fm) is False
 
 
-@pytest.mark.xfail(
-    strict=True, reason="#61: DEFAULT_FRONTMATTER uses author/published_date/thumbnail"
-)
 def test_created_notes_use_the_canonical_field_names(vault):
     # Given a book resolved from Google Books
     book = Book(

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -62,7 +62,9 @@ def write_note(vault, filename, **overrides):
                 lines.append(f"{key}: []")
             else:
                 lines.append(f"{key}:")
-                lines.extend(f"  - {item}" for item in value)
+                # Quote as the vault does, so a wikilink is a string and not a
+                # nested YAML sequence.
+                lines.extend(f'  - "{item}"' for item in value)
         elif isinstance(value, str):
             lines.append(f'{key}: "{value}"')
         else:
@@ -203,3 +205,38 @@ def test_created_notes_use_the_canonical_field_names(vault):
     assert "authors:" in content
     assert "date_published:" in content
     assert "cover_thumbnail:" in content
+
+
+def test_an_author_written_as_a_wikilink_reads_as_a_plain_name(vault):
+    # Given a note that links its author to their own note
+    note = write_note(
+        vault,
+        "Atlas Shrugged - Ayn Rand.md",
+        title="Atlas Shrugged",
+        authors=["[[Ayn Rand]]"],
+    )
+
+    # Then the name is used, not the link markup
+    # Seven notes in the vault store authors this way; the brackets would
+    # otherwise end up in a canonical filename.
+    from libris.markdown import BookNote
+
+    assert BookNote.read(note).authors == ["Ayn Rand"]
+    assert BookNote.read(note).canonical_filename == "Atlas Shrugged - Ayn Rand.md"
+
+
+def test_stray_whitespace_in_an_author_name_is_collapsed(vault):
+    # Given an author name carrying a doubled space
+    note = write_note(
+        vault,
+        "10% Happier - Dan Harris.md",
+        title="10% Happier",
+        authors=["Dan   Harris"],
+    )
+
+    # Then it matches the same name written normally
+    # This is why the migration first missed one polluted title: the check
+    # compared "Dan   Harris" against "Dan Harris" literally.
+    from libris.markdown import BookNote
+
+    assert BookNote.read(note).first_author == "Dan Harris"

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -83,10 +83,6 @@ def vault(tmp_path):
     return shelf
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#61: _build_vault_index reads fm['author'], so every note is skipped",
-)
 def test_vault_index_finds_notes_written_with_canonical_fields(vault):
     # Given two Book Notes shaped like the ones in the vault
     write_note(
@@ -108,10 +104,6 @@ def test_vault_index_finds_notes_written_with_canonical_fields(vault):
     assert len(index) == 2
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#61: _author_key reads fm['author'], making author a wildcard for every note",
-)
 def test_duplicates_does_not_group_books_by_different_authors(vault):
     # Given two unrelated books that happen to share a title
     write_note(vault, "Poems - Catullus.md", title="Poems", authors=["Catullus"])
@@ -131,9 +123,6 @@ def test_duplicates_does_not_group_books_by_different_authors(vault):
     assert groups == []
 
 
-@pytest.mark.xfail(
-    strict=True, reason="#61: compute_canonical_filename reads fm['author']"
-)
 def test_canonical_filename_resolves_from_the_authors_field(vault):
     # Given a Book Note with a misnamed file
     note = write_note(vault, "wrong-name.md", title="Dune", authors=["Frank Herbert"])
@@ -146,7 +135,6 @@ def test_canonical_filename_resolves_from_the_authors_field(vault):
     assert result == "Dune - Frank Herbert.md"
 
 
-@pytest.mark.xfail(strict=True, reason="#61: rename_book_file reads fm['author']")
 def test_rename_reads_the_authors_field(vault):
     # Given a Book Note with a misnamed file
     note = write_note(vault, "wrong-name.md", title="Dune", authors=["Frank Herbert"])
@@ -159,9 +147,6 @@ def test_rename_reads_the_authors_field(vault):
     assert result.status != "missing_author"
 
 
-@pytest.mark.xfail(
-    strict=True, reason="#61: _build_query_from_frontmatter reads fm['author']"
-)
 def test_enrichment_query_searches_by_author(vault):
     # Given frontmatter from a Book Note in the vault
     fm = {**CANONICAL_FRONTMATTER, "title": "Poems", "authors": ["Catullus"]}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,10 +92,10 @@ def test_cleanup_command(tmp_path):
 
 def test_search_command_generic(monkeypatch):
     """Search with no flags performs a generic query."""
-    from libris.api import Book
+    from libris.api import BookCandidate
 
     mock_books = [
-        Book(
+        BookCandidate(
             title="The Great Gatsby",
             authors=["F. Scott Fitzgerald"],
             isbn="1234567890123",
@@ -123,14 +123,14 @@ def test_search_command_generic(monkeypatch):
 
 def test_search_command_by_author(monkeypatch):
     """Search with --author prepends inauthor: prefix."""
-    from libris.api import Book
+    from libris.api import BookCandidate
 
     captured = {}
 
     def fake_search(self, q):
         captured["query"] = q
         return [
-            Book(
+            BookCandidate(
                 title="Dune",
                 authors=["Frank Herbert"],
                 isbn=None,
@@ -154,14 +154,14 @@ def test_search_command_by_author(monkeypatch):
 
 def test_search_command_by_title(monkeypatch):
     """Search with --title prepends intitle: prefix."""
-    from libris.api import Book
+    from libris.api import BookCandidate
 
     captured = {}
 
     def fake_search(self, q):
         captured["query"] = q
         return [
-            Book(
+            BookCandidate(
                 title="Dune",
                 authors=["Frank Herbert"],
                 isbn=None,
@@ -184,14 +184,14 @@ def test_search_command_by_title(monkeypatch):
 
 def test_search_command_by_isbn(monkeypatch):
     """Search with --isbn prepends isbn: prefix."""
-    from libris.api import Book
+    from libris.api import BookCandidate
 
     captured = {}
 
     def fake_search(self, q):
         captured["query"] = q
         return [
-            Book(
+            BookCandidate(
                 title="Dune",
                 authors=["Frank Herbert"],
                 isbn="9780441013593",
@@ -222,10 +222,10 @@ def test_search_command_no_results(monkeypatch):
 
 
 def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
-    from libris.api import Book
+    from libris.api import BookCandidate
 
     mock_books = [
-        Book(
+        BookCandidate(
             title="Dune",
             authors=["Frank Herbert"],
             isbn="9780441013593",

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -40,7 +40,7 @@ def test_duplicate_by_title(tmp_path):
         title="Same Title",
         isbn="111",
         google_books_id="a1",
-        author=["Author A"],
+        authors=["Author A"],
     )
     _write_book(
         tmp_path,
@@ -48,7 +48,7 @@ def test_duplicate_by_title(tmp_path):
         title="same title",
         isbn="222",
         google_books_id="b2",
-        author=["Author A"],
+        authors=["Author A"],
     )
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
@@ -57,14 +57,14 @@ def test_duplicate_by_title(tmp_path):
 
 
 def test_same_title_different_author_not_duplicate(tmp_path):
-    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", author=["Author A"])
-    _write_book(tmp_path, "B.md", title="Zero Day", isbn="222", author=["Author B"])
+    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", authors=["Author A"])
+    _write_book(tmp_path, "B.md", title="Zero Day", isbn="222", authors=["Author B"])
     assert find_duplicates(tmp_path) == []
 
 
 def test_same_title_missing_author_is_duplicate(tmp_path):
     """A book with no author should match same-titled books as a potential duplicate."""
-    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", author=["Author A"])
+    _write_book(tmp_path, "A.md", title="Zero Day", isbn="111", authors=["Author A"])
     _write_book(tmp_path, "B.md", title="Zero Day", isbn="222")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 1
@@ -96,7 +96,7 @@ def test_transitive_duplicates_merged(tmp_path):
         title="Shared Title",
         isbn="111",
         google_books_id="a1",
-        author=["Same Author"],
+        authors=["Same Author"],
     )
     _write_book(
         tmp_path,
@@ -104,7 +104,7 @@ def test_transitive_duplicates_merged(tmp_path):
         title="Shared Title",
         isbn="222",
         google_books_id="b2",
-        author=["Same Author"],
+        authors=["Same Author"],
     )
     _write_book(tmp_path, "C.md", title="Other Title", isbn="222", google_books_id="c3")
     groups = find_duplicates(tmp_path)
@@ -113,18 +113,18 @@ def test_transitive_duplicates_merged(tmp_path):
 
 
 def test_multiple_independent_groups(tmp_path):
-    _write_book(tmp_path, "A.md", title="Group One", isbn="111", author=["Author X"])
-    _write_book(tmp_path, "B.md", title="Group One", isbn="112", author=["Author X"])
-    _write_book(tmp_path, "C.md", title="Group Two", isbn="333", author=["Author Y"])
-    _write_book(tmp_path, "D.md", title="Group Two", isbn="444", author=["Author Y"])
+    _write_book(tmp_path, "A.md", title="Group One", isbn="111", authors=["Author X"])
+    _write_book(tmp_path, "B.md", title="Group One", isbn="112", authors=["Author X"])
+    _write_book(tmp_path, "C.md", title="Group Two", isbn="333", authors=["Author Y"])
+    _write_book(tmp_path, "D.md", title="Group Two", isbn="444", authors=["Author Y"])
     _write_book(tmp_path, "E.md", title="Unique", isbn="555")
     groups = find_duplicates(tmp_path)
     assert len(groups) == 2
 
 
 def test_files_without_frontmatter_skipped(tmp_path):
-    _write_book(tmp_path, "A.md", title="Same", isbn="111", author=["Author"])
-    _write_book(tmp_path, "B.md", title="Same", isbn="222", author=["Author"])
+    _write_book(tmp_path, "A.md", title="Same", isbn="111", authors=["Author"])
+    _write_book(tmp_path, "B.md", title="Same", isbn="222", authors=["Author"])
     # File without frontmatter
     (tmp_path / "plain.md").write_text("# Just a heading\n")
     groups = find_duplicates(tmp_path)
@@ -148,7 +148,7 @@ def test_cli_duplicates_command_reports(tmp_path):
         title="Dup Book",
         isbn="111",
         google_books_id="g1",
-        author=["Author"],
+        authors=["Author"],
     )
     _write_book(
         vault,
@@ -156,7 +156,7 @@ def test_cli_duplicates_command_reports(tmp_path):
         title="Dup Book",
         isbn="222",
         google_books_id="g2",
-        author=["Author"],
+        authors=["Author"],
     )
     set_config("vault_path", str(vault))
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -186,7 +186,7 @@ def test_import_detects_duplicates(tmp_path):
         vault,
         "Existing Book - Author A.md",
         title="Existing Book",
-        author=["Author A"],
+        authors=["Author A"],
         status="Read",
         format="Audiobook",
     )
@@ -213,7 +213,7 @@ def test_import_updates_status_on_duplicate(tmp_path):
         vault,
         "My Book - Author A.md",
         title="My Book",
-        author=["Author A"],
+        authors=["Author A"],
         status="To Read",
         format=None,
     )
@@ -239,7 +239,7 @@ def test_import_updates_format_on_duplicate(tmp_path):
         vault,
         "My Book - Author A.md",
         title="My Book",
-        author=["Author A"],
+        authors=["Author A"],
         status="Read",
         format=None,
     )
@@ -264,7 +264,7 @@ def test_import_updates_format_when_field_missing(tmp_path):
     # Create a book note without a format field at all
     existing = vault / "My Book - Author A.md"
     existing.write_text(
-        "---\ntitle: My Book\nauthor:\n- Author A\nstatus: Read\n---\n",
+        "---\ntitle: My Book\nauthors:\n- Author A\nstatus: Read\n---\n",
         encoding="utf-8",
     )
 
@@ -288,7 +288,7 @@ def test_import_updates_both_status_and_format(tmp_path):
         vault,
         "My Book - Author A.md",
         title="My Book",
-        author=["Author A"],
+        authors=["Author A"],
         status="To Read",
         format=None,
     )
@@ -316,7 +316,7 @@ def test_import_skips_up_to_date_duplicate(tmp_path):
         vault,
         "My Book - Author A.md",
         title="My Book",
-        author=["Author A"],
+        authors=["Author A"],
         status="Read",
         format="Audiobook",
     )
@@ -354,7 +354,7 @@ def test_import_case_insensitive_duplicate(tmp_path):
         vault,
         "The Great Book - Jane Smith.md",
         title="The Great Book",
-        author=["Jane Smith"],
+        authors=["Jane Smith"],
         status="Read",
         format="Audiobook",
     )

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -40,7 +40,7 @@ def test_create_book_note(tmp_path):
 
     content = file_path.read_text()
     assert "title: Test Book" in content
-    assert "author:\n- Author One" in content
+    assert "authors:\n- Author One" in content
     assert "### Description" in content
     assert "A test description" in content
 
@@ -206,7 +206,7 @@ def test_ensure_frontmatter_sets_status_read_when_date_finished(tmp_path):
     assert "status: Read" in content
 
 
-def test_ensure_frontmatter_converts_author_string_to_list(tmp_path):
+def test_ensure_frontmatter_migrates_legacy_author_to_authors_list(tmp_path):
     file_path = tmp_path / "string_author.md"
     file_path.write_text(
         "---\ntitle: Test\nauthor: John Doe\ngoogle_books_id: abc\n---\n"
@@ -218,7 +218,7 @@ def test_ensure_frontmatter_converts_author_string_to_list(tmp_path):
     assert updated is True
 
     content = file_path.read_text()
-    assert "author:\n- John Doe" in content
+    assert "authors:\n- John Doe" in content
 
 
 def test_ensure_frontmatter_fields_tricky_spacing(tmp_path):
@@ -388,9 +388,9 @@ def test_update_frontmatter_from_book_adds_title_heading_when_missing(tmp_path):
 def test_update_frontmatter_from_book_does_not_overwrite(tmp_path):
     f = tmp_path / "book.md"
     f.write_text(
-        "---\ntitle: My Title\nauthor:\n- Original\nisbn: '999'\n"
-        "page_count: 50\npublished_date: '2019'\ngoogle_books_id: existing\n"
-        "thumbnail: http://old.jpg\ngenres:\n- Nonfiction\n---\n"
+        "---\ntitle: My Title\nauthors:\n- Original\nisbn: '999'\n"
+        "page_count: 50\ndate_published: '2019'\ngoogle_books_id: existing\n"
+        "cover_thumbnail: http://old.jpg\ngenres:\n- Nonfiction\n---\n"
     )
 
     book = Book(
@@ -535,9 +535,9 @@ def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
     file_path = tmp_path / "good_book.md"
     # Write a file with all fields present and title already standardized
     file_path.write_text(
-        "---\ntitle: The Great Gatsby\nauthor:\n- F. Scott Fitzgerald\nisbn: '123'\n"
-        "page_count: 200\npublished_date: '1925'\ngoogle_books_id: abc\n"
-        "thumbnail: null\ngenres: null\ntags: Book\nformat: null\n"
+        "---\ntitle: The Great Gatsby\nauthors:\n- F. Scott Fitzgerald\nisbn: '123'\n"
+        "page_count: 200\ndate_published: '1925'\ngoogle_books_id: abc\n"
+        "cover_thumbnail: null\ngenres: null\ntags: Book\nformat: null\n"
         "status: To Read\nrating: null\nreferred_by: null\n"
         "date_added: null\ndate_started: null\ndate_finished: null\n---\n"
     )

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,7 +2,7 @@ import time
 from pathlib import Path
 from statistics import median
 
-from libris.api import Book
+from libris.api import BookCandidate
 from libris.markdown import (
     compute_canonical_filename,
     create_book_note,
@@ -22,7 +22,7 @@ def test_sanitize_filename():
 
 
 def test_create_book_note(tmp_path):
-    book = Book(
+    book = BookCandidate(
         title="Test Book",
         authors=["Author One"],
         isbn="1234567890",
@@ -47,7 +47,7 @@ def test_create_book_note(tmp_path):
 
 def test_create_book_note_with_overrides(tmp_path):
     """Test that overrides dict sets frontmatter fields."""
-    book = Book(
+    book = BookCandidate(
         title="Override Book",
         authors=["Author Two"],
         isbn="0987654321",
@@ -78,7 +78,7 @@ def test_create_book_note_with_overrides(tmp_path):
 
 def test_create_book_note_overrides_status(tmp_path):
     """Test that status in overrides takes precedence over the status parameter."""
-    book = Book(
+    book = BookCandidate(
         title="Status Book",
         authors=["Author Three"],
         isbn="1111111111",
@@ -105,7 +105,7 @@ def test_create_book_note_invalid_override_raises(tmp_path):
     """Test that an unknown override key raises ValueError."""
     import pytest
 
-    book = Book(
+    book = BookCandidate(
         title="Bad Override",
         authors=["Author Four"],
         isbn="2222222222",
@@ -315,7 +315,7 @@ def test_update_frontmatter_from_book_fills_nulls(tmp_path):
         "---\ntitle: null\nisbn: null\ngoogle_books_id: null\nstatus: Reading\n---\n"
     )
 
-    book = Book(
+    book = BookCandidate(
         title="Real Title",
         authors=["Author A"],
         isbn="1234567890",
@@ -344,7 +344,7 @@ def test_update_frontmatter_from_book_skips_existing_description(tmp_path):
     f = tmp_path / "book.md"
     f.write_text("---\ntitle: null\n---\n\n### Description\nExisting desc\n")
 
-    book = Book(
+    book = BookCandidate(
         title="Title",
         authors=["A"],
         isbn=None,
@@ -367,7 +367,7 @@ def test_update_frontmatter_from_book_adds_title_heading_when_missing(tmp_path):
     f = tmp_path / "book.md"
     f.write_text("---\ntitle: Test Book\nauthors: null\n---\n\n## Notes\n")
 
-    book = Book(
+    book = BookCandidate(
         title="Test Book",
         authors=["Author"],
         isbn="123",
@@ -393,7 +393,7 @@ def test_update_frontmatter_from_book_does_not_overwrite(tmp_path):
         "cover_thumbnail: http://old.jpg\ngenres:\n- Nonfiction\n---\n"
     )
 
-    book = Book(
+    book = BookCandidate(
         title="Other Title",
         authors=["Author B"],
         isbn="111",

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,4 +1,5 @@
 import time
+from datetime import date
 from pathlib import Path
 from statistics import median
 
@@ -14,6 +15,7 @@ from libris.markdown import (
     update_frontmatter_from_book,
     update_wikilinks_in_vault,
 )
+from libris.note_format import mint_libris_id
 
 
 def test_sanitize_filename():
@@ -41,8 +43,8 @@ def test_create_book_note(tmp_path):
     content = file_path.read_text()
     assert "title: Test Book" in content
     assert "authors:\n- Author One" in content
-    assert "### Description" in content
-    assert "A test description" in content
+    assert "> [!abstract]- Description" in content
+    assert "> A test description" in content
 
 
 def test_create_book_note_with_overrides(tmp_path):
@@ -221,6 +223,25 @@ def test_ensure_frontmatter_migrates_legacy_author_to_authors_list(tmp_path):
     assert "authors:\n- John Doe" in content
 
 
+def test_ensuring_frontmatter_mints_a_missing_libris_id(tmp_path):
+    from libris.markdown import ensure_frontmatter_fields
+
+    # Given a note typed straight into Obsidian, with no identity
+    file_path = tmp_path / "typed by hand.md"
+    file_path.write_text(
+        "---\ntitle: Dune\nauthors:\n- Frank Herbert\ndate_added: 2019-03-12\n---\n",
+        encoding="utf-8",
+    )
+
+    # When its frontmatter is ensured
+    updated, data = ensure_frontmatter_fields(file_path)
+
+    # Then it gains an identity, timed from when the book was added
+    assert updated is True
+    assert len(data["libris_id"]) == 26
+    assert data["libris_id"] < mint_libris_id(date(2026, 1, 1))
+
+
 def test_ensure_frontmatter_fields_tricky_spacing(tmp_path):
     # Test with extra spaces after --- and no newline after second ---
     file_path = tmp_path / "tricky_book.md"
@@ -336,13 +357,15 @@ def test_update_frontmatter_from_book_fills_nulls(tmp_path):
     assert data["status"] == "Reading"
     # description should be added to the body
     content = f.read_text()
-    assert "### Description" in content
+    assert "> [!abstract]- Description" in content
     assert "A description" in content
 
 
 def test_update_frontmatter_from_book_skips_existing_description(tmp_path):
     f = tmp_path / "book.md"
-    f.write_text("---\ntitle: null\n---\n\n### Description\nExisting desc\n")
+    f.write_text(
+        "---\ntitle: null\n---\n\n> [!abstract]- Description\n> Existing desc\n"
+    )
 
     book = BookCandidate(
         title="Title",
@@ -358,7 +381,7 @@ def test_update_frontmatter_from_book_skips_existing_description(tmp_path):
 
     update_frontmatter_from_book(f, book)
     content = f.read_text()
-    assert content.count("### Description") == 1
+    assert content.count("[!abstract]- Description") == 1
     assert "Existing desc" in content
     assert "New desc" not in content
 
@@ -535,10 +558,12 @@ def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
     file_path = tmp_path / "good_book.md"
     # Write a file with all fields present and title already standardized
     file_path.write_text(
-        "---\ntitle: The Great Gatsby\nauthors:\n- F. Scott Fitzgerald\nisbn: '123'\n"
+        "---\nlibris_id: 01JQ8Z3K7M4X2VB9WCN5PDRT6E\n"
+        "title: The Great Gatsby\nauthors:\n- F. Scott Fitzgerald\nisbn: '123'\n"
         "page_count: 200\ndate_published: '1925'\ngoogle_books_id: abc\n"
-        "cover_thumbnail: null\ngenres: null\ntags: Book\nformat: null\n"
-        "status: To Read\nrating: null\nreferred_by: null\n"
+        "cover_thumbnail: null\ngenres: null\nseries: null\n"
+        "status: To Read\npriority: null\nrating: null\nformat: null\n"
+        "tags: Book\nreferred_by: null\n"
         "date_added: null\ndate_started: null\ndate_finished: null\n---\n"
     )
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -365,7 +365,7 @@ def test_update_frontmatter_from_book_skips_existing_description(tmp_path):
 
 def test_update_frontmatter_from_book_adds_title_heading_when_missing(tmp_path):
     f = tmp_path / "book.md"
-    f.write_text("---\ntitle: Test Book\nauthor: null\n---\n\n## Notes\n")
+    f.write_text("---\ntitle: Test Book\nauthors: null\n---\n\n## Notes\n")
 
     book = Book(
         title="Test Book",
@@ -551,26 +551,26 @@ def test_ensure_frontmatter_no_update_when_title_already_standard(tmp_path):
 
 def test_compute_canonical_filename(tmp_path):
     f = tmp_path / "old name.md"
-    f.write_text("---\ntitle: The Great Gatsby\nauthor:\n- F. Scott Fitzgerald\n---\n")
+    f.write_text("---\ntitle: The Great Gatsby\nauthors:\n- F. Scott Fitzgerald\n---\n")
     result = compute_canonical_filename(f)
     assert result == "The Great Gatsby - F. Scott Fitzgerald.md"
 
 
 def test_compute_canonical_filename_missing_author(tmp_path):
     f = tmp_path / "no_author.md"
-    f.write_text("---\ntitle: Solo Title\nauthor: null\n---\n")
+    f.write_text("---\ntitle: Solo Title\nauthors: null\n---\n")
     assert compute_canonical_filename(f) is None
 
 
 def test_compute_canonical_filename_missing_title(tmp_path):
     f = tmp_path / "no_title.md"
-    f.write_text("---\ntitle: null\nauthor:\n- Someone\n---\n")
+    f.write_text("---\ntitle: null\nauthors:\n- Someone\n---\n")
     assert compute_canonical_filename(f) is None
 
 
 def test_compute_canonical_filename_sanitizes(tmp_path):
     f = tmp_path / "bad.md"
-    f.write_text("---\ntitle: 'Title: With Colon'\nauthor:\n- Author\n---\n")
+    f.write_text("---\ntitle: 'Title: With Colon'\nauthors:\n- Author\n---\n")
     result = compute_canonical_filename(f)
     assert ":" not in result
     assert result == "Title With Colon - Author.md"
@@ -633,7 +633,7 @@ def test_update_wikilinks_excludes_target_file(tmp_path):
 
 def test_rename_book_file(tmp_path):
     f = tmp_path / "wrong name.md"
-    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    f.write_text("---\ntitle: Dune\nauthors:\n- Frank Herbert\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "renamed"
     assert result.new_path.name == "Dune - Frank Herbert.md"
@@ -643,7 +643,7 @@ def test_rename_book_file(tmp_path):
 
 def test_rename_book_file_updates_links(tmp_path):
     book = tmp_path / "wrong name.md"
-    book.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    book.write_text("---\ntitle: Dune\nauthors:\n- Frank Herbert\n---\n")
     note = tmp_path / "reading log.md"
     note.write_text("Currently reading [[wrong name]].\n")
 
@@ -655,7 +655,7 @@ def test_rename_book_file_updates_links(tmp_path):
 
 def test_rename_book_file_collision_skips(tmp_path):
     f = tmp_path / "wrong name.md"
-    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    f.write_text("---\ntitle: Dune\nauthors:\n- Frank Herbert\n---\n")
     collision = tmp_path / "Dune - Frank Herbert.md"
     collision.write_text("---\ntitle: Dune\n---\n")
 
@@ -667,14 +667,14 @@ def test_rename_book_file_collision_skips(tmp_path):
 
 def test_rename_book_file_already_canonical(tmp_path):
     f = tmp_path / "Dune - Frank Herbert.md"
-    f.write_text("---\ntitle: Dune\nauthor:\n- Frank Herbert\n---\n")
+    f.write_text("---\ntitle: Dune\nauthors:\n- Frank Herbert\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "already_canonical"
 
 
 def test_rename_book_file_missing_title(tmp_path):
     f = tmp_path / "some file.md"
-    f.write_text("---\ntitle: null\nauthor:\n- Some Author\n---\n")
+    f.write_text("---\ntitle: null\nauthors:\n- Some Author\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "missing_title"
     assert f.exists()
@@ -682,7 +682,7 @@ def test_rename_book_file_missing_title(tmp_path):
 
 def test_rename_book_file_missing_author(tmp_path):
     f = tmp_path / "some file.md"
-    f.write_text("---\ntitle: Some Title\nauthor: null\n---\n")
+    f.write_text("---\ntitle: Some Title\nauthors: null\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "missing_author"
     assert f.exists()
@@ -690,13 +690,13 @@ def test_rename_book_file_missing_author(tmp_path):
 
 def test_rename_book_file_empty_author_list(tmp_path):
     f = tmp_path / "some file.md"
-    f.write_text("---\ntitle: Some Title\nauthor: []\n---\n")
+    f.write_text("---\ntitle: Some Title\nauthors: []\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "missing_author"
 
 
 def test_rename_book_file_whitespace_title(tmp_path):
     f = tmp_path / "some file.md"
-    f.write_text("---\ntitle: '   '\nauthor:\n- Author\n---\n")
+    f.write_text("---\ntitle: '   '\nauthors:\n- Author\n---\n")
     result = rename_book_file(f, tmp_path)
     assert result.status == "missing_title"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -5,13 +5,15 @@ from datetime import date
 from libris.markdown import BookNote
 from libris.migrate import (
     leaked_alias_keys,
-    mint_libris_id,
     plan_note_migration,
     recover_title,
-    render_description_callout,
     reorder_frontmatter,
-    split_body,
     split_frontmatter_blocks,
+)
+from libris.note_format import (
+    mint_libris_id,
+    render_description_callout,
+    split_body,
 )
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -99,7 +99,7 @@ def test_reordering_does_not_rewrite_values_it_did_not_change():
 def test_description_below_the_notes_heading_is_separated():
     # Given the shape most notes have
     prose, description = split_body(
-        "# Dune\n\n## Notes\n\nmy prose\n\n### Description\nblurb\n"
+        "# Dune\n\n## Notes\n\nmy prose\n\n### Description\nblurb\n", ("Dune",)
     )
 
     # Then the reader's prose and the blurb are told apart
@@ -110,7 +110,7 @@ def test_description_below_the_notes_heading_is_separated():
 def test_description_above_the_notes_heading_does_not_swallow_prose():
     # Given a note where the description comes first
     prose, description = split_body(
-        "# Dune\n\n### Description\nblurb\n\n# Notes\n\nmy prose\n"
+        "# Dune\n\n### Description\nblurb\n\n# Notes\n\nmy prose\n", ("Dune",)
     )
 
     # Then the description stops at the next heading
@@ -133,7 +133,8 @@ def test_merged_content_is_prose_not_blurb():
 def test_an_already_migrated_body_reads_back_unchanged():
     # Given a body in the shape the migration produces
     prose, description = split_body(
-        "# Dune\n\n## Notes\n\nmy prose\n\n> [!abstract]- Description\n> blurb\n> more\n"
+        "# Dune\n\n## Notes\n\nmy prose\n\n> [!abstract]- Description\n> blurb\n> more\n",
+        ("Dune",),
     )
 
     # Then it round-trips, so the migration is safe to run twice
@@ -147,6 +148,36 @@ def test_callout_quotes_every_line_including_blank_ones():
 
     # Then every line is quoted and the callout is collapsed
     assert rendered == "> [!abstract]- Description\n> first\n>\n> second"
+
+
+def test_a_heading_the_reader_wrote_is_not_mistaken_for_the_title():
+    # Given a note opening with the reader's own H1
+    prose, _ = split_body(
+        "# Notes from GetAbstract\n\nthe seven habits are:\n", ("The 7 Habits",)
+    )
+
+    # Then it survives, because it does not name the title
+    assert prose.startswith("# Notes from GetAbstract")
+
+
+def test_a_heading_further_down_the_note_is_never_consumed():
+    # Given a contents list above the reader's first heading
+    prose, _ = split_body(
+        "- [[#General]]\n- [[#Healthy]]\n\n# General\n\nsome content\n",
+        ("Tools of Titans",),
+    )
+
+    # Then nothing is stripped, because no title heading leads the body
+    assert "# General" in prose
+    assert "[[#Healthy]]" in prose
+
+
+def test_a_leaked_heading_is_consumed_even_without_a_title():
+    # Given a note whose H1 the linter replaced with the Notes heading
+    prose, _ = split_body("# Notes\n\nmy prose\n", ())
+
+    # Then it is removed, since it was never the reader's
+    assert prose == "my prose"
 
 
 # --- Repairs ---

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,261 @@
+"""Tests for the one-time migration of the Shelf to the canonical Book Note shape."""
+
+from datetime import date
+
+from libris.markdown import BookNote
+from libris.migrate import (
+    leaked_alias_keys,
+    mint_libris_id,
+    plan_note_migration,
+    recover_title,
+    render_description_callout,
+    reorder_frontmatter,
+    split_body,
+    split_frontmatter_blocks,
+)
+
+
+def write_note(path, frontmatter: str, body: str):
+    """Write a note from raw frontmatter and body text."""
+    path.write_text(f"---\n{frontmatter}\n---\n\n{body}", encoding="utf-8")
+    return path
+
+
+# --- Libris IDs ---
+
+
+def test_libris_ids_sort_in_the_order_books_were_added():
+    # Given two books added years apart
+    early = mint_libris_id(date(2019, 3, 12))
+    late = mint_libris_id(date(2026, 5, 7))
+
+    # When their IDs are compared as strings
+    # Then the earlier book sorts first
+    assert early < late
+
+
+def test_libris_id_accepts_an_iso_string():
+    # Given a date_added that YAML left as a string
+    minted = mint_libris_id("2019-03-12")
+
+    # Then it is a well-formed ULID
+    assert len(minted) == 26
+
+
+def test_libris_id_falls_back_when_the_date_is_unusable():
+    # Given notes with no usable date_added
+    # Then an ID is still minted for each, and they differ
+    assert len(mint_libris_id(None)) == 26
+    assert len(mint_libris_id("not a date")) == 26
+    assert mint_libris_id(None) != mint_libris_id(None)
+
+
+# --- Frontmatter ---
+
+
+def test_sequence_items_stay_with_their_key():
+    # Given frontmatter holding a multi-line sequence
+    blocks = split_frontmatter_blocks(
+        'title: "Dune"\nauthors:\n  - Frank Herbert\n  - Someone Else\nisbn: "123"'
+    )
+
+    # Then each key keeps its own lines, rendered exactly as written
+    assert dict(blocks)["authors"] == "authors:\n  - Frank Herbert\n  - Someone Else"
+    assert dict(blocks)["isbn"] == 'isbn: "123"'
+
+
+def test_reordering_groups_fields_and_adds_the_missing_ones():
+    # Given a note carrying two modelled fields and one the linter added
+    blocks = [
+        ("status", "status: Read"),
+        ("title", "title: Dune"),
+        ("date_created", "date_created: Tuesday"),
+    ]
+
+    # When the frontmatter is regrouped
+    keys = [key for key, _ in reorder_frontmatter(blocks)]
+
+    # Then identity comes first, dates last, and the unmodelled field survives
+    assert keys[0] == "libris_id"
+    assert keys.index("title") < keys.index("status")
+    assert keys[-1] == "date_created"
+    assert "priority" in keys and "series" in keys
+
+
+def test_reordering_does_not_rewrite_values_it_did_not_change():
+    # Given a value with quoting the vault chose
+    blocks = [("isbn", 'isbn: "9780441013593"')]
+
+    # When regrouped
+    ordered = dict(reorder_frontmatter(blocks))
+
+    # Then the value renders exactly as it did
+    assert ordered["isbn"] == 'isbn: "9780441013593"'
+
+
+# --- Bodies ---
+
+
+def test_description_below_the_notes_heading_is_separated():
+    # Given the shape most notes have
+    prose, description = split_body(
+        "# Dune\n\n## Notes\n\nmy prose\n\n### Description\nblurb\n"
+    )
+
+    # Then the reader's prose and the blurb are told apart
+    assert prose == "my prose"
+    assert description == "blurb"
+
+
+def test_description_above_the_notes_heading_does_not_swallow_prose():
+    # Given a note where the description comes first
+    prose, description = split_body(
+        "# Dune\n\n### Description\nblurb\n\n# Notes\n\nmy prose\n"
+    )
+
+    # Then the description stops at the next heading
+    assert prose == "my prose"
+    assert description == "blurb"
+
+
+def test_merged_content_is_prose_not_blurb():
+    # Given a note that merge.py joined with a thematic break
+    prose, description = split_body(
+        "# Dune\n\n### Description\nblurb\n\n---\n\n"
+        "**Merged from duplicate entry:**\n\nnotes from the other copy\n"
+    )
+
+    # Then the reader's writing is kept out of the description
+    assert description == "blurb"
+    assert "notes from the other copy" in prose
+
+
+def test_an_already_migrated_body_reads_back_unchanged():
+    # Given a body in the shape the migration produces
+    prose, description = split_body(
+        "# Dune\n\n## Notes\n\nmy prose\n\n> [!abstract]- Description\n> blurb\n> more\n"
+    )
+
+    # Then it round-trips, so the migration is safe to run twice
+    assert prose == "my prose"
+    assert description == "blurb\nmore"
+
+
+def test_callout_quotes_every_line_including_blank_ones():
+    # Given a description with a paragraph break
+    rendered = render_description_callout("first\n\nsecond")
+
+    # Then every line is quoted and the callout is collapsed
+    assert rendered == "> [!abstract]- Description\n> first\n>\n> second"
+
+
+# --- Repairs ---
+
+
+def test_a_title_overwritten_by_a_heading_is_recovered_from_the_filename(tmp_path):
+    # Given a note whose title the linter replaced with the Notes heading
+    path = tmp_path / "Dune - Frank Herbert.md"
+    note = BookNote(
+        path=path, frontmatter={"title": "Notes", "authors": ["Frank Herbert"]}
+    )
+
+    # When the title is repaired
+    repaired, reason = recover_title(note)
+
+    # Then it comes back from the filename, without the author
+    assert repaired == "Dune"
+    assert "recovered from filename" in reason
+
+
+def test_an_author_inside_the_title_is_removed(tmp_path):
+    # Given a title the linter built from the filename
+    path = tmp_path / "10% Happier - Dan Harris.md"
+    note = BookNote(
+        path=path,
+        frontmatter={"title": "10% Happier - Dan Harris", "authors": ["Dan Harris"]},
+    )
+
+    # When the title is repaired
+    repaired, reason = recover_title(note)
+
+    # Then only the title remains
+    assert repaired == "10% Happier"
+    assert reason == "removed author from title"
+
+
+def test_a_good_title_is_left_alone(tmp_path):
+    # Given a title with nothing wrong with it
+    path = tmp_path / "Dune - Frank Herbert.md"
+    note = BookNote(
+        path=path, frontmatter={"title": "Dune", "authors": ["Frank Herbert"]}
+    )
+
+    # Then nothing is repaired
+    assert recover_title(note) == (None, None)
+
+
+def test_only_wholly_leaked_aliases_are_dropped():
+    # Given one alias that leaked from a heading and one the reader added
+    leaked = leaked_alias_keys([("aliases", "aliases:\n  - Notes")])
+    mixed = leaked_alias_keys([("aliases", "aliases:\n  - Notes\n  - Dune")])
+
+    # Then only the wholly leaked block is discarded
+    assert leaked == ["aliases"]
+    assert mixed == []
+
+
+# --- End to end ---
+
+
+def test_migrating_a_note_mints_an_id_regroups_and_restructures(tmp_path):
+    # Given a Book Note in the shape the vault holds
+    path = write_note(
+        tmp_path / "Dune - Frank Herbert.md",
+        'title: "Dune"\nauthors:\n  - Frank Herbert\nstatus: Read\n'
+        "date_added: 2019-03-12\ndate_created: Tuesday",
+        "## Notes\n\nmy prose\n\n### Description\nblurb\n",
+    )
+
+    # When the migration is planned
+    plan = plan_note_migration(path)
+
+    # Then the note gains an identity, a title heading and a collapsed blurb
+    assert "libris_id: 01" in plan.migrated
+    assert "# Dune\n\n## Notes\n\nmy prose" in plan.migrated
+    assert "> [!abstract]- Description\n> blurb" in plan.migrated
+
+    # And the field a plugin added survives untouched
+    assert "date_created: Tuesday" in plan.migrated
+
+    # And the value the vault already had is not rewritten
+    assert 'title: "Dune"' in plan.migrated
+
+
+def test_migrating_a_note_twice_changes_nothing_the_second_time(tmp_path):
+    # Given a note that has already been migrated
+    path = write_note(
+        tmp_path / "Dune - Frank Herbert.md",
+        'title: "Dune"\nauthors:\n  - Frank Herbert\ndate_added: 2019-03-12',
+        "## Notes\n\nmy prose\n\n### Description\nblurb\n",
+    )
+    path.write_text(plan_note_migration(path).migrated, encoding="utf-8")
+
+    # When it is planned again
+    second = plan_note_migration(path)
+
+    # Then there is nothing left to do
+    assert not second.changed
+    assert second.changes == []
+
+
+def test_a_note_without_frontmatter_is_skipped_not_mangled(tmp_path):
+    # Given a file that is not a Book Note
+    path = tmp_path / "stray.md"
+    path.write_text("# Just a heading\n", encoding="utf-8")
+
+    # When the migration is planned
+    plan = plan_note_migration(path)
+
+    # Then it is left exactly as it was, and says why
+    assert not plan.changed
+    assert plan.warnings == ["no parseable frontmatter; skipped"]

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "python-ulid" },
     { name = "pyyaml" },
     { name = "questionary" },
     { name = "titlecase" },
@@ -295,6 +296,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "python-ulid", specifier = ">=4.0.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.1.1" },
     { name = "titlecase", specifier = ">=2.4" },
@@ -453,6 +455,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/41/65079023c81491a21799c0120bce5925366b6913596bf797806f19973290/python_ulid-4.0.1.tar.gz", hash = "sha256:bbeec02556190bb9dc3401faa7268696acbfbe7b6db9908c155dc3548629f20c", size = 101683, upload-time = "2026-07-20T15:21:41.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/15/8b39b36f55b6618ec4ca9b55134dcfd9c04cecbc72709f5d8e6bdebed9cd/python_ulid-4.0.1-py3-none-any.whl", hash = "sha256:6f1d69ceb97e99fe542df8476ebcd7a668284bf53ee14b3106bcc6a341a95ed9", size = 14609, upload-time = "2026-07-20T15:21:40.214Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
There was no type for a book in the Library. It travelled as a loose `Path` plus an untyped
dict, and every field read was `fm.get("name")` against that dict. So when `DEFAULT_FRONTMATTER`
drifted from the 3,137 notes in the vault — declaring `author`, `published_date` and
`thumbnail` where every note held `authors`, `date_published` and `cover_thumbnail` — nothing
raised. Reads returned `None`, silently, for years.

Six behaviours were completely broken while all 154 tests passed, because no fixture had ever
constructed a note shaped like a real one.

## What was broken, measured against the vault

| | Before | After |
|---|---|---|
| `_build_vault_index` entries | **0** | 3,135 |
| `compute_canonical_filename` resolves | 0/400 | 400/400 |
| `find_duplicates` groups | 15, all false | 3, all genuine |
| `autoenrich` would search | 152 | 5 |
| Notes with an identity | 0 | 3,138 |

`_build_vault_index` returning nothing meant **import duplicate detection had never matched
anything** — every imported book was treated as new, which is a plausible source of the
duplicates already in the vault. `find_duplicates` grouped on title alone, reporting nineteen
unrelated poets as one duplicate group. `clean --rename` was a no-op vault-wide.

## Approach

The first commit is red on purpose: seven tests built from the vault's actual key set, marked
`xfail(strict=True)` so the branch stayed green and each fix forced its own marker off. Those
tests are the safety net the existing suite could not be, since it validated the wrong contract.

`BookNote` now owns a note's file, frontmatter and body, and exposes `title`, `authors`,
`first_author`, `libris_id` and `canonical_filename`. Normalisation lives in one place, so a
name the vault does not use cannot fail quietly at five call sites again.

`api.Book` becomes `BookCandidate` — metadata proposed by a source, not yet accepted — freeing
the word "book" for a book. `ImportBook` narrows from 14 fields to 4; nine of them were never
populated by any parser.

`note_format.py` holds the canonical shape: which fields a note carries and in what order, how
a body is written, how an ID is minted. Note creation and the migration both render through it,
so a note added today and a note migrated from 2019 come out identical. Without this the
migration would have been undone by the next `libris add`.

## The migration

`libris migrate` plans, diffs and applies. Frontmatter moves as text blocks rather than
round-tripping through YAML, because `yaml.dump` does not write what this vault holds — it
leaves sequences unindented, renders `None` as `null` and prefers single quotes. A round trip
would have shown a cosmetic diff on all 3,137 notes and buried the changes that matter.

**It has been run.** All 3,138 notes carry a unique ULID, timestamped from their own
`date_added` so the library sorts in the order it was acquired.

The dry run caught three data-loss bugs before anything was written, none of which a test
written up front would have found:

- five notes carry the description *above* the Notes heading, so ending it at the end of the
  body swept the reader's writing into the blurb
- twenty-two notes carry content `merge.py` joined with a `---` divider, absorbed the same way
- the leading H1 was stripped wherever it appeared, deleting `# General` from *Tools of Titans*
  and `# Notes from GetAbstract` from *The 7 Habits*

A word-level check now confirms every word of every original body survives in every migrated
one, across all 3,137.

## Also repaired

Four flavours of damage from Obsidian Linter reading headings it should not have: 4 notes whose
`title` was `"Notes"`, 18 carrying the author inside the title, 14 with a corrupted `# Notes`
heading, and 14 aliased "Notes" or "Description". The rule causing the ongoing pollution
(`yaml-title` with `mode: filename`) has been disabled; `yaml-title-alias` stays, since ADR 0009
depends on it.

`Reading List.base` sorted on `author`, `genre`, `Genre` and `Status` — none of which exist in
any note. Those columns have been rendering empty; they now populate.

## For reviewers

- **`CONTEXT.md` and `docs/adr/` are the reasoning.** Twelve ADRs covering identity, the note
  format, the canonical vocabulary, and why the alternatives lost.
- **`clean --rename` is now live** after being dead for the vault's whole life. It would rename
  132 files and rewrite wikilinks. Deliberate decision, not run here.
- **`uv run pytest` fails locally** on a stale console shim; `uv run python -m pytest` works.
  A fresh `uv sync` in CI should not hit it.
- New dependency: `python-ulid`.

185 tests, ruff clean.

Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
