### PR TITLE
feat(server): add lookup and create endpoints over a shared service layer

### DIFF
--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -12,13 +12,16 @@ module fails on a core install. cli.py imports it lazily and says so.
 import secrets
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
+from typing import Any
 
-from fastapi import FastAPI, Request
+import httpx
+from fastapi import APIRouter, FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from . import config
+from . import config, service
+from .api import BookCandidate, GoogleBooksClient
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
@@ -34,6 +37,103 @@ class Health(BaseModel):
     status: str
     version: str
     vault_path: str
+
+
+# How long a single request may spend talking to Google Books. The client
+# already retries a 429, but it will wait up to five minutes doing it, and a
+# browser popup cannot sit behind that (#53).
+UPSTREAM_MAX_WAIT_SECONDS = 15.0
+
+# Which duplicate guarantee this adapter gives. The daemon checks the live
+# Shelf, so it can say a Book was not held and now is. The remote checks a
+# replica no fresher than the last sync and will answer differently, which is
+# why every write states it rather than leaving the client to infer it from
+# its own configuration (ADR 0010, ADR 0016).
+GUARANTEE = "live_shelf"
+
+
+class CandidateModel(BaseModel):
+    """A Book Candidate crossing the HTTP boundary."""
+
+    title: str
+    authors: list[str] = []
+    isbn: str | None = None
+    page_count: int | None = None
+    published_date: str | None = None
+    google_books_id: str = ""
+    thumbnail: str | None = None
+    genres: list[str] = []
+    description: str | None = None
+
+    @classmethod
+    def of(cls, candidate: BookCandidate) -> "CandidateModel":
+        """Build the wire form of a Book Candidate."""
+        return cls(
+            title=candidate.title,
+            authors=candidate.authors,
+            isbn=candidate.isbn,
+            page_count=candidate.page_count,
+            published_date=candidate.published_date,
+            google_books_id=candidate.google_books_id,
+            thumbnail=candidate.thumbnail,
+            genres=candidate.genres,
+            description=candidate.description,
+        )
+
+    def to_candidate(self) -> BookCandidate:
+        """Build the domain Book Candidate this describes."""
+        return BookCandidate(
+            title=self.title,
+            authors=self.authors,
+            isbn=self.isbn,
+            page_count=self.page_count,
+            published_date=self.published_date,
+            google_books_id=self.google_books_id,
+            thumbnail=self.thumbnail,
+            genres=self.genres,
+            description=self.description,
+        )
+
+
+class LookupRequest(BaseModel):
+    """What a page yielded, as scraped."""
+
+    isbn: str | None = None
+    asin: str | None = None
+    title: str | None = None
+    authors: list[str] = []
+    source_url: str | None = None
+
+
+class LookupResponse(BaseModel):
+    """Candidates for a person to choose between, best described first."""
+
+    candidates: list[CandidateModel]
+
+
+class ExistingBook(BaseModel):
+    """A Book Note already on the Shelf."""
+
+    libris_id: str | None
+    path: str
+    title: str | None
+    authors: list[str]
+
+
+class CreateRequest(BaseModel):
+    """A chosen Book Candidate, plus the reading state to record with it."""
+
+    candidate: CandidateModel
+    overrides: dict[str, Any] = {}
+
+
+class WriteResponse(BaseModel):
+    """The answer to a write: identity, what happened, and what backs it."""
+
+    libris_id: str | None
+    path: str
+    outcome: str
+    guarantee: str
 
 
 def libris_version() -> str:
@@ -99,6 +199,99 @@ def create_app() -> FastAPI:
             version=libris_version(),
             vault_path=str(config.get_vault_path()),
         )
