### PR TITLE
docs: settle the three deferred design decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,11 @@ The ULID stamped into a Book Note's frontmatter that identifies it across every 
 Stable across renames, title standardisation, and merges.
 _Avoid_: uid, book id, key
 
+**Superseded ID**:
+A Libris ID that identified a Book Note which has since merged into another. It is not
+reused and never dangles: it resolves to the surviving note.
+_Avoid_: dead id, old id, tombstone
+
 **Matching**:
 Deciding whether two Book Notes describe the same book — the judgement behind duplicate
 detection and import de-duplication. Deliberately separate from identity, and allowed to be
@@ -62,6 +67,12 @@ A change to the Library recorded by a Surface and applied to the Shelf later by 
 either adding a Book Note or setting named fields on an existing one. An Intent names only
 the fields it changes, so it can never overwrite a field it knows nothing about.
 _Avoid_: delta, patch, command, event
+
+**Intent Outcome**:
+What became of an Intent once the CLI tried to apply it. *Applied*: the Shelf changed as
+asked. *Absorbed*: the Library already satisfied it, and the outcome names the Libris ID it
+turned out to mean. *Rejected*: it could not apply and a person has to decide.
+_Avoid_: intent status, failure, error
 
 **Resolution**:
 Turning a person's reference to a book ("that Sanderson one I just finished") into a Libris

--- a/docs/adr/0013-intent-outcomes-and-the-path-back.md
+++ b/docs/adr/0013-intent-outcomes-and-the-path-back.md
@@ -1,0 +1,44 @@
+# An Intent that cannot apply is absorbed or rejected, not simply failed
+
+An Intent arrives at the Shelf some time after the person who created it has gone, so what
+happens when it does not fit matters more than it would in a request-response design. We had
+deferred this; ADR 0010 made it urgent by pointing out that a duplicate caught at apply time
+is the common case rather than an edge one.
+
+Treating every Intent that does not apply verbatim as a failure would generate human work on
+the most frequent path in the system. So an Intent has three terminal outcomes rather than
+two:
+
+- **Applied** - the Shelf changed as the Intent asked.
+- **Absorbed** - the Library already satisfied the Intent. An add-intent for a Book already
+  held is the ordinary case: the person wanted the Book in their Library and it is. The
+  outcome carries the Libris ID the Intent turned out to mean, so the replica corrects
+  itself rather than staying wrong.
+- **Rejected** - the Intent could not apply and a person has to decide. This is narrow by
+  design: an update-intent naming a Libris ID the Shelf no longer holds, or an Intent
+  carrying a value the Library does not accept.
+
+An add-intent that duplicates a held Book *and* carries fields the note contradicts is
+absorbed, not rejected. An Intent names only the fields it changes, so applying those fields
+to the note it turned out to mean is precisely what it asked for. We considered rejecting
+this case to stop a stale Surface overwriting the Shelf, and rejected that: it reintroduces
+conflict resolution, which ADR 0002 removes from the design deliberately.
+
+Rejections reach the person through the Vault. `libris sync` runs unattended as a Scheduled
+Task, so `typer.echo` reaches nobody, and the person is by construction somewhere else -
+that is why the remote exists. Sync therefore rewrites a single Libris-owned note next to
+the Shelf, in the folder the Shelf sits in rather than in the Shelf itself, listing what did
+not apply and why. Obsidian Sync is on, so it is on the phone within minutes with no
+infrastructure, and it is actionable where it lands: the fix for a dead Libris ID is to edit
+the Book Note in Obsidian, which writes straight to the Shelf.
+
+Two consequences worth stating. The note is a rendering, not a store - the remote stays
+authoritative for Intent state, and the note is overwritten each run rather than
+accumulating. And this is the first Markdown file Libris writes that is not a Book Note; it
+must stay outside the Shelf, because `list_books` scans the Shelf directory and the Bases
+view reads what it returns.
+
+We rejected leaving rejections on the remote for a Surface to display when next opened. The
+extension popup is a capture UI opened while buying a book, not an inbox, so a rejection
+could sit unseen for months - the same silent wrongness ADR 0003 refuses. A push channel
+reaches the person faster and remains open as an addition once workstream 4 exists.

