### PR TITLE
refactor: extract matching helpers into matching.py

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -12,7 +12,7 @@ from .config import (
     set_book_vault_path,
     set_config,
 )
-from .importer import SUPPORTED_FORMATS, normalize_for_match, run_import
+from .importer import SUPPORTED_FORMATS, run_import
 from .markdown import (
     BookNote,
     RenameResult,
@@ -24,6 +24,13 @@ from .markdown import (
     rename_book_file,
     update_book_status,
     update_frontmatter_from_book,
+)
+from .matching import (
+    best_match,
+    build_search_query,
+    metadata_score,
+    normalize_for_match,
+    titles_match,
 )
 from .merge import (
     check_auto_merge,
@@ -424,44 +431,14 @@ def cleanup(
             typer.echo(f"  • {name}")
 
 
-def _normalize_for_match(text: str) -> str:
-    """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace.
-
-    Delegates to the shared implementation in importer module.
-    """
-    return normalize_for_match(text)
-
-
-def _build_search_query(filename_stem: str) -> str:
-    """Build an effective Google Books search query from a filename stem.
-
-    Handles common filename patterns like:
-      - "Title - Author"
-      - "Title Subtitle - Author"
-
-    Splits on " - " to separate title from author, then uses Google Books
-    query operators (intitle:/inauthor:) for more precise results.
-    If no separator is found, returns the stem as-is.
-    """
-    parts = filename_stem.split(" - ", maxsplit=1)
-    if len(parts) == 2:
-        title_part = parts[0].strip()
-        author_part = parts[1].strip()
-        return f"intitle:{title_part} inauthor:{author_part}"
-    return filename_stem
-
-
-def _titles_match(filename_stem: str, book_title: str) -> bool:
-    """Check if a Google Books title fuzzy-matches the filename stem.
-
-    Returns True if the normalized filename stem is contained within the
-    normalized book title, or vice versa.
-    """
-    norm_file = _normalize_for_match(filename_stem)
-    norm_title = _normalize_for_match(book_title)
-    if not norm_file or not norm_title:
-        return False
-    return norm_file in norm_title or norm_title in norm_file
+# Thin re-exports of the shared matching helpers (#63). The private names are
+# what this module's call sites and tests already use; the implementations live
+# in matching.py because every adapter needs them, not just the CLI.
+_normalize_for_match = normalize_for_match
+_build_search_query = build_search_query
+_titles_match = titles_match
+_metadata_score = metadata_score
+_best_match = best_match
 
 
 def _enrich_auto(file_path: Path, unmatched_log: list[str]) -> bool:
@@ -604,36 +581,6 @@ def _needs_enrichment(fm: dict) -> bool:
     earlier enrichment.
     """
     return not any(fm.get(f) for f in _API_SOURCED_FIELDS)
-
-
-# Fields counted when ranking which edition has the most complete metadata.
-_COMPLETENESS_FIELDS = (
-    "isbn",
-    "page_count",
-    "published_date",
-    "google_books_id",
-    "thumbnail",
-    "genres",
-    "description",
-)
-
-
-def _metadata_score(book) -> int:
-    """Count how many metadata fields are non-empty on a BookCandidate."""
-    score = 0
-    for field in _COMPLETENESS_FIELDS:
-        val = getattr(book, field, None)
-        if val:
-            # Lists/strings: only count if non-empty
-            if isinstance(val, (list, str)) and len(val) == 0:
-                continue
-            score += 1
-    return score
-
-
-def _best_match(candidates: list) -> object:
-    """Pick the candidate with the most complete metadata."""
-    return max(candidates, key=_metadata_score)
 
 
 def _build_query_from_frontmatter(fm: dict, file_path: Path) -> str:

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -15,12 +15,7 @@ from .markdown import (
     list_books,
     update_book_status,
 )
-
-
-def normalize_for_match(text: str) -> str:
-    """Normalize text for fuzzy comparison: lowercase, strip punctuation/extra whitespace."""
-    text = re.sub(r"[^\w\s]", " ", text.lower())
-    return re.sub(r"\s+", " ", text).strip()
+from .matching import normalize_for_match
 
 
 @dataclass

--- a/src/libris/matching.py
+++ b/src/libris/matching.py
@@ -1,0 +1,128 @@
+"""Deciding which Book Candidate a reference means.
+
+Matching is the fuzzy judgement behind duplicate detection, import
+de-duplication and enrichment: whether two descriptions of a book describe the
+same book. It is deliberately separate from identity, which is exact and lives
+in the Libris ID (ADR 0001).
+
+These helpers were private to cli.py until #63. Every adapter in workstream 2
+needs them - the `libris serve` endpoints first, the MCP tools after - and none
+of them should reach into the CLI module to get them.
+"""
+
+import re
+
+from .api import BookCandidate
+
+# Fields counted when ranking which edition has the most complete metadata.
+COMPLETENESS_FIELDS = (
+    "isbn",
+    "page_count",
+    "published_date",
+    "google_books_id",
+    "thumbnail",
+    "genres",
+    "description",
+)
+
+
+def normalize_for_match(text: str) -> str:
+    """Normalize text for fuzzy comparison.
+
+    Lowercases, replaces punctuation with whitespace, and collapses runs of
+    whitespace. Punctuation becomes a space rather than being deleted, so
+    "Book:One" and "Book One" normalize alike.
+
+    Args:
+        text: The text to normalize.
+
+    Returns:
+        The normalized text, which may be empty if the input held no word
+        characters.
+    """
+    text = re.sub(r"[^\w\s]", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def build_search_query(filename_stem: str) -> str:
+    """Build a Google Books search query from a filename stem.
+
+    Handles the "Title - Author" and "Title Subtitle - Author" shapes the Shelf
+    uses, turning them into `intitle:`/`inauthor:` operators so the search is
+    constrained by author rather than title alone. Splits on the first " - "
+    only, so a title containing a separator keeps everything after it as the
+    author.
+
+    Args:
+        filename_stem: A Book Note's filename without its extension.
+
+    Returns:
+        A query string, or the stem unchanged when it holds no separator.
+    """
+    parts = filename_stem.split(" - ", maxsplit=1)
+    if len(parts) == 2:
+        title_part = parts[0].strip()
+        author_part = parts[1].strip()
+        return f"intitle:{title_part} inauthor:{author_part}"
+    return filename_stem
+
+
+def titles_match(filename_stem: str, book_title: str) -> bool:
+    """Check whether a Book Candidate's title fuzzily matches a filename stem.
+
+    True when either normalized string contains the other, which tolerates the
+    subtitle a candidate carries and the filename does not.
+
+    Args:
+        filename_stem: A Book Note's filename without its extension.
+        book_title: The title a Book Candidate proposes.
+
+    Returns:
+        True if the two plausibly describe the same book. False if either
+        normalizes to empty, since empty is contained in everything and would
+        otherwise match indiscriminately.
+    """
+    norm_file = normalize_for_match(filename_stem)
+    norm_title = normalize_for_match(book_title)
+    if not norm_file or not norm_title:
+        return False
+    return norm_file in norm_title or norm_title in norm_file
+
+
+def metadata_score(book: BookCandidate) -> int:
+    """Count how many of the completeness fields a Book Candidate populates.
+
+    A proxy for which edition is best described, used to choose between
+    candidates that all match the same book.
+
+    Args:
+        book: The candidate to score.
+
+    Returns:
+        The number of populated fields, between zero and the length of
+        COMPLETENESS_FIELDS.
+    """
+    score = 0
+    for field in COMPLETENESS_FIELDS:
+        if getattr(book, field, None):
+            score += 1
+    return score
+
+
+def best_match(candidates: list[BookCandidate]) -> BookCandidate:
+    """Pick the Book Candidate with the most complete metadata.
+
+    Ties keep the earliest candidate, preserving the order the source ranked
+    them in.
+
+    Args:
+        candidates: The candidates to choose between. Must not be empty.
+
+    Returns:
+        The candidate with the highest metadata score.
+
+    Raises:
+        ValueError: If `candidates` is empty. Callers check for no results
+            before choosing between them.
+    """
+    return max(candidates, key=metadata_score)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,232 @@
+"""Tests for the shared matching helpers.
+
+These cover the behaviour every adapter in workstream 2 depends on, lifted out
+of cli.py by #63. The move is meant to preserve behaviour exactly, so these
+assert what the helpers did in cli.py rather than what they arguably should do.
+"""
+
+import pytest
+
+from libris.api import BookCandidate
+from libris.matching import (
+    best_match,
+    build_search_query,
+    metadata_score,
+    normalize_for_match,
+    titles_match,
+)
+
+
+def _candidate(**overrides) -> BookCandidate:
+    """Build a BookCandidate with only the fields a test cares about."""
+    fields = {"title": "Dune", "authors": ["Frank Herbert"]}
+    fields.update(overrides)
+    return BookCandidate(**fields)
+
+
+# --- normalize_for_match ---
+
+
+def test_normalize_lowercases_and_collapses_whitespace():
+    # Given text with mixed case and irregular spacing
+    text = "  The   Way OF Kings  "
+
+    # When it is normalized
+    result = normalize_for_match(text)
+
+    # Then case is flattened and runs of whitespace become single spaces
+    assert result == "the way of kings"
+
+
+def test_normalize_replaces_punctuation_with_spaces():
+    # Given a title carrying punctuation
+    text = "It's a Test: Book #1"
+
+    # When it is normalized
+    result = normalize_for_match(text)
+
+    # Then punctuation becomes whitespace rather than being deleted
+    assert result == "it s a test book 1"
+
+
+def test_normalize_of_punctuation_only_text_is_empty():
+    # Given text with nothing but punctuation
+    text = "--- !!! ---"
+
+    # When it is normalized
+    result = normalize_for_match(text)
+
+    # Then the result is empty, which callers treat as unmatchable
+    assert result == ""
+
+
+# --- build_search_query ---
+
+
+def test_build_search_query_splits_title_from_author():
+    # Given a filename stem in "Title - Author" form
+    stem = "Dune - Frank Herbert"
+
+    # When a query is built
+    query = build_search_query(stem)
+
+    # Then title and author become separate Google Books operators
+    assert query == "intitle:Dune inauthor:Frank Herbert"
+
+
+def test_build_search_query_splits_only_on_the_first_separator():
+    # Given a stem whose title itself contains " - "
+    stem = "Leviathan Wakes - Book 1 - James S. A. Corey"
+
+    # When a query is built
+    query = build_search_query(stem)
+
+    # Then everything after the first separator is treated as the author
+    assert query == "intitle:Leviathan Wakes inauthor:Book 1 - James S. A. Corey"
+
+
+def test_build_search_query_without_a_separator_returns_the_stem():
+    # Given a stem with no " - " separator
+    stem = "Poems"
+
+    # When a query is built
+    query = build_search_query(stem)
+
+    # Then the stem is used as-is, with no operators
+    assert query == "Poems"
+
+
+# --- titles_match ---
+
+
+def test_titles_match_when_the_stem_is_contained_in_the_title():
+    # Given a filename stem that is a prefix of the candidate's fuller title
+    # When the two are compared
+    # Then they match
+    assert titles_match("Dune", "Dune: Deluxe Edition") is True
+
+
+def test_titles_match_when_the_title_is_contained_in_the_stem():
+    # Given a stem carrying more than the candidate's title does
+    # When the two are compared
+    # Then containment in either direction counts as a match
+    assert titles_match("Dune Messiah Special", "Dune Messiah") is True
+
+
+def test_titles_match_ignores_case_and_punctuation():
+    # Given the same title differing only in case and punctuation
+    # When the two are compared
+    # Then normalization makes them match
+    assert titles_match("the hobbit", "The Hobbit!") is True
+
+
+def test_titles_do_not_match_when_unrelated():
+    # Given two unrelated titles
+    # When they are compared
+    # Then they do not match
+    assert titles_match("Dune", "Neuromancer") is False
+
+
+def test_titles_do_not_match_when_either_normalizes_to_empty():
+    # Given a stem that is nothing but punctuation
+    # When it is compared against a real title
+    # Then it does not match, rather than matching everything by empty containment
+    assert titles_match("...", "Dune") is False
+    assert titles_match("Dune", "...") is False
+
+
+# --- metadata_score ---
+
+
+def test_metadata_score_counts_populated_fields():
+    # Given a candidate with three of the counted fields populated
+    candidate = _candidate(isbn="9780441013593", page_count=412, description="A desert.")
+
+    # When it is scored
+    score = metadata_score(candidate)
+
+    # Then each populated field contributes one point
+    assert score == 3
+
+
+def test_metadata_score_ignores_empty_values():
+    # Given a candidate whose counted fields are empty rather than absent
+    candidate = _candidate(isbn="", page_count=0, genres=[], description=None)
+
+    # When it is scored
+    score = metadata_score(candidate)
+
+    # Then nothing empty is counted
+    assert score == 0
+
+
+def test_metadata_score_ignores_uncounted_fields():
+    # Given a candidate populated only in fields outside the completeness set
+    candidate = _candidate(title="Dune", authors=["Frank Herbert"], source="audible")
+
+    # When it is scored
+    score = metadata_score(candidate)
+
+    # Then title, authors and source do not contribute
+    assert score == 0
+
+
+# --- best_match ---
+
+
+def test_best_match_picks_the_most_complete_candidate():
+    # Given three candidates of differing completeness
+    sparse = _candidate(isbn="1")
+    rich = _candidate(isbn="2", page_count=412, genres=["SF"], description="A desert.")
+    middling = _candidate(isbn="3", page_count=412)
+
+    # When the best is chosen
+    chosen = best_match([sparse, rich, middling])
+
+    # Then the one with the most populated metadata fields wins
+    assert chosen is rich
+
+
+def test_best_match_returns_the_first_of_an_equal_scoring_tie():
+    # Given two candidates scoring identically
+    first = _candidate(isbn="1")
+    second = _candidate(isbn="2")
+
+    # When the best is chosen
+    chosen = best_match([first, second])
+
+    # Then the earlier candidate wins, preserving the API's own ranking
+    assert chosen is first
+
+
+def test_best_match_on_an_empty_list_raises():
+    # Given no candidates at all
+    # When the best is chosen
+    # Then it raises rather than inventing a result; callers guard for emptiness
+    with pytest.raises(ValueError):
+        best_match([])
+
+
+# --- re-exports ---
+
+
+def test_cli_re_exports_the_same_objects():
+    # Given cli.py keeps thin re-exports so existing call sites are untouched
+    from libris import cli
+
+    # When the re-exported names are resolved
+    # Then they are the very functions defined in matching, not copies
+    assert cli._normalize_for_match is normalize_for_match
+    assert cli._build_search_query is build_search_query
+    assert cli._titles_match is titles_match
+    assert cli._metadata_score is metadata_score
+    assert cli._best_match is best_match
+
+
+def test_importer_re_exports_the_same_normalizer():
+    # Given importer.normalize_for_match is imported by existing tests
+    from libris import importer
+
+    # When the name is resolved
+    # Then it is the shared implementation rather than a second one
+    assert importer.normalize_for_match is normalize_for_match

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -140,7 +140,9 @@ def test_titles_do_not_match_when_either_normalizes_to_empty():
 
 def test_metadata_score_counts_populated_fields():
     # Given a candidate with three of the counted fields populated
-    candidate = _candidate(isbn="9780441013593", page_count=412, description="A desert.")
+    candidate = _candidate(
+        isbn="9780441013593", page_count=412, description="A desert."
+    )
 
     # When it is scored
     score = metadata_score(candidate)


### PR DESCRIPTION
Closes #63. Unblocks #53.

Ranking and matching lived as private functions in `cli.py`. Every adapter in workstream 2 needs them — the `libris serve` endpoints first, the MCP tools after — and none of them should reach into the CLI module to get them.

Split out of #53 deliberately, so the refactor lands as a change the existing suite validates unchanged and the new HTTP surface arrives separately. A behaviour difference cannot hide inside a diff that adds no behaviour.

## What moved

`metadata_score`, `best_match`, `normalize_for_match`, `titles_match` and `build_search_query` now live in `src/libris/matching.py`, typed and documented. `cli.py` keeps thin re-exports under the old private names, so its call sites and every existing test are untouched — `cli.py` loses 85 lines and gains an import.

**No test file is modified by this PR.** The suite went 185 → 204; all 19 additions are new tests in `tests/test_matching.py`.

## Two things the issue got wrong, and one dead branch

**There was no duplicate `normalize_for_match` to consolidate.** #63 asked for the two implementations to be compared before collapsing, on the basis that a difference would be live behaviour somewhere. There is only one: `cli._normalize_for_match` was already a delegating wrapper around `importer.normalize_for_match`, consolidated during #62. So `importer.py` now imports the shared implementation and `cli.py` aliases it, and nothing had to be reconciled.

**`metadata_score` loses dead code.** It read:

```python
if val:
    # Lists/strings: only count if non-empty
    if isinstance(val, (list, str)) and len(val) == 0:
        continue
    score += 1
```

The `if val:` has already excluded every empty list and string before the inner check runs, so that branch cannot execute. It is gone.

This is the only function whose body changed, so rather than rely on reading it I checked it exhaustively: **972 combinations** — every falsy and truthy shape each of the seven counted fields can hold — old implementation against new, **zero mismatches**.

**`_COMPLETENESS_FIELDS` is not another `_API_SOURCED_FIELDS`.** It names `published_date` and `thumbnail`, which read like the frontmatter drift #62 undid. They are not: these are read with `getattr` against `BookCandidate`, which really does carry both. Checked, because that bug class is why this refactor exists.

## Verification against the real Shelf

All 3,136 Book Note filenames through the moved helpers: 3,127 produce `intitle:`/`inauthor:` queries, 9 are bare stems with no ` - ` separator, none normalize to empty, all match themselves.

`uv run ruff check .` clean. `uv run python -m pytest` — 204 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