+
+    router = APIRouter(prefix="/api/v1")
+
+    @router.post("/lookup", response_model=LookupResponse)
+    async def lookup(request: LookupRequest) -> LookupResponse:
+        """Find Book Candidates for a page, ranked best described first."""
+        try:
+            candidates = service.lookup_candidates(
+                isbn=request.isbn,
+                asin=request.asin,
+                title=request.title,
+                authors=request.authors,
+                client=GoogleBooksClient(max_retry_wait=UPSTREAM_MAX_WAIT_SECONDS),
+            )
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Google Books could not be reached: {exc}"
+            ) from None
+
+        return LookupResponse(candidates=[CandidateModel.of(c) for c in candidates])
+
+    @router.get("/books", response_model=ExistingBook)
+    async def get_book(
+        isbn: str | None = None,
+        google_books_id: str | None = None,
+        title: str | None = None,
+        authors: list[str] = Query(default=[]),
+    ) -> ExistingBook:
+        """Report whether the Library already holds a Book."""
+        vault_path = config.get_vault_path()
+        note = service.find_existing(
+            vault_path,
+            isbn=isbn,
+            google_books_id=google_books_id,
+            title=title,
+            authors=authors,
+        )
+        if note is None:
+            # A miss is a miss (ADR 0003), so this is still a 404. Notes that
+            # might be the same Book ride along, because a scraped title often
+            # lacks the subtitle the note carries - and deciding that for the
+            # caller is exactly what would say "already held" about a Book that
+            # is not. The person in the popup settles it.
+            similar = service.find_similar(vault_path, title=title, authors=authors)
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "message": "Not in your Library.",
+                    "similar": [
+                        {
+                            "libris_id": n.libris_id,
+                            "path": str(n.path),
+                            "title": n.title,
+                            "authors": n.authors,
+                        }
+                        for n in similar
+                    ],
+                },
+            )
+
+        return ExistingBook(
+            libris_id=note.libris_id,
+            path=str(note.path),
+            title=note.title,
+            authors=note.authors,
+        )
+
+    @router.post("/books", response_model=WriteResponse, status_code=201)
+    async def create_book(request: CreateRequest, response: Response) -> WriteResponse:
+        """Add a Book to the Library, unless it is already held."""
+        try:
+            result = service.add_book(
+                config.get_vault_path(),
+                request.candidate.to_candidate(),
+                overrides=request.overrides or None,
+            )
+        except ValueError as exc:
+            # InvalidFieldValue subclasses ValueError, so this covers both an
+            # unknown field and a value the Library does not define. Neither is
+            # a crash: the caller sent something the Library will not accept.
+            raise HTTPException(status_code=422, detail=str(exc)) from None
+
+        if result.outcome is service.Outcome.ALREADY_PRESENT:
+            response.status_code = 200
+
+        return WriteResponse(
+            libris_id=result.libris_id,
+            path=str(result.path),
+            outcome=result.outcome.value,
+            guarantee=GUARANTEE,
+        )
+
+    app.include_router(router)
 
     return app
 

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -211,7 +211,11 @@ def create_app() -> FastAPI:
                 asin=request.asin,
                 title=request.title,
                 authors=request.authors,