--- a/docs/adr/0014-merged-ids-leave-a-forwarding-address.md
+++ b/docs/adr/0014-merged-ids-leave-a-forwarding-address.md
@@ -1,0 +1,24 @@
+# A merged-away Libris ID leaves a forwarding address on the survivor
+
+Merging two Book Notes destroys one of them. Until now the loser's Libris ID went with it:
+`merge.py` deleted the file and nothing recorded what the note had become. That was harmless
+while the Shelf was the only replica, because no other Surface had ever seen the ID.
+
+It stops being harmless once Intents exist. A person marks a book Read from their phone; the
+desktop merges that book's duplicate before sync runs, and the note they referred to is the
+one that lost. Sync would then reject an Intent for a note Libris itself destroyed, and could
+not even say what it became.
+
+So the surviving note carries the IDs it superseded, as a `superseded_ids` list in its
+frontmatter. An Intent naming a superseded ID resolves to the survivor and applies normally.
+Matching stays a separate, fuzzy judgement (ADR 0001); this is identity, and it is exact.
+
+The forwarding address lives in the Shelf rather than in a tombstone file beside it, because
+a second store would be state that has to be kept in step with the notes - the situation
+ADR 0002 exists to avoid. Keeping it in frontmatter means it travels with the note through
+sync, backup, and any future replica, at the cost of one more field in the canonical schema
+and a vault index that has to look through it.
+
+A note that is deleted in Obsidian rather than merged leaves nothing behind, and an Intent
+naming it is rejected. That is correct: Libris did not cause it and cannot know what was
+meant.

--- a/docs/adr/0015-sync-detects-change-by-content-hash.md
+++ b/docs/adr/0015-sync-detects-change-by-content-hash.md
@@ -1,0 +1,41 @@
+# Sync detects change by content hash, in a per-machine state file
+
+Sync has to know which Book Notes changed since last time. We measured the Shelf rather than
+reasoning about it, and the measurements decided this.
+
+All 3,136 notes carry the same mtime: the migration rewrote every one of them in a single
+pass. That is not a one-off. `clean --rename` would touch 132 files, `autoenrich` touches
+whatever it enriches, and a restore from `local-backup` would touch everything. mtime on this
+Shelf is not a weak signal, it is an absent one - and it can never detect a deletion, because
+a file that is gone has no timestamp to compare.
+
+Reading and hashing all 3,136 notes takes 2.54 seconds against 4.6 MB. With sync running
+every thirty minutes there is no performance case for cleverness, so there is no mtime
+prefilter and no incremental cache to go stale: every run hashes the whole Shelf.
+
+The state file maps Libris ID to content hash and lives in `~/.config/libris/` beside
+`config.yaml`. Keyed by ID rather than path, because paths move - `clean --rename` alone
+moves 132 of them - and surviving exactly that is what a Libris ID is for (ADR 0001). Kept
+outside the Vault, because it is per-machine state: in the Vault it would sync to the phone
+and land in every backup to no purpose. If it is lost, the next run pushes everything and
+repairs it.
+
+Pushing the whole Shelf every run was the alternative that needed no detection at all. It was
+rejected on cost rather than principle: 4.6 MB and roughly 150,000 Cosmos writes a day to
+transmit nothing, on a serverless account billed per request.
+
+## Deletions
+
+Because deletions are now detectable, they need a meaning. A Book Note that leaves the Shelf
+has its remote document deleted: the remote is a replica and the Shelf is the source of truth
+(ADR 0002), so a book that is not in the Library should not be answerable from it. A query for
+the dead ID misses, which is what ADR 0003 says a miss should do.
+
+A merged-away ID is not a deletion in this sense. The survivor's document carries its
+`superseded_ids` (ADR 0014) and is pushed in the same run, so the remote can still answer for
+the old ID without keeping a tombstone of its own.
+
+Sync refuses to propagate deletions when the count is implausible or the Shelf scans empty; it
+stops and reports instead. An unmounted drive or a half-finished Obsidian Sync would otherwise
+present as 3,136 deletions and empty the remote Library, which is too much to lose to save a
+conditional.

--- a/docs/adr/0015-sync-detects-change-by-content-hash.md
+++ b/docs/adr/0015-sync-detects-change-by-content-hash.md
@@ -13,12 +13,12 @@ Reading and hashing all 3,136 notes takes 2.54 seconds against 4.6 MB. With sync
 every thirty minutes there is no performance case for cleverness, so there is no mtime
 prefilter and no incremental cache to go stale: every run hashes the whole Shelf.
 
