### PR TITLE
docs: settle the daemon's URL shape and write response

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,12 @@ agent. Only the CLI writes to the Shelf; every other Surface reaches the Library
 the remote replica.
 _Avoid_: client, front end
 
+**Duplicate Guarantee**:
+What a Surface's duplicate check was made against: the live Shelf, or a replica no fresher than
+the last sync. Every write states which one it gave, so a Surface can say "added" or "queued"
+truthfully rather than guessing.
+_Avoid_: freshness, confidence
+
 **Intent**:
 A change to the Library recorded by a Surface and applied to the Shelf later by the CLI —
 either adding a Book Note or setting named fields on an existing one. An Intent names only

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,8 +64,8 @@ _Avoid_: client, front end
 
 **Duplicate Guarantee**:
 What a Surface's duplicate check was made against: the live Shelf, or a replica no fresher than
-the last sync. Every write states which one it gave, so a Surface can say "added" or "queued"
-truthfully rather than guessing.
+the last sync. Every add attempt states which one it gave, so a Surface can say "added" or
+"queued" truthfully rather than guessing.
 _Avoid_: freshness, confidence
 
 **Intent**:

--- a/docs/adr/0008-two-adapters-over-one-service-layer.md
+++ b/docs/adr/0008-two-adapters-over-one-service-layer.md
@@ -21,3 +21,14 @@ view are additive over the same service layer.
 Extended by ADR 0010: there are three adapters, not two. The Edge extension (#51) reaches
 the same service layer over a local daemon, and the count here was taken before that plan
 was known.
+
+The `/api/v1` prefix was revisited when #53 turned out to specify bare paths, and kept. A query
+parameter cannot be routed on, so two versions would share a handler body and the version would
+sit in the same namespace as the query data. A header keeps URLs clean but makes a hand-typed
+curl diverge from what the extension receives, on a daemon meant to be debugged by hand.
+Dropping versioning altogether was the tempting option, since ADR 0004 makes this single-tenant
+and the many-clients-pinned-at-many-versions problem will never arrive here - but the client is
+a browser extension that updates through a store on its own schedule, so a daemon briefly
+serving an old extension and a new one is normal rather than exceptional. A router prefix costs
+nothing to carry, and it is what makes ADR 0010's base-URL swap a configuration change rather
+than a rewrite: the paths after the base URL have to be identical on both adapters.

--- a/docs/adr/0008-two-adapters-over-one-service-layer.md
+++ b/docs/adr/0008-two-adapters-over-one-service-layer.md
@@ -22,13 +22,14 @@ Extended by ADR 0010: there are three adapters, not two. The Edge extension (#51
 the same service layer over a local daemon, and the count here was taken before that plan
 was known.
 
-The `/api/v1` prefix was revisited when #53 turned out to specify bare paths, and kept. A query
-parameter cannot be routed on, so two versions would share a handler body and the version would
-sit in the same namespace as the query data. A header keeps URLs clean but makes a hand-typed
-curl diverge from what the extension receives, on a daemon meant to be debugged by hand.
-Dropping versioning altogether was the tempting option, since ADR 0004 makes this single-tenant
-and the many-clients-pinned-at-many-versions problem will never arrive here - but the client is
-a browser extension that updates through a store on its own schedule, so a daemon briefly
-serving an old extension and a new one is normal rather than exceptional. A router prefix costs
-nothing to carry, and it is what makes ADR 0010's base-URL swap a configuration change rather
-than a rewrite: the paths after the base URL have to be identical on both adapters.
+The `/api/v1` prefix was revisited when #53 turned out to specify bare paths, and kept. A
+query parameter cannot be routed on, so two versions would share a handler body and the
+version would sit in the same namespace as the query data. A header keeps URLs clean but
+makes a hand-typed curl diverge from what the extension receives, on a daemon meant to be
+debugged by hand. Dropping versioning altogether was the tempting option, since ADR 0004
+makes this single-tenant and the many-clients-pinned-at-many-versions problem will never
+arrive here — but the client is a browser extension that updates through a store on its own
+schedule, so a daemon briefly serving an old extension and a new one is normal rather than
+exceptional. A router prefix costs nothing to carry, and it is what makes ADR 0010's
+base-URL swap a configuration change rather than a rewrite: the paths after the base URL
+have to be identical on both adapters.

--- a/docs/adr/0016-writes-answer-with-identity-and-guarantee.md
+++ b/docs/adr/0016-writes-answer-with-identity-and-guarantee.md
@@ -1,0 +1,25 @@
+# A write answers with identity, an outcome, and the guarantee behind it
+
+#53 specified `POST /books` as returning a path and an `already_exists` flag. Both halves are
+wrong in ways that only surface later, so the write endpoints answer differently.
+
+**A path is not identity.** `create_book_note` mints a Libris ID and returns only a `Path`, so
+the endpoint as written would have handed the extension the one field that moves and withheld
+the one that does not: `clean --rename` alone would move 132 files, and surviving exactly that
+is what a Libris ID is for (ADR 0001). Every write therefore answers with the `libris_id`. The
+path travels too, but as something to show a person - "added as Dune - Frank Herbert.md" -
+never as a handle to the Book.
+
+**A bare `already_exists` does not say what backs it.** ADR 0010 requires a response to state
+which guarantee it gave. That looks redundant on a daemon which always checks the live Shelf,
+until the extension is repointed at the remote by changing a base URL - which ADR 0010
+promises is all it takes. The same client code then receives a duplicate check no fresher than
+the last sync. If the answer does not carry its own guarantee, the extension has to infer
+freshness from its own configuration, restoring exactly the coupling ADR 0010 removed. So a
+write reports what happened - the Book Note was created, or the Book was already held - and
+which guarantee stands behind it.
+
+The vocabulary deliberately does not reuse ADR 0013's `absorbed`. That word describes an
+Intent: a change recorded by a Surface and applied to the Shelf later by the CLI. The daemon
+writes now, so no Intent exists and nothing is absorbed. Two mechanisms, two vocabularies,
+so the sync protocol stays readable when both are in play.

--- a/docs/adr/0016-writes-answer-with-identity-and-guarantee.md
+++ b/docs/adr/0016-writes-answer-with-identity-and-guarantee.md
@@ -7,7 +7,7 @@ wrong in ways that only surface later, so the write endpoints answer differently
 the endpoint as written would have handed the extension the one field that moves and withheld
 the one that does not: `clean --rename` alone would move 132 files, and surviving exactly that
 is what a Libris ID is for (ADR 0001). Every write therefore answers with the `libris_id`. The
-path travels too, but as something to show a person - "added as Dune - Frank Herbert.md" -
+path travels too, but as something to show a person — "added as Dune - Frank Herbert.md" —
 never as a handle to the Book.
 
 **A bare `already_exists` does not say what backs it.** ADR 0010 requires a response to state


### PR DESCRIPTION
Grilled before implementing #53, and no code changes.

#53 was written before ADRs 0008, 0010 and 0013 existed, and contradicts all three in small ways. Not carelessness — the ADRs came later — but it means the issue text can no longer be read as the spec. These docs settle what it should say, and #53 will be updated to match.

## ADR 0016 — a write answers with identity, an outcome, and the guarantee behind it

#53 specifies `POST /books` as returning "path + `already_exists` flag". Both halves are wrong in ways that only surface later.

**A path is not identity.** `create_book_note` mints a `libris_id` and returns only a `Path`, so the endpoint as specified would hand the extension the one field that moves and withhold the one that doesn't. `clean --rename` alone would move 132 files, and surviving exactly that is what a Libris ID is for (ADR 0001). Every write now answers with the `libris_id`; the path travels too, but as something to show a person, never as a handle to the Book.

**A bare `already_exists` doesn't say what backs it.** ADR 0010 requires a response to state which guarantee it gave. That looks redundant on a daemon that always checks the live Shelf — until the extension is repointed at the remote by changing a base URL, which ADR 0010 promises is all it takes. The same client code then gets a duplicate check no fresher than the last sync. Without the guarantee in the response, the extension has to infer freshness from its own configuration, which restores exactly the coupling ADR 0010 removed.

Deliberately **not** reusing ADR 0013's `absorbed`. That word describes an Intent — a change recorded by a Surface and applied later by the CLI. The daemon writes now, so no Intent exists and nothing is absorbed. Two mechanisms, two vocabularies, so the sync protocol stays readable when both are live.

## ADR 0008 — why `/api/v1` stays a path prefix

Amended rather than re-decided, because the prefix was already there; what was missing is why it beat the alternatives.

A **query parameter** can't be routed on in FastAPI, so two versions would share a handler body — and the version would sit in the same namespace as the query data. A **header** keeps URLs clean but makes a hand-typed curl diverge from what the extension receives, on a daemon meant to be debugged by hand.

**Dropping versioning entirely** was the genuinely tempting option: ADR 0004 makes this single-tenant, so the many-clients-pinned-at-many-versions problem will never arrive. What kills it is that the client is a browser extension updating through a store on its own schedule, so a daemon briefly serving an old extension and a new one is normal rather than exceptional. A router prefix costs nothing to carry, and it's what makes ADR 0010's base-URL swap a configuration change rather than a rewrite — the paths after the base URL have to be identical on both adapters.

## CONTEXT.md

Gains **Duplicate Guarantee**: what a Surface's duplicate check was made against — the live Shelf, or a replica no fresher than the last sync.

## Settled here, but belonging to the issue rather than an ADR

- **#53 depends on #65.** `POST /books` is the first thing accepting field values from off this machine, so an illegal `status` shouldn't be able to reach a Book Note.
- **`POST /books` gets exercised against a copy of the Shelf first.** The whole Shelf is 4.6 MB, so a copy is free and gives the real duplicate groups, the nineteen notes titled "Poems", and the one storing two authors in a comma-joined string — none of which a fixture has. Only then does it write to the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