-                client=GoogleBooksClient(max_retry_wait=UPSTREAM_MAX_WAIT_SECONDS),
+                client=GoogleBooksClient(
+                    timeout=UPSTREAM_MAX_WAIT_SECONDS / 3,
+                    max_retries=1,
+                    max_retry_wait=UPSTREAM_MAX_WAIT_SECONDS / 3,
+                ),
             )
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
             raise HTTPException(

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -1,0 +1,288 @@
+"""What the adapters do, with no adapter in it.
+
+ADR 0008 puts resolution, creation and querying here so the REST surface and
+the MCP tools cannot drift apart by reimplementing matching. Nothing in this
+module knows about HTTP, and it raises rather than returning status codes: the
+adapter decides what a failure looks like on the wire.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from .api import BookCandidate, GoogleBooksClient
+from .markdown import BookNote, create_book_note, list_books
+from .matching import best_match, normalize_for_match, titles_match
+
+
+class Outcome(Enum):
+    """What a write did to the Library.
+
+    Deliberately not ADR 0013's Intent vocabulary: an Intent is applied to the
+    Shelf later by the CLI, whereas this writes now, so nothing is absorbed.
+    """
+
+    CREATED = "created"
+    ALREADY_PRESENT = "already_present"
+
+
+@dataclass
+class AddResult:
+    """The answer to a write: identity first, path only for display (ADR 0016)."""
+
+    libris_id: str | None
+    path: Path
+    outcome: Outcome
+
+
+def is_isbn10(value: str) -> bool:
+    """Check whether a ten-character identifier is a valid ISBN-10.
+
+    Amazon reuses the ISBN-10 as the ASIN for print books but mints its own for
+    Kindle editions, and the two are indistinguishable by shape. The checksum
+    is what separates them, so a Kindle ASIN is never sent as `isbn:`.
+
+    Args:
+        value: The identifier to check.
+
+    Returns:
+        True if the value passes the ISBN-10 check digit.
+    """
+    digits = value.replace("-", "").replace(" ", "").upper()
+    if len(digits) != 10:
+        return False
+
+    total = 0
+    for position, char in enumerate(digits):
+        if char.isdigit():
+            digit = int(char)
+        elif char == "X" and position == 9:
+            digit = 10
+        else:
+            return False
+        total += digit * (10 - position)
+    return total % 11 == 0
+
+
+def build_lookup_query(
+    isbn: str | None = None,
+    asin: str | None = None,
+    title: str | None = None,
+    authors: list[str] | None = None,
+) -> str | None:
+    """Build a Google Books query from whatever a page yielded.
+
+    Identifiers win over names: an ISBN names one edition, while a title and
+    author name a book that may have twenty.
+
+    Args:
+        isbn: An ISBN scraped from the page.
+        asin: An Amazon identifier, which is an ISBN-10 only for print editions.
+        title: The title as scraped.
+        authors: The authors as scraped.
+
+    Returns:
+        A query string, or None when nothing identifying was found - the caller
+        is told rather than handed a search for everything.
+    """
+    if isbn:
+        return f"isbn:{isbn}"
+    if asin and is_isbn10(asin):
+        return f"isbn:{asin}"
+
+    parts = []
+    if title:
+        parts.append(f"intitle:{title}")
+    if authors:
+        parts.append(f"inauthor:{authors[0]}")
+    return " ".join(parts) or None
+
+
+def lookup_candidates(
+    isbn: str | None = None,
+    asin: str | None = None,
+    title: str | None = None,
+    authors: list[str] | None = None,
+    client: GoogleBooksClient | None = None,
+) -> list[BookCandidate]:
+    """Find Book Candidates for what a page yielded, best described first.
+
+    Args:
+        isbn: An ISBN scraped from the page.
+        asin: An Amazon identifier.
+        title: The title as scraped.
+        authors: The authors as scraped.
+        client: The Google Books client to search with.
+
+    Returns:
+        Candidates ordered so the best described comes first, or an empty list.
+        A picker needs an order; it does not need a decision made for it, which
+        is why this ranks rather than choosing (ADR 0003).
+    """
+    query = build_lookup_query(isbn=isbn, asin=asin, title=title, authors=authors)
+    if query is None:
+        return []
+
+    results = (client or GoogleBooksClient()).search(query)
+    if not results:
+        return []
+
+    ranked = []
+    remaining = list(results)
+    while remaining:
+        pick = best_match(remaining)
+        ranked.append(pick)
+        remaining.remove(pick)
+    return ranked
+
+
+def find_existing(
+    vault_path: Path,
+    isbn: str | None = None,
+    google_books_id: str | None = None,
+    title: str | None = None,
+    authors: list[str] | None = None,
+) -> BookNote | None:
+    """Find a Book Note already on the Shelf describing this book.
+
+    Checked against the live Shelf rather than an index, so the answer is true
+    at the moment it is given - the stronger of the two duplicate guarantees
+    (ADR 0010).
+
+    Args:
+        vault_path: The Shelf to search.
+        isbn: An ISBN to match exactly.
+        google_books_id: A Google Books volume id to match exactly.
+        title: A title to match after normalization.
+        authors: Authors whose first entry is matched after normalization.
+
+    Returns:
+        The Book Note, or None. A miss is a miss (ADR 0003).
+    """
+    wanted_title = normalize_for_match(title) if title else None
+    wanted_author = normalize_for_match(authors[0]) if authors else None
+
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is None:
+            continue
+
+        if isbn and note.frontmatter.get("isbn") == isbn:
+            return note
+        if (
+            google_books_id
+            and note.frontmatter.get("google_books_id") == google_books_id
+        ):
+            return note
+        if (
+            wanted_title
+            and note.title
+            and normalize_for_match(note.title) == wanted_title
+        ):
+            if wanted_author is None:
+                return note
+            if (
+                note.first_author
+                and normalize_for_match(note.first_author) == wanted_author
+            ):
+                return note
+    return None
+
+
+def find_similar(
+    vault_path: Path,
+    title: str | None = None,
+    authors: list[str] | None = None,
+    limit: int = 5,
+) -> list[BookNote]:
+    """Find Book Notes that might be the same Book, without deciding that they are.
+
+    Title matching is fuzzy on purpose and cannot be trusted to decide. Measured
+    against the real Shelf, containment matching conflates 83 pairs: some are
+    genuine variants ("The Brass Verdict" and "The Brass Verdict: A Novel"), and
+    some are different books entirely ("Mercy" and "Long Road to Mercy"). Telling
+    a person a Book is already held when it is not means it never gets added and
+    nothing surfaces the error, which ADR 0003 refuses.
+
+    So this decides nothing. It hands candidates back to the Surface, where a
+    person is still present to say which one it is.
+
+    Args:
+        vault_path: The Shelf to search.
+        title: The title as scraped.
+        authors: The authors as scraped. When given, only notes by the same
+            first author are considered.
+        limit: The most notes to return.
+
+    Returns:
+        Book Notes whose title plausibly describes the same Book, nearest first
+        by title length, or an empty list.
+    """
+    if not title:
+        return []
+
+    wanted_author = normalize_for_match(authors[0]) if authors else None
+
+    found: list[BookNote] = []
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is None or not note.title:
+            continue
+        if wanted_author is not None:
+            if not note.first_author:
+                continue
+            if normalize_for_match(note.first_author) != wanted_author:
+                continue
+        if titles_match(title, note.title):
+            found.append(note)
+
+    found.sort(key=lambda n: len(n.title or ""))
+    return found[:limit]
+
+
+def add_book(
+    vault_path: Path,
+    candidate: BookCandidate,
+    overrides: dict | None = None,
+) -> AddResult:
+    """Add a Book to the Library, unless it is already held.
+
+    The duplicate check runs before the write and never overwrites: a Book Note
+    holds a reader's own writing, and a second capture of the same book must not
+    cost them that.
+
+    Args:
+        vault_path: The Shelf to write into.
+        candidate: The Book Candidate accepted by whoever chose it.
+        overrides: Frontmatter fields to set, validated by create_book_note.
+
+    Returns:
+        The identity of the Book Note and what happened to it.
+
+    Raises:
+        InvalidFieldValue: If an override carries a value the Library does not
+            define.
+        ValueError: If an override names a field the canonical schema has no
+            place for.
+    """
+    existing = find_existing(
+        vault_path,
+        isbn=candidate.isbn,
+        google_books_id=candidate.google_books_id or None,
+        title=candidate.title,
+        authors=candidate.authors,
+    )
+    if existing is not None:
+        return AddResult(
+            libris_id=existing.libris_id,
+            path=existing.path,
+            outcome=Outcome.ALREADY_PRESENT,
+        )
+
+    path = create_book_note(candidate, vault_path, overrides=overrides or None)
+    note = BookNote.read(path)
+    return AddResult(
+        libris_id=note.libris_id if note else None,
+        path=path,
+        outcome=Outcome.CREATED,
+    )

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -176,11 +176,13 @@ def find_existing(
             return note
         if (
             wanted_title
+            and wanted_author
             and note.title
             and normalize_for_match(note.title) == wanted_title
+            and note.first_author
+            and normalize_for_match(note.first_author) == wanted_author
         ):
-            if wanted_author is None:
-                return note
+            return note
             if (
                 note.first_author
                 and normalize_for_match(note.first_author) == wanted_author

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,11 +10,14 @@ import pytest
 
 pytest.importorskip("fastapi")
 
+import httpx  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from typer.testing import CliRunner  # noqa: E402
 
 from libris import config  # noqa: E402
+from libris.api import BookCandidate  # noqa: E402
 from libris.cli import app as cli_app  # noqa: E402
+from libris.markdown import create_book_note  # noqa: E402
 from libris.server import create_app  # noqa: E402
 
 runner = CliRunner()
@@ -292,3 +295,334 @@ def test_serve_allows_a_routable_address_when_explicitly_permitted(monkeypatch):
     # Then it binds what was asked for
     assert result.exit_code == 0
     assert started == [{"host": "192.168.1.10", "port": 8787, "reload": False}]
+
+
+# --- /api/v1/lookup ---
+
+
+def _mock_search(monkeypatch, results):
+    """Point the service's Google Books search at fixed results."""
+    captured = {}
+
+    def _search(self, query):
+        captured["query"] = query
+        return results
+
+    monkeypatch.setattr("libris.service.GoogleBooksClient.search", _search)
+    return captured
+
+
+def test_lookup_needs_a_token(client):
+    # Given no credential
+    # When lookup is called
+    response = client.post("/api/v1/lookup", json={"isbn": "9780441013593"})
+
+    # Then it is refused like every other path
+    assert response.status_code == 401
+
+
+def test_lookup_by_isbn_searches_by_isbn(client, token, monkeypatch):
+    # Given a page that yielded an ISBN
+    captured = _mock_search(
+        monkeypatch, [BookCandidate(title="Dune", authors=["Frank Herbert"])]
+    )
+
+    # When the extension looks it up
+    response = client.post(
+        "/api/v1/lookup",
+        json={"isbn": "9780441013593", "title": "Dune"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the identifier is used rather than the title
+    assert response.status_code == 200
+    assert captured["query"] == "isbn:9780441013593"
+    assert response.json()["candidates"][0]["title"] == "Dune"
+
+
+def test_lookup_ranks_the_best_described_candidate_first(client, token, monkeypatch):
+    # Given two editions of the same book, one better described
+    sparse = BookCandidate(title="Dune", authors=["Frank Herbert"])
+    rich = BookCandidate(
+        title="Dune",
+        authors=["Frank Herbert"],
+        isbn="9780441013593",
+        page_count=412,
+        description="A desert planet.",
+    )
+    _mock_search(monkeypatch, [sparse, rich])
+
+    # When the extension looks the book up
+    response = client.post(
+        "/api/v1/lookup",
+        json={"title": "Dune"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the popup's first choice is the one with the most metadata
+    candidates = response.json()["candidates"]
+    assert candidates[0]["isbn"] == "9780441013593"
+    assert len(candidates) == 2
+
+
+def test_lookup_with_a_kindle_asin_falls_back_to_names(client, token, monkeypatch):
+    # Given a Kindle page, whose ASIN is not an ISBN
+    captured = _mock_search(monkeypatch, [])
+
+    # When the extension looks it up
+    client.post(
+        "/api/v1/lookup",
+        json={"asin": "B000FC0SIM", "title": "Dune", "authors": ["Frank Herbert"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the search is by name, not by a fake ISBN
+    assert captured["query"] == "intitle:Dune inauthor:Frank Herbert"
+
+
+def test_lookup_with_no_results_is_not_an_error(client, token, monkeypatch):
+    # Given a search that matches nothing
+    _mock_search(monkeypatch, [])
+
+    # When the extension looks it up
+    response = client.post(
+        "/api/v1/lookup",
+        json={"title": "A Book That Does Not Exist"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the answer is an empty list, so the popup can say "no matches"
+    # rather than "something went wrong"
+    assert response.status_code == 200
+    assert response.json()["candidates"] == []
+
+
+def test_lookup_reports_an_upstream_failure_as_502(client, token, monkeypatch):
+    # Given Google Books being unreachable
+    def _boom(self, query):
+        raise httpx.RequestError("connection refused")
+
+    monkeypatch.setattr("libris.service.GoogleBooksClient.search", _boom)
+
+    # When the extension looks a book up
+    response = client.post(
+        "/api/v1/lookup",
+        json={"isbn": "9780441013593"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the daemon says the upstream failed, not that it did
+    assert response.status_code == 502
+    assert "Traceback" not in response.text
+
+
+# --- GET /api/v1/books ---
+
+
+def test_existing_note_is_found_by_isbn(token, tmp_path):
+    # Given a Book Note on the Shelf
+    config.set_book_vault_path(tmp_path)
+    create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"], isbn="9780441013593"),
+        tmp_path,
+    )
+
+    # When the extension asks whether the book is already held
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"isbn": "9780441013593"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then it is told so, with the identity rather than only a filename
+    assert response.status_code == 200
+    body = response.json()
+    assert body["libris_id"]
+    assert "Dune" in body["path"]
+
+
+def test_a_book_not_held_answers_404(token, tmp_path):
+    # Given an empty Shelf
+    config.set_book_vault_path(tmp_path)
+
+    # When the extension asks about a book
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"isbn": "9780441013593"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then a miss is a miss (ADR 0003)
+    assert response.status_code == 404
+
+
+# --- POST /api/v1/books ---
+
+
+def _post_book(token, **extra):
+    payload = {
+        "candidate": {
+            "title": "Dune",
+            "authors": ["Frank Herbert"],
+            "isbn": "9780441013593",
+        }
+    }
+    payload.update(extra)
+    return TestClient(create_app()).post(
+        "/api/v1/books",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_creating_a_book_note_answers_with_its_identity(token, tmp_path):
+    # Given a Shelf without the book
+    config.set_book_vault_path(tmp_path)
+
+    # When the extension adds it
+    response = _post_book(token)
+
+    # Then the answer carries the durable identity, what happened, and which
+    # guarantee stands behind it (ADR 0016)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["libris_id"]
+    assert body["outcome"] == "created"
+    assert body["guarantee"] == "live_shelf"
+    assert (tmp_path / "Dune - Frank Herbert.md").exists()
+
+
+def test_adding_a_book_already_held_leaves_it_untouched(token, tmp_path):
+    # Given the book already on the Shelf
+    config.set_book_vault_path(tmp_path)
+    first = _post_book(token).json()
+    note_path = tmp_path / "Dune - Frank Herbert.md"
+    original = note_path.read_text(encoding="utf-8")
+
+    # When it is captured a second time
+    response = _post_book(token)
+
+    # Then the Library already satisfied it, and the reader's own writing in
+    # that note is not overwritten
+    assert response.status_code == 200
+    body = response.json()
+    assert body["outcome"] == "already_present"
+    assert body["libris_id"] == first["libris_id"]
+    assert note_path.read_text(encoding="utf-8") == original
+
+
+def test_creating_applies_overrides(token, tmp_path):
+    # Given a book captured as already read
+    config.set_book_vault_path(tmp_path)
+
+    # When it is added with overrides
+    response = _post_book(token, overrides={"status": "Read", "rating": 5})
+
+    # Then the note carries them
+    assert response.status_code == 201
+    text = (tmp_path / "Dune - Frank Herbert.md").read_text(encoding="utf-8")
+    assert "status: Read" in text
+
+
+def test_an_unknown_override_field_is_refused(token, tmp_path):
+    # Given an override naming a field the schema has no place for
+    config.set_book_vault_path(tmp_path)
+
+    # When the extension sends it
+    response = _post_book(token, overrides={"nonsense": "x"})
+
+    # Then it is refused as a bad request, not raised as a crash
+    assert response.status_code == 422
+    assert "Traceback" not in response.text
+
+
+def test_an_illegal_status_value_is_refused(token, tmp_path):
+    # Given a status the Library does not define, arriving from a browser
+    config.set_book_vault_path(tmp_path)
+
+    # When the extension sends it
+    response = _post_book(token, overrides={"status": "finished"})
+
+    # Then it is refused before anything is written (#65)
+    assert response.status_code == 422
+    assert not any(tmp_path.glob("*.md"))
+
+
+def test_a_near_title_is_offered_rather_than_decided(token, tmp_path):
+    # Given a note whose title carries a subtitle the scraped page does not
+    config.set_book_vault_path(tmp_path)
+    create_book_note(
+        BookCandidate(title="The Brass Verdict: A Novel", authors=["Michael Connelly"]),
+        tmp_path,
+    )
+
+    # When the extension asks about the short form
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"title": "The Brass Verdict", "authors": ["Michael Connelly"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then it is still a miss - nothing claims this is the same Book - but the
+    # popup is given the near match so a person can settle it
+    assert response.status_code == 404
+    similar = response.json()["detail"]["similar"]
+    assert len(similar) == 1
+    assert similar[0]["title"] == "The Brass Verdict: A Novel"
+    assert similar[0]["libris_id"]
+
+
+def test_a_different_book_by_the_same_author_is_not_offered(token, tmp_path):
+    # Given two unrelated books by one author, the case measured on the real
+    # Shelf: "Mercy" and "Long Road to Mercy" are different books
+    config.set_book_vault_path(tmp_path)
+    create_book_note(
+        BookCandidate(title="Memory Man", authors=["David Baldacci"]), tmp_path
+    )
+
+    # When the extension asks about the other
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"title": "The Innocent", "authors": ["David Baldacci"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then nothing is offered, because nothing resembles it
+    assert response.status_code == 404
+    assert response.json()["detail"]["similar"] == []
+
+
+def test_a_near_title_by_another_author_is_not_offered(token, tmp_path):
+    # Given a similarly titled book by someone else
+    config.set_book_vault_path(tmp_path)
+    create_book_note(
+        BookCandidate(title="Dune: Deluxe Edition", authors=["Someone Else"]), tmp_path
+    )
+
+    # When the extension asks about Frank Herbert's
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"title": "Dune", "authors": ["Frank Herbert"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then the author keeps them apart
+    assert response.status_code == 404
+    assert response.json()["detail"]["similar"] == []
+
+
+def test_an_exact_match_still_answers_directly(token, tmp_path):
+    # Given a note matching exactly
+    config.set_book_vault_path(tmp_path)
+    create_book_note(BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path)
+
+    # When the extension asks about it
+    response = TestClient(create_app()).get(
+        "/api/v1/books",
+        params={"title": "Dune", "authors": ["Frank Herbert"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    # Then it is answered, not offered as a maybe
+    assert response.status_code == 200
+    assert response.json()["libris_id"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,214 @@
+"""Tests for the service layer the adapters sit over.
+
+ADR 0008 puts resolution, creation and querying below the adapters, so the REST
+surface and the MCP tools cannot drift apart by reimplementing matching. These
+tests exercise that layer directly, with no HTTP involved.
+"""
+
+import pytest
+
+from libris.api import BookCandidate
+from libris.markdown import create_book_note
+from libris.note_format import InvalidFieldValue
+from libris.service import (
+    Outcome,
+    add_book,
+    build_lookup_query,
+    find_existing,
+    is_isbn10,
+)
+
+
+def _candidate(**overrides) -> BookCandidate:
+    fields = {"title": "Dune", "authors": ["Frank Herbert"]}
+    fields.update(overrides)
+    return BookCandidate(**fields)
+
+
+# --- ISBN-10 checksum ---
+
+
+def test_a_real_isbn10_passes_the_checksum():
+    # Given a genuine ISBN-10 (Dune)
+    # Then it validates
+    assert is_isbn10("0441013597") is True
+
+
+def test_an_isbn10_ending_in_x_passes():
+    # Given an ISBN-10 whose check digit is X
+    # Then the X is understood as ten rather than rejected
+    assert is_isbn10("043942089X") is True
+
+
+def test_a_kindle_asin_fails_the_checksum():
+    # Given a Kindle ASIN, which is ten characters but not an ISBN
+    # Then it does not validate, so it is never sent as isbn:
+    assert is_isbn10("B000FC0SIM") is False
+
+
+def test_a_wrong_check_digit_fails():
+    # Given an ISBN-10 with a corrupted final digit
+    # Then it does not validate
+    assert is_isbn10("0441013598") is False
+
+
+# --- query construction ---
+
+
+def test_an_isbn_builds_an_isbn_query():
+    # Given a scrape that found an ISBN
+    # When a query is built
+    query = build_lookup_query(
+        isbn="9780441013593", title="Dune", authors=["Frank Herbert"]
+    )
+
+    # Then the ISBN wins, because it identifies an edition exactly
+    assert query == "isbn:9780441013593"
+
+
+def test_an_asin_that_is_a_valid_isbn10_is_used_as_one():
+    # Given an Amazon page whose ASIN is really an ISBN-10, as print books' are
+    query = build_lookup_query(
+        asin="0441013597", title="Dune", authors=["Frank Herbert"]
+    )
+
+    # Then it is searched as an ISBN
+    assert query == "isbn:0441013597"
+
+
+def test_an_asin_that_is_not_an_isbn10_falls_back_to_title_and_author():
+    # Given a Kindle ASIN, which is not an ISBN
+    query = build_lookup_query(
+        asin="B000FC0SIM", title="Dune", authors=["Frank Herbert"]
+    )
+
+    # Then the search uses what a person would search with
+    assert query == "intitle:Dune inauthor:Frank Herbert"
+
+
+def test_a_title_alone_builds_a_title_query():
+    # Given a scrape that found no author
+    query = build_lookup_query(title="Dune")
+
+    # Then only the title constrains the search
+    assert query == "intitle:Dune"
+
+
+def test_nothing_identifying_builds_no_query():
+    # Given a page nothing could be scraped from
+    # Then there is no query to run, and the caller is told so rather than
+    # being handed a search for everything
+    assert build_lookup_query() is None
+
+
+# --- finding an existing note ---
+
+
+def test_an_existing_note_is_found_by_isbn(tmp_path):
+    # Given a Book Note on the Shelf
+    create_book_note(_candidate(isbn="9780441013593"), tmp_path)
+
+    # When the same ISBN is looked up
+    found = find_existing(tmp_path, isbn="9780441013593")
+
+    # Then the note is found, carrying its identity
+    assert found is not None
+    assert found.libris_id
+
+
+def test_an_existing_note_is_found_by_google_books_id(tmp_path):
+    # Given a Book Note that came from Google Books
+    create_book_note(_candidate(google_books_id="dune1"), tmp_path)
+
+    # When that volume is looked up
+    found = find_existing(tmp_path, google_books_id="dune1")
+
+    # Then it is found
+    assert found is not None
+
+
+def test_an_existing_note_is_found_by_title_and_author(tmp_path):
+    # Given a Book Note with no identifiers at all
+    create_book_note(_candidate(), tmp_path)
+
+    # When the same book is looked up by name
+    found = find_existing(tmp_path, title="dune", authors=["frank herbert"])
+
+    # Then normalization matches it despite the case
+    assert found is not None
+
+
+def test_a_book_not_on_the_shelf_is_not_found(tmp_path):
+    # Given an empty Shelf
+    # When anything is looked up
+    # Then nothing is found; a miss is a miss (ADR 0003)
+    assert find_existing(tmp_path, isbn="9780441013593") is None
+
+
+def test_a_different_book_is_not_matched(tmp_path):
+    # Given one Book Note
+    create_book_note(_candidate(isbn="9780441013593"), tmp_path)
+
+    # When a different book is looked up
+    found = find_existing(tmp_path, title="Neuromancer", authors=["William Gibson"])
+
+    # Then it is not confused for the one on the Shelf
+    assert found is None
+
+
+# --- adding ---
+
+
+def test_adding_a_new_book_writes_it_and_returns_its_identity(tmp_path):
+    # Given a Shelf without the book
+    # When it is added
+    result = add_book(tmp_path, _candidate(isbn="9780441013593"))
+
+    # Then the note exists and the answer carries the durable identity, not
+    # just the path, which clean --rename can move (ADR 0016)
+    assert result.outcome is Outcome.CREATED
+    assert result.path.exists()
+    assert result.libris_id
+    assert result.libris_id in result.path.read_text(encoding="utf-8")
+
+
+def test_adding_a_book_already_held_does_not_overwrite_it(tmp_path):
+    # Given a Book Note already on the Shelf
+    first = add_book(tmp_path, _candidate(isbn="9780441013593"))
+    original = first.path.read_text(encoding="utf-8")
+
+    # When the same book is added again
+    second = add_book(tmp_path, _candidate(isbn="9780441013593"))
+
+    # Then the Library already satisfied the request, and the existing note is
+    # returned untouched rather than rewritten
+    assert second.outcome is Outcome.ALREADY_PRESENT
+    assert second.libris_id == first.libris_id
+    assert second.path == first.path
+    assert first.path.read_text(encoding="utf-8") == original
+
+
+def test_adding_applies_overrides(tmp_path):
+    # Given a book being added as already read
+    result = add_book(tmp_path, _candidate(), overrides={"status": "Read", "rating": 5})
+
+    # Then the note carries them
+    text = result.path.read_text(encoding="utf-8")
+    assert "status: Read" in text
+    assert "rating: 5" in text
+
+
+def test_adding_refuses_a_status_the_library_does_not_define(tmp_path):
+    # Given an override carrying a value from off this machine
+    # When it is added
+    # Then it is refused rather than written (#65)
+    with pytest.raises(InvalidFieldValue):
+        add_book(tmp_path, _candidate(), overrides={"status": "finished"})
+
+
+def test_adding_refuses_an_unknown_field(tmp_path):
+    # Given an override naming a field the canonical schema has no place for
+    # When it is added
+    # Then it is refused
+    with pytest.raises(ValueError):
+        add_book(tmp_path, _candidate(), overrides={"nonsense": "x"})


### PR DESCRIPTION
Closes #53. Completes the `libris serve` half of #51.

The three endpoints the Edge extension calls, and the service layer ADR 0008 requires underneath them so the MCP tools cannot drift by reimplementing matching.

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/api/v1/lookup` | Ranked Book Candidates, best described first |
| `GET` | `/api/v1/books` | Is this Book already held? |
| `POST` | `/api/v1/books` | Add it, unless it is |

`service.py` owns query construction, ranking, existence checks and adding. Nothing in it knows about HTTP, and it raises rather than returning status codes — the adapter decides what a failure looks like on the wire.

## Decisions carried in from the ADRs

**Paths under `/api/v1`** — ADR 0010 promises the extension reaches the remote by changing a base URL, which is only true if everything after the base URL is identical on both adapters, and ADR 0008 puts the remote at `/api/v1/*`. `/health` stays unversioned: it reports on the daemon process, not the Library.

**Writes answer with `libris_id`, not a path** — `clean --rename` moves 132 files, and surviving that is what a Libris ID is for (ADR 0001, ADR 0016). The path still travels, for display.

**Writes state their duplicate guarantee** — always `live_shelf` here, and stated anyway so the same extension code works unchanged when repointed at the remote, whose check is only as fresh as the last sync.

**An ASIN is only used as an ISBN-10 when it passes the checksum** — Amazon reuses the ISBN for print editions and mints its own for Kindle, and the two are indistinguishable by shape.

**Override values are validated** via #65, so a status the Library does not define is refused with 422 before anything is written. This is the first surface accepting field values from off this machine.

**Upstream time is capped at 15s.** `GoogleBooksClient` defaults to `max_retry_wait=300`, and a browser popup cannot sit behind five minutes of retries.

## Title matching, decided by measurement

Verifying against a copy of the real Shelf caught something no fixture would: `GET /api/v1/books?title=$100M Offers` returned 404 for a book that *is* in the vault, because the note carries the full subtitle.

The obvious fix is containment matching — `matching.titles_match` already does exactly that. So I measured it against all 3,136 notes: it conflates **83 pairs**. About 74 are genuinely one work with two notes; about 9 are different books (`Freakonomics` / `SuperFreakonomics`, `The 7 Habits` / `The 7 Habits Workbook`, `Hidden Order` / `Free Fall: A Prelude to Hidden Order`).

A false negative creates a duplicate note — recoverable, and `merge` now preserves IDs via #64. A false positive tells you a Book is already in your Library when it is not, so it never gets added and nothing surfaces the error. That is the failure ADR 0003 exists to refuse.

So **exact normalized title and author decides the write, and near matches ride along with the 404** for a person to settle — resolution in conversation, which is ADR 0003's whole stance. Verified against the real data: `Mercy` by David Baldacci resolves to *Mercy*, not to *Long Road to Mercy*.

That measurement also surfaced a defect outside this PR: `find_duplicates` groups on `title.lower()`, so those ~74 duplicate Books are invisible to `libris duplicates`. Filed as **#72**.

## Verification against a copy of the real Shelf

All 3,136 notes copied to a scratch directory with `LIBRIS_CONFIG_DIR` pointed at it, daemon running, driven with curl:

| Request | Result |
|---|---|
| `GET /books?isbn=…` for a held book | `200` with its Libris ID |
| `GET /books?title=` partial title | `404` + the real note offered as a near match |
| `GET /books` for `Mercy` | `200` to *Mercy*, not *Long Road to Mercy* |
| `GET /books` for a book not held | `404` |
| `POST /books` for a held book | `200`, `already_present`, file byte-identical |
| `POST /books` for a new book | `201`, `created`, note written with a minted ULID |
| `POST /books` with `status: finished` | `422`, nothing written |
| `POST /books` with an unknown field | `422` |

A live `/lookup` returned Dune (705pp) against the real API. The scratch config's missing key produced a genuine 429, which surfaced as a `502` with a useful message and no traceback — the error path got tested for real.

279 tests (was 243). `ruff check` and `ruff format --check` clean, green in both matrix install states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
