### PR TITLE
fix: refuse status and priority values the Library does not define

### DIFF
--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -42,6 +42,7 @@ from .merge import (
     write_merged_book,
 )
 from .migrate import apply_migration, plan_migration
+from .note_format import InvalidFieldValue, validate_field_value
 
 app = typer.Typer()
 
@@ -188,6 +189,14 @@ def add(
     ),
 ):
     """Search for a book and add it to your Obsidian vault."""
+    # Checked before the search, so an invalid status is not reported after a
+    # network round trip and a book picker.
+    try:
+        validate_field_value("status", status)
+    except InvalidFieldValue as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from None
+
     client = GoogleBooksClient()
     books = client.search(query)
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -17,6 +17,7 @@ from .note_format import (
     mint_libris_id,
     render_body,
     render_description_callout,
+    validate_field_value,
 )
 
 # Values a Book Note starts with when nothing else supplies them.
@@ -182,6 +183,8 @@ def create_book_note(
     filename = sanitize_filename(f"{book.title} - {', '.join(book.authors[:1])}.md")
     file_path = vault_path / filename
 
+    validate_field_value("status", status)
+
     added = date.today()
     frontmatter = {
         **DEFAULT_FRONTMATTER,
@@ -205,6 +208,7 @@ def create_book_note(
                     f"Unknown frontmatter field: '{key}'. "
                     f"Valid fields: {', '.join(DEFAULT_FRONTMATTER.keys())}"
                 )
+            validate_field_value(key, value)
             frontmatter[key] = value
 
     yaml_content = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True)
@@ -215,7 +219,12 @@ def create_book_note(
 
 
 def update_book_status(file_path: Path, new_status: str):
-    """Updates the status in the book's frontmatter."""
+    """Updates the status in the book's frontmatter.
+
+    Raises:
+        InvalidFieldValue: If the status is not one the Library defines.
+    """
+    validate_field_value("status", new_status)
     content = file_path.read_text(encoding="utf-8")
 
     # Simple regex to find and replace status

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -183,8 +183,11 @@ def create_book_note(
     filename = sanitize_filename(f"{book.title} - {', '.join(book.authors[:1])}.md")
     file_path = vault_path / filename
 
-    validate_field_value("status", status)
+    if overrides and "status" in overrides:
+        status = overrides["status"]
+        overrides = {k: v for k, v in overrides.items() if k != "status"}
 
+    validate_field_value("status", status)
     added = date.today()
     frontmatter = {
         **DEFAULT_FRONTMATTER,

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -79,7 +79,7 @@ def validate_field_value(field: str, value: object) -> None:
             in it.
     """
     allowed = FIELD_VOCABULARIES.get(field)
-    if allowed is None or value is None or value == "":
+    if allowed is None or value is None:
         return
     if value not in allowed:
         raise InvalidFieldValue(

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -25,6 +25,18 @@ BIBLIOGRAPHIC_FIELDS = (
     "series",
 )
 READING_FIELDS = ("status", "priority", "rating", "format", "tags", "referred_by")
+
+# The values these fields may hold, taken from the vault rather than from what
+# the code used to assume (ADR 0005). Measured across all 3,136 notes: status
+# and priority already hold nothing else. `format` is absent on purpose - it
+# holds eleven shapes across two types today and needs a migration before it
+# can be constrained.
+STATUS_VALUES = ("To Read", "Reading", "Read", "Not To Read")
+PRIORITY_VALUES = ("Low", "Medium", "High")
+FIELD_VOCABULARIES = {
+    "status": STATUS_VALUES,
+    "priority": PRIORITY_VALUES,
+}
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
 MODELLED_FIELDS = IDENTITY_FIELDS + BIBLIOGRAPHIC_FIELDS + READING_FIELDS + DATE_FIELDS
@@ -41,6 +53,38 @@ _H1 = re.compile(r"^#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
 # A section ends at the next heading or a thematic break. merge.py joins bodies
 # with a "---" divider, and the reader's writing must not be swept into a blurb.
 _SECTION_BREAK = re.compile(r"^(?:#{1,6}[ \t]+\S|-{3,}[ \t]*$)", re.MULTILINE)
+
+
+class InvalidFieldValue(ValueError):
+    """A Book Note field was given a value the Library does not define.
+
+    Subclasses ValueError so callers that already guard against bad input keep
+    working; the distinct type is what lets the CLI report it as a user error
+    rather than a crash.
+    """
+
+
+def validate_field_value(field: str, value: object) -> None:
+    """Check a field value against the vocabulary the Library defines for it.
+
+    Fields with no vocabulary, and values that are simply unset, always pass:
+    absent is not the same as invalid, and 2,251 notes have no priority.
+
+    Args:
+        field: The frontmatter field being written.
+        value: The value proposed for it.
+
+    Raises:
+        InvalidFieldValue: If the field has a vocabulary and the value is not
+            in it.
+    """
+    allowed = FIELD_VOCABULARIES.get(field)
+    if allowed is None or value is None or value == "":
+        return
+    if value not in allowed:
+        raise InvalidFieldValue(
+            f"Invalid {field}: {value!r}. Valid values: {', '.join(allowed)}."
+        )
 
 
 def mint_libris_id(date_added: object) -> str:

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -18,7 +18,9 @@ from libris.markdown import (
     create_book_note,
     find_duplicates,
     rename_book_file,
+    update_book_status,
 )
+from libris.note_format import InvalidFieldValue
 
 # The exact key set present on all 3,137 notes in the vault.
 CANONICAL_FRONTMATTER = {
@@ -240,3 +242,122 @@ def test_stray_whitespace_in_an_author_name_is_collapsed(vault):
     from libris.markdown import BookNote
 
     assert BookNote.read(note).first_author == "Dan Harris"
+
+
+# --- field value vocabularies (#65) ---
+#
+# Measured against the vault before writing these: all 3,136 notes already hold
+# a legal status (1,667 Read, 1,467 To Read, 1 Reading, 1 Not To Read) and a
+# legal priority (2,251 unset, then Low/Medium/High). Nothing needs migrating,
+# so this is pure enforcement. `format` is deliberately not validated here: it
+# holds eleven shapes across two types and needs a migration of its own.
+
+
+def _candidate() -> BookCandidate:
+    return BookCandidate(title="Dune", authors=["Frank Herbert"])
+
+
+@pytest.mark.parametrize("status", ["To Read", "Reading", "Read", "Not To Read"])
+def test_every_status_the_vault_uses_is_accepted(tmp_path, status):
+    # Given a status that exists in the vault today
+    # When a note is created with it
+    path = create_book_note(_candidate(), tmp_path, status=status)
+
+    # Then it is written
+    assert path.exists()
+
+
+def test_an_unknown_status_is_refused(tmp_path):
+    # Given a status outside the four the Library defines
+    # When a note is created with it
+    # Then it is refused rather than silently written into the Shelf
+    with pytest.raises(InvalidFieldValue):
+        create_book_note(_candidate(), tmp_path, status="finished")
+
+
+def test_a_status_differing_only_in_case_is_refused(tmp_path):
+    # Given the right word in the wrong case
+    # When a note is created with it
+    # Then it is refused; the vault's Bases views group on the exact string
+    with pytest.raises(InvalidFieldValue):
+        create_book_note(_candidate(), tmp_path, status="read")
+
+
+def test_the_refusal_names_the_field_and_the_legal_values(tmp_path):
+    # Given an illegal status
+    # When a note is created with it
+    with pytest.raises(InvalidFieldValue) as excinfo:
+        create_book_note(_candidate(), tmp_path, status="finished")
+
+    # Then the message is usable without reading the source
+    message = str(excinfo.value)
+    assert "status" in message
+    assert "finished" in message
+    assert "To Read" in message
+
+
+@pytest.mark.parametrize("priority", ["Low", "Medium", "High"])
+def test_every_priority_the_vault_uses_is_accepted(tmp_path, priority):
+    # Given a priority that exists in the vault today
+    # When a note is created with it
+    path = create_book_note(_candidate(), tmp_path, overrides={"priority": priority})
+
+    # Then it is written
+    assert path.exists()
+
+
+def test_priority_may_be_unset(tmp_path):
+    # Given a book never triaged - 2,251 notes in the vault
+    # When a note is created with no priority
+    path = create_book_note(_candidate(), tmp_path, overrides={"priority": None})
+
+    # Then that is legal; absent is not the same as invalid
+    assert path.exists()
+
+
+def test_an_unknown_priority_is_refused(tmp_path):
+    # Given a priority outside Low, Medium, High
+    # When a note is created with it
+    # Then it is refused
+    with pytest.raises(InvalidFieldValue):
+        create_book_note(_candidate(), tmp_path, overrides={"priority": "Urgent"})
+
+
+def test_status_override_is_validated_too(tmp_path):
+    # Given an illegal status arriving as an override rather than the argument
+    # When a note is created
+    # Then the same rule applies; there is one gate, not two
+    with pytest.raises(InvalidFieldValue):
+        create_book_note(_candidate(), tmp_path, overrides={"status": "finished"})
+
+
+def test_updating_to_an_unknown_status_is_refused(tmp_path):
+    # Given an existing note
+    path = create_book_note(_candidate(), tmp_path, status="To Read")
+
+    # When its status is updated to something the Library does not define
+    # Then it is refused and the note is left alone
+    with pytest.raises(InvalidFieldValue):
+        update_book_status(path, "finished")
+    assert "status: To Read" in path.read_text(encoding="utf-8")
+
+
+def test_updating_to_a_known_status_is_allowed(tmp_path):
+    # Given an existing note
+    path = create_book_note(_candidate(), tmp_path, status="To Read")
+
+    # When its status is updated to a legal value
+    update_book_status(path, "Read")
+
+    # Then the note carries it
+    assert "status: Read" in path.read_text(encoding="utf-8")
+
+
+def test_format_is_not_validated_yet(tmp_path):
+    # Given the vault holds format as both string and list, in mixed case
+    # When a note is created with a bare string, as `libris add -f` writes today
+    path = create_book_note(_candidate(), tmp_path, overrides={"format": "Audiobook"})
+
+    # Then it is accepted. Validating this needs the field's type settled and
+    # 1,341 notes migrated first, which is its own piece of work.
+    assert path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,6 +226,10 @@ def test_search_command_no_results(monkeypatch):
 
 
 def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
+    # Status is "Read" rather than the "Finished" this test used to pass: the
+    # Library defines four statuses and Finished is not one of them (#65). The
+    # assertion here is that overrides reach create_book_note, not that any
+    # string may be written into a Book Note.
     from libris.api import BookCandidate
 
     mock_books = [
@@ -273,7 +277,7 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
             "add",
             "dune",
             "--status",
-            "Finished",
+            "Read",
             "--format",
             "kindle",
             "--rating",
@@ -292,9 +296,9 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert captured["book"] == mock_books[0]
     assert captured["vault_path"] == tmp_path
-    assert captured["status"] == "Finished"
+    assert captured["status"] == "Read"
     assert captured["overrides"] == {
-        "status": "Finished",
+        "status": "Read",
         "format": "kindle",
         "rating": 5,
         "referred_by": "Alice",
@@ -386,3 +390,21 @@ def test_serve_show_token_prints_the_token():
     # Then it is generated, printed, and the daemon does not start
     assert result.exit_code == 0
     assert config.get_server_token() in result.output
+
+
+def test_add_refuses_an_unknown_status_before_searching(monkeypatch):
+    # Given a search that would fail loudly if it ran
+    def _never(*args, **kwargs):
+        raise AssertionError("the API was called despite an invalid status")
+
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", _never)
+
+    # When a book is added with a status the Library does not define
+    result = runner.invoke(app, ["add", "Dune", "--status", "finished"])
+
+    # Then it is refused up front, before the network call and before the user
+    # is made to pick a book, and the message says what is allowed
+    assert result.exit_code != 0
+    assert "finished" in result.output
+    assert "To Read" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
Part of #65 — the `status` and `priority` half. `format` turned out to be a different problem and moved to #69. Unblocks #53.

`markdown.py:23` defaulted `status` to `"To Read"` and never checked the value, so any string reaching that field was written into a Book Note. Harmless while a person typed it. Not harmless once `POST /books` (#53) accepts overrides from a browser extension — and ADR 0013 makes "an Intent carrying a value the Library does not accept" one of only two grounds for rejecting an Intent, which requires the rule to exist before it can be applied.

## The measurement came first, and changed the work

The issue said to measure the vault before assuming there were no out-of-vocabulary values. Doing that split the issue in two.

**`status` and `priority` are provably clean.** Across all 3,136 notes: 1,667 `Read`, 1,467 `To Read`, 1 `Reading`, 1 `Not To Read`; and 2,251 unset priorities plus Low/Medium/High. Nothing to migrate, so this is pure enforcement.

**`format` is a type problem wearing a value problem's clothes** — 1,341 bare strings against 873 lists, 35 case variants, 3 notes genuinely multi-valued because a book can be owned in Physical *and* Audiobook. And `cli.py:174` offers "paperback, kindle, audiobook" while `importer.py:32` claims "Hardcover, Paperback, eBook", neither matching a single note. Same drift class as #62. It needs the type settled and 1,341 notes migrated, so it is **#69**.

## What this does

- `STATUS_VALUES` and `PRIORITY_VALUES` live in `note_format.py` beside the field definitions — one definition for the CLI, the server and sync, since the drift #62 undid began with two places disagreeing about a field.
- `InvalidFieldValue` subclasses `ValueError`, so callers already guarding against bad input keep working while the distinct type lets the CLI report a user error rather than a crash.
- Enforced at both write sites: `create_book_note` (the `status` argument *and* the overrides — one gate, not two) and `update_book_status`.
- `libris add` validates `--status` **before** the search, so an invalid value isn't reported after a network round trip and an interactive book picker.
- Unset stays legal. 2,251 notes have no priority, and absent is not the same as invalid.

## Verification against the real Shelf

Re-checked after implementing, not just in fixtures: **6,272 field values across 3,136 real notes, zero rejections.** The rule is exactly as strict as the data already is.

```
$ libris add "Dune" --status junk
Invalid status: 'junk'. Valid values: To Read, Reading, Read, Not To Read.
$ echo $?
1
```

No network call is made. 243 tests pass, `ruff check` and `ruff format --check` clean.

## One existing test changed, and why

`test_add_command_passes_cli_overrides` passed `--status Finished` and asserted it reached the note. `Finished` is not one of the four statuses, so **that test was asserting the bug** — the same way #62's fixtures were green over six broken behaviours. It now uses `Read` and still asserts what it was written to assert: that overrides reach `create_book_note`. A comment records why, so it doesn't get "restored" later.

`test_format_is_not_validated_yet` is deliberate — it pins the gap #69 closes, so the exclusion is visible rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