-The state file maps Libris ID to content hash and lives in `~/.config/libris/` beside
-`config.yaml`. Keyed by ID rather than path, because paths move - `clean --rename` alone
-moves 132 of them - and surviving exactly that is what a Libris ID is for (ADR 0001). Kept
-outside the Vault, because it is per-machine state: in the Vault it would sync to the phone
-and land in every backup to no purpose. If it is lost, the next run pushes everything and
-repairs it.
+The state file maps Libris ID to content hash and lives in Libris's config directory (the
+same directory as `config.yaml`, honoring `$LIBRIS_CONFIG_DIR` when set). Keyed by ID rather
+than path, because paths move - `clean --rename` alone moves 132 of them - and surviving
+exactly that is what a Libris ID is for (ADR 0001). Kept outside the Vault, because it is
+per-machine state: in the Vault it would sync to the phone and land in every backup to no
+purpose. If it is lost, the next run pushes everything and repairs it.
 
 Pushing the whole Shelf every run was the alternative that needed no detection at all. It was
 rejected on cost rather than principle: 4.6 MB and roughly 150,000 Cosmos writes a day to

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -61,8 +61,8 @@ Two live consequences, both caused by that:
 Extract matching and note-writing into a shared service layer (#53), then put adapters over
 it. Both candidate adapters need no infrastructure, and the order is settled:
 
-1. `matching.py`, extracted from `cli.py` on its own. Both adapters need it and neither can
-   be built well without it.
+1. `matching.py`, extracted from `cli.py` on its own (#63). Both adapters need it and
+   neither can be built well without it.
 2. `libris serve` on loopback plus the Edge extension (#52, #53, #54, #55). Already
    specified, and the adapter with the stronger duplicate guarantee (ADR 0010).
 3. `search_books` / `add_book` / `update_book` over stdio MCP, driven from Claude Code.
@@ -88,10 +88,10 @@ ID, and deletions propagate behind a refusal guard (ADR 0015).
 Carried forward into this workstream from those decisions:
 
 - `merge.py` records `superseded_ids` on the surviving note instead of deleting the loser
-  without trace (ADR 0014). The field must exist before the remote does; no Libris ID has
+  without trace (ADR 0014, #64). The field must exist before the remote does; no Libris ID has
   reached a remote yet, so merging today's three duplicate groups loses nothing.
-- Nothing validates `status` today - `markdown.py` defaults it to "To Read" and never checks
-  the value - so an Intent could write a value outside the four the Library allows. Rejecting
+- Nothing validates `status` today (#65) - `markdown.py` defaults it to "To Read" and never
+  checks the value - so an Intent could write a value outside the four the Library allows. Rejecting
   an Intent for an illegal value needs that validation to exist.
 
 ## 4. Infrastructure

--- a/docs/workstreams.md
+++ b/docs/workstreams.md
@@ -59,18 +59,40 @@ Two live consequences, both caused by that:
 ## 2. Service layer and its first adapters
 
 Extract matching and note-writing into a shared service layer (#53), then put adapters over
-it. Two candidates, both needing no infrastructure, ordering not yet settled:
+it. Both candidate adapters need no infrastructure, and the order is settled:
 
-- `libris serve` on loopback plus the Edge extension (#51, #52, #53) — already specified,
-  and the adapter with the stronger duplicate guarantee (ADR 0010)
-- `search_books` / `add_book` / `update_book` over stdio MCP, driven from Claude Code — where
-  the resolution design risk lives (ADR 0003, ADR 0007)
+1. `matching.py`, extracted from `cli.py` on its own. Both adapters need it and neither can
+   be built well without it.
+2. `libris serve` on loopback plus the Edge extension (#52, #53, #54, #55). Already
+   specified, and the adapter with the stronger duplicate guarantee (ADR 0010).
+3. `search_books` / `add_book` / `update_book` over stdio MCP, driven from Claude Code.
+
+Chosen for momentum: the daemon and its endpoints are specified down to the test list, so a
+session starts on implementation rather than on a spec. The accepted cost is that the
+resolution design (ADR 0003) — search returns candidates carrying Libris IDs, and a
+confidence threshold was rejected — stays unvalidated against the real Shelf until the MCP
+adapter lands, and workstreams 3-5 lean on it.
+
+Neither adapter records Intents. Both write straight to the Shelf, so an Intent that cannot
+apply is a workstream 3 problem, not a workstream 2 one.
 
 ## 3. Sync
 
 `libris sync`, the Intent protocol, the Scheduled Task (ADR 0002).
 
-Open: what happens to an Intent that cannot apply, and how sync detects changed notes.
+Both questions left open here are now settled. An Intent that cannot apply is absorbed or
+rejected, and rejections come back through a Libris-owned note next to the Shelf (ADR 0013).
+Sync detects change by hashing every note against a per-machine state file keyed on Libris
+ID, and deletions propagate behind a refusal guard (ADR 0015).
+
+Carried forward into this workstream from those decisions:
+
+- `merge.py` records `superseded_ids` on the surviving note instead of deleting the loser
+  without trace (ADR 0014). The field must exist before the remote does; no Libris ID has
+  reached a remote yet, so merging today's three duplicate groups loses nothing.
+- Nothing validates `status` today - `markdown.py` defaults it to "To Read" and never checks
+  the value - so an Intent could write a value outside the four the Library allows. Rejecting
+  an Intent for an illegal value needs that validation to exist.
 
 ## 4. Infrastructure
 


### PR DESCRIPTION
Three decisions were deferred rather than made — recorded as open items in `docs/workstreams.md`, with ADR 0010 flagging one of them as urgent rather than theoretical. All three are now settled, along with two sub-decisions they forced once examined.

No code changes. This is the reference the workstream 2 and 3 implementation will lean on, so it is worth reading before it becomes load-bearing.

## What was decided

**ADR 0013 — an Intent has three terminal outcomes, not two.** Treating everything that does not apply verbatim as a failure would generate human work on the most frequent path in the system. So: `applied`, `absorbed` (the Library already satisfied it, and the outcome carries the Libris ID it turned out to mean, so the replica self-corrects), and `rejected` (narrow by design — a dead Libris ID, or a value the Library does not accept).

An add-intent that duplicates a held Book *and* contradicts its fields is absorbed, not rejected. Rejecting it would reintroduce conflict resolution, which ADR 0002 removes from the design deliberately.

Rejections reach the person through the Vault. `libris sync` runs unattended as a Scheduled Task, so `typer.echo` reaches nobody, and the person is by construction somewhere else — that is why the remote exists. Sync rewrites a Libris-owned note next to the Shelf; Obsidian Sync carries it to the phone within minutes, and it is actionable where it lands. We rejected leaving rejections on the remote for a Surface to display: the extension popup is a capture UI opened while buying a book, not an inbox, and a rejection could sit unseen for months — the same silent wrongness ADR 0003 refuses.

**ADR 0014 — a merged-away Libris ID leaves a forwarding address.** `merge.py` currently has no knowledge of `libris_id`; `delete_secondary_file` removes the loser and its ULID disappears with no trace. Once Intents exist, that means Libris rejecting an Intent for a note it destroyed itself, unable to say what it became. The survivor now carries `superseded_ids`. It lives in frontmatter rather than a tombstone file beside the Shelf, because a second store is state that has to be kept in step with the notes — the situation ADR 0002 exists to avoid.

**ADR 0015 — sync detects change by content hash.** Decided by measuring the real Shelf rather than reasoning about it:

- All 3,136 notes carry the same mtime, because the migration rewrote every one of them. Not a one-off either: `clean --rename` would touch 132 files, `autoenrich` touches whatever it enriches, a restore from backup touches everything. mtime here is not a weak signal, it is an absent one — and it can never detect a deletion.
- Reading and hashing the entire Shelf takes **2.54 seconds** against 4.6 MB. With sync every thirty minutes there is no performance case for an mtime prefilter or an incremental cache to go stale.

So: a per-machine state file in `~/.config/libris/`, mapping Libris ID to content hash, fully recomputed each run. Keyed on ID rather than path because paths move — `clean --rename` alone moves 132 — and surviving that is what a Libris ID is for. Outside the Vault, because it is machine-local state. If lost, one full push repairs it.

Pushing everything every run was rejected on cost: roughly 150,000 Cosmos writes a day to transmit nothing, on an account billed per request.

Deletions propagate, behind a refusal guard. An unmounted drive or a half-finished Obsidian Sync presents as 3,136 deletions, and emptying the remote Library is too much to lose to save a conditional.

**Workstream 2 adapter order.** `matching.py`, then `libris serve` plus the extension, then stdio MCP. Chosen for momentum — the daemon and its endpoints are specified down to the test list. The accepted cost, stated plainly in the doc: the ADR 0003 resolution design stays unvalidated against the real Shelf until the MCP adapter lands, and workstreams 3–5 lean on it.

## Glossary

`CONTEXT.md` gains **Intent Outcome** and **Superseded ID**.

## Issues filed

- #63 — extract `matching.py`, split out of #53 so the refactor lands as a behaviour-preserving change the existing suite validates unchanged. #53 is now endpoints only and depends on it.
- #64 — `superseded_ids` on merge (ADR 0014). No Libris ID has reached a remote yet, so merging the three known duplicate groups today loses nothing; the field only has to exist before the remote does.
- #65 — nothing validates `status`, `priority` or `format`. ADR 0013 cannot reject an Intent for an illegal value until this exists, and `POST /books` in #53 accepts `status` from a browser extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
