### PR TITLE
feat(merge): record superseded_ids on the surviving note

### DIFF
--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -16,6 +16,7 @@ from .note_format import (
     SUPERSEDED_IDS_FIELD,
     has_description_callout,
     mint_libris_id,
+    read_superseded_ids,
     render_body,
     render_description_callout,
     validate_field_value,
@@ -104,14 +105,7 @@ class BookNote:
             The superseded identities, or an empty list. A note that has never
             absorbed another does not carry the field at all.
         """
-        value = self.frontmatter.get(SUPERSEDED_IDS_FIELD)
-        if isinstance(value, str):
-            value = [value]
-        if not isinstance(value, list):
-            return []
-        return [
-            item.strip() for item in value if isinstance(item, str) and item.strip()
-        ]
+        return read_superseded_ids(self.frontmatter.get(SUPERSEDED_IDS_FIELD))
 
     @property
     def title(self) -> str | None:

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -13,6 +13,7 @@ from titlecase import titlecase
 from .api import BookCandidate
 from .note_format import (
     MODELLED_FIELDS,
+    SUPERSEDED_IDS_FIELD,
     has_description_callout,
     mint_libris_id,
     render_body,
@@ -94,6 +95,23 @@ class BookNote:
         """The note's stable identity, or None until the vault is migrated."""
         value = self.frontmatter.get("libris_id")
         return value.strip() if isinstance(value, str) and value.strip() else None
+
+    @property
+    def superseded_ids(self) -> list[str]:
+        """Identities of Book Notes merged into this one (ADR 0014).
+
+        Returns:
+            The superseded identities, or an empty list. A note that has never
+            absorbed another does not carry the field at all.
+        """
+        value = self.frontmatter.get(SUPERSEDED_IDS_FIELD)
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list):
+            return []
+        return [
+            item.strip() for item in value if isinstance(item, str) and item.strip()
+        ]
 
     @property
     def title(self) -> str | None:

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 from .markdown import read_frontmatter
-from .note_format import SUPERSEDED_IDS_FIELD
+from .note_format import SUPERSEDED_IDS_FIELD, read_superseded_ids
 
 
 @dataclass
@@ -150,10 +150,13 @@ def _collect_superseded_ids(
     """
     survivor_id = primary_fm.get("libris_id")
 
+    # Read through the shared rule rather than iterating the raw value: a bare
+    # string would otherwise be walked character by character, and every letter
+    # would look like an identity.
     candidates: List[Any] = []
-    candidates.extend(primary_fm.get(SUPERSEDED_IDS_FIELD) or [])
+    candidates.extend(read_superseded_ids(primary_fm.get(SUPERSEDED_IDS_FIELD)))
     candidates.append(secondary_fm.get("libris_id"))
-    candidates.extend(secondary_fm.get(SUPERSEDED_IDS_FIELD) or [])
+    candidates.extend(read_superseded_ids(secondary_fm.get(SUPERSEDED_IDS_FIELD)))
 
     collected: List[str] = []
     for value in candidates:

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 from .markdown import read_frontmatter
+from .note_format import SUPERSEDED_IDS_FIELD
 
 
 @dataclass
@@ -129,6 +130,42 @@ def _resolve_field_value(
     return primary_value, True
 
 
+def _collect_superseded_ids(
+    primary_fm: Dict[str, Any], secondary_fm: Dict[str, Any]
+) -> List[str]:
+    """Gather every identity the surviving note should answer for (ADR 0014).
+
+    A merge destroys the secondary note, and its Libris ID with it unless the
+    survivor records it. The secondary may itself have absorbed others, so the
+    chain carries forward: without that, a second merge silently breaks what the
+    first one preserved.
+
+    Args:
+        primary_fm: Frontmatter of the surviving note.
+        secondary_fm: Frontmatter of the note being merged away.
+
+    Returns:
+        The superseded identities, in the order they were absorbed, without
+        duplicates and never including the survivor's own live identity.
+    """
+    survivor_id = primary_fm.get("libris_id")
+
+    candidates: List[Any] = []
+    candidates.extend(primary_fm.get(SUPERSEDED_IDS_FIELD) or [])
+    candidates.append(secondary_fm.get("libris_id"))
+    candidates.extend(secondary_fm.get(SUPERSEDED_IDS_FIELD) or [])
+
+    collected: List[str] = []
+    for value in candidates:
+        if not isinstance(value, str):
+            continue
+        identity = value.strip()
+        if not identity or identity == survivor_id or identity in collected:
+            continue
+        collected.append(identity)
+    return collected
+
+
 def merge_two_books(
     primary_path: Path, secondary_path: Path, allow_conflicts: bool = False
 ) -> Tuple[Dict[str, Any], str, List[MergeConflict]]:
@@ -174,6 +211,15 @@ def merge_two_books(
 
         if has_conflict:
             conflicts.append(MergeConflict(field, primary_val, secondary_val))
+
+    # The secondary is about to be deleted, so the survivor takes on the
+    # identities it answered for (ADR 0014). Done outside the field loop because
+    # this is not a value being reconciled: it is the record of what was destroyed.
+    superseded = _collect_superseded_ids(primary_fm, secondary_fm)
+    if superseded:
+        merged_fm[SUPERSEDED_IDS_FIELD] = superseded
+    else:
+        merged_fm.pop(SUPERSEDED_IDS_FIELD, None)
 
     # If there are conflicts and we don't allow them, return early
     if conflicts and not allow_conflicts:

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -95,6 +95,28 @@ def validate_field_value(field: str, value: object) -> None:
         )
 
 
+def read_superseded_ids(value: object) -> list[str]:
+    """Read a `superseded_ids` value into the list of identities it means.
+
+    Frontmatter arrives from YAML and may hold any shape. This vault writes
+    list-shaped fields as bare strings often enough to matter - 1,341 notes do
+    it with `format` - and a bare string here is especially dangerous, because
+    iterating one yields characters that each look like an identity.
+
+    Args:
+        value: Whatever the frontmatter held.
+
+    Returns:
+        The identities, with blanks dropped. Anything that is neither a string
+        nor a list names no identity at all.
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
 def mint_libris_id(date_added: object) -> str:
     """Mint a Libris ID whose timestamp comes from when the book was added.
 

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -39,6 +39,14 @@ FIELD_VOCABULARIES = {
 }
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
+# The identities of Book Notes merged into this one (ADR 0014). Deliberately
+# NOT part of MODELLED_FIELDS: it is absent on a note that has never absorbed
+# another, which is all but a handful, and adding it to the canonical shape
+# would write `superseded_ids: null` into every note in the Shelf to say
+# nothing. Both `ensure_frontmatter_fields` and the migration preserve keys
+# they do not model, so a note that carries it keeps it.
+SUPERSEDED_IDS_FIELD = "superseded_ids"
+
 MODELLED_FIELDS = IDENTITY_FIELDS + BIBLIOGRAPHIC_FIELDS + READING_FIELDS + DATE_FIELDS
 
 # Headings the linter mistook for a title, and the values that leaked from them.

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -136,6 +136,47 @@ def lookup_candidates(
     return ranked
 
 
+def find_by_libris_id(vault_path: Path, libris_id: str) -> BookNote | None:
+    """Resolve a Libris ID to the Book Note that answers for it.
+
+    A note merged away leaves its identity on the survivor (ADR 0014), so an
+    Intent naming an ID that no longer lives anywhere still applies rather than
+    being rejected for a note Libris itself destroyed.
+
+    Args:
+        vault_path: The Shelf to search.
+        libris_id: The identity to resolve.
+
+    Returns:
+        The Book Note holding that identity, the note that superseded it, or
+        None. A live identity always wins over a superseded one.
+
+    Note:
+        Guaranteeing that a live identity wins means the scan cannot stop at the
+        first superseded match, so resolving an identity that is superseded or
+        unknown reads every Book Note: about 14 seconds against the 3,136-note
+        Shelf. Resolving one Intent that way is fine; resolving a queue of them
+        in a loop is not. A caller with many to resolve should build an index in
+        one pass instead.
+    """
+    if not libris_id:
+        return None
+
+    wanted = libris_id.strip()
+    superseding: BookNote | None = None
+
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is None:
+            continue
+        if note.libris_id == wanted:
+            return note
+        if superseding is None and wanted in note.superseded_ids:
+            superseding = note
+
+    return superseding
+
+
 def find_existing(
     vault_path: Path,
     isbn: str | None = None,

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -159,10 +159,12 @@ def find_by_libris_id(vault_path: Path, libris_id: str) -> BookNote | None:
         in a loop is not. A caller with many to resolve should build an index in
         one pass instead.
     """
-    if not libris_id:
+    wanted = libris_id.strip() if libris_id else ""
+    if not wanted:
+        # Checked after stripping: a whitespace-only id would otherwise read
+        # every note on the Shelf to find nothing.
         return None
 
-    wanted = libris_id.strip()
     superseding: BookNote | None = None
 
     for book_path in list_books(vault_path):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -814,8 +814,10 @@ def test_a_merge_with_no_ids_to_record_adds_no_field(tmp_path):
     # When they are merged
     merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
 
-    # Then nothing is invented
-    assert not merged_fm.get("superseded_ids")
+    # Then nothing is invented. Asserted as absence rather than falsiness: the
+    # field is meant not to exist, and `.get()` cannot tell that apart from a
+    # key present and empty.
+    assert "superseded_ids" not in merged_fm
 
 
 def test_the_written_survivor_holds_the_superseded_id(tmp_path):
@@ -832,3 +834,39 @@ def test_the_written_survivor_holds_the_superseded_id(tmp_path):
     # Then the file itself carries the forwarding address
     note = BookNote.read(primary)
     assert note.superseded_ids == ["LOSER"]
+
+
+def test_a_superseded_id_stored_as_a_bare_string_is_read_as_one_id(tmp_path):
+    # Given a note whose superseded_ids is a bare string rather than a list -
+    # the shape 1,341 notes already use for `format`
+    primary = _note(tmp_path, "Keeper")
+    secondary = _note(tmp_path, "Loser", superseded_ids="EARLIER")
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then it is one identity, not one per character
+    assert merged_fm["superseded_ids"] == ["LOSER", "EARLIER"]
+
+
+def test_a_superseded_id_of_an_unusable_shape_is_ignored(tmp_path):
+    # Given frontmatter holding something that names no identity
+    primary = _note(tmp_path, "Keeper", superseded_ids=42)
+    secondary = _note(tmp_path, "Loser")
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then only the real identity is recorded
+    assert merged_fm["superseded_ids"] == ["LOSER"]
+
+
+def test_reading_superseded_ids_from_a_bare_string(tmp_path):
+    # Given a note carrying the field as a string
+    path = _note(tmp_path, "Solo", superseded_ids="GONE")
+
+    # When the note is read
+    note = BookNote.read(path)
+
+    # Then the reader agrees with the merge helper, because both use one rule
+    assert note.superseded_ids == ["GONE"]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -5,7 +5,10 @@ Tests for book merge functionality.
 from pathlib import Path
 
 import pytest
+import yaml
 
+from libris.api import BookCandidate
+from libris.markdown import BookNote, create_book_note, read_frontmatter
 from libris.merge import (
     check_auto_merge,
     delete_secondary_file,
@@ -707,3 +710,125 @@ class TestMergeCLI:
         # Both files should still exist
         assert (vault / "A.md").exists()
         assert (vault / "B.md").exists()
+
+
+# --- superseded ids (#64, ADR 0014) ---
+
+
+def _note(tmp_path, name, **frontmatter):
+    """Write a Book Note with the given frontmatter and a line of reader's notes."""
+    fields = {
+        "libris_id": name.upper(),
+        "title": name,
+        "authors": ["Frank Herbert"],
+        "status": "To Read",
+    }
+    fields.update(frontmatter)
+    path = tmp_path / f"{name}.md"
+    body = yaml.dump(fields, sort_keys=False, allow_unicode=True)
+    path.write_text(
+        f"---\n{body}---\n\n# {name}\n\n## Notes\n\nMine.\n", encoding="utf-8"
+    )
+    return path
+
+
+def test_merging_records_the_losing_id_on_the_survivor(tmp_path):
+    # Given two notes for one Book
+    primary = _note(tmp_path, "Keeper", isbn="9780441013593")
+    secondary = _note(tmp_path, "Loser")
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the survivor carries the identity the deleted note had, so an Intent
+    # naming it still resolves (ADR 0014)
+    assert merged_fm["superseded_ids"] == ["LOSER"]
+
+
+def test_merging_carries_forward_ids_the_loser_had_absorbed(tmp_path):
+    # Given a note that had itself already absorbed another
+    primary = _note(tmp_path, "Keeper")
+    secondary = _note(tmp_path, "Loser", superseded_ids=["EARLIER"])
+
+    # When it is merged away in turn
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the whole chain survives; a second merge must not break the first
+    assert merged_fm["superseded_ids"] == ["LOSER", "EARLIER"]
+
+
+def test_merging_keeps_ids_the_survivor_had_already_absorbed(tmp_path):
+    # Given a survivor that has absorbed a note before
+    primary = _note(tmp_path, "Keeper", superseded_ids=["OLDEST"])
+    secondary = _note(tmp_path, "Loser")
+
+    # When it absorbs another
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then both are held
+    assert merged_fm["superseded_ids"] == ["OLDEST", "LOSER"]
+
+
+def test_superseded_ids_are_not_duplicated(tmp_path):
+    # Given both notes claiming the same superseded id
+    primary = _note(tmp_path, "Keeper", superseded_ids=["SHARED"])
+    secondary = _note(tmp_path, "Loser", superseded_ids=["SHARED"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then it appears once
+    assert merged_fm["superseded_ids"] == ["SHARED", "LOSER"]
+
+
+def test_the_survivor_never_supersedes_itself(tmp_path):
+    # Given a secondary that somehow lists the survivor's own id
+    primary = _note(tmp_path, "Keeper")
+    secondary = _note(tmp_path, "Loser", superseded_ids=["KEEPER"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the survivor's live identity is not also listed as superseded, which
+    # would make it resolve to itself through two different fields
+    assert "KEEPER" not in merged_fm["superseded_ids"]
+    assert merged_fm["libris_id"] == "KEEPER"
+
+
+def test_a_note_that_absorbed_nothing_has_no_superseded_ids(tmp_path):
+    # Given a note created normally
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path
+    )
+
+    # Then the field is absent rather than present and empty: it is not part of
+    # the canonical shape every note carries
+    assert "superseded_ids" not in read_frontmatter(path)
+
+
+def test_a_merge_with_no_ids_to_record_adds_no_field(tmp_path):
+    # Given notes from before identities existed
+    primary = _note(tmp_path, "Keeper", libris_id=None)
+    secondary = _note(tmp_path, "Loser", libris_id=None)
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then nothing is invented
+    assert not merged_fm.get("superseded_ids")
+
+
+def test_the_written_survivor_holds_the_superseded_id(tmp_path):
+    # Given a completed merge
+    primary = _note(tmp_path, "Keeper")
+    secondary = _note(tmp_path, "Loser")
+    merged_fm, merged_body, _ = merge_two_books(
+        primary, secondary, allow_conflicts=True
+    )
+
+    # When it is written to disk
+    write_merged_book(primary, merged_fm, merged_body)
+
+    # Then the file itself carries the forwarding address
+    note = BookNote.read(primary)
+    assert note.superseded_ids == ["LOSER"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -278,3 +278,13 @@ def test_a_live_id_wins_over_a_superseded_one(tmp_path):
 
     # Then the note that actually holds the identity wins
     assert found.path == live
+
+
+def test_a_blank_libris_id_does_not_resolve(tmp_path):
+    # Given a Shelf with notes on it
+    create_book_note(_candidate(), tmp_path)
+
+    # When an empty or whitespace-only identity is resolved
+    # Then it misses immediately rather than reading every note to find nothing
+    assert find_by_libris_id(tmp_path, "") is None
+    assert find_by_libris_id(tmp_path, "   ") is None

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,12 +8,16 @@ tests exercise that layer directly, with no HTTP involved.
 import pytest
 
 from libris.api import BookCandidate
-from libris.markdown import create_book_note
+from libris.markdown import (
+    BookNote,  # noqa: F401
+    create_book_note,
+)
 from libris.note_format import InvalidFieldValue
 from libris.service import (
     Outcome,
     add_book,
     build_lookup_query,
+    find_by_libris_id,
     find_existing,
     is_isbn10,
 )
@@ -212,3 +216,65 @@ def test_adding_refuses_an_unknown_field(tmp_path):
     # Then it is refused
     with pytest.raises(ValueError):
         add_book(tmp_path, _candidate(), overrides={"nonsense": "x"})
+
+
+# --- resolution through superseded ids (#64, ADR 0014) ---
+
+
+def test_a_live_libris_id_resolves(tmp_path):
+    # Given a Book Note on the Shelf
+    path = create_book_note(_candidate(), tmp_path)
+    note = BookNote.read(path)
+
+    # When it is looked up by its identity
+    found = find_by_libris_id(tmp_path, note.libris_id)
+
+    # Then it is found
+    assert found is not None
+    assert found.path == path
+
+
+def test_a_superseded_id_resolves_to_the_survivor(tmp_path):
+    # Given a note that absorbed another during a merge
+    path = create_book_note(_candidate(), tmp_path)
+    text = path.read_text(encoding="utf-8")
+    path.write_text(
+        text.replace("title:", "superseded_ids:\n- GONE\ntitle:", 1), encoding="utf-8"
+    )
+
+    # When an Intent names the identity that was merged away
+    found = find_by_libris_id(tmp_path, "GONE")
+
+    # Then it resolves to the surviving note rather than missing, so the Intent
+    # applies instead of being rejected for a note Libris itself destroyed
+    assert found is not None
+    assert found.path == path
+
+
+def test_an_unknown_libris_id_does_not_resolve(tmp_path):
+    # Given a Shelf that never held the Book
+    create_book_note(_candidate(), tmp_path)
+
+    # When an unknown identity is looked up
+    # Then a miss is a miss (ADR 0003)
+    assert find_by_libris_id(tmp_path, "01NOPE") is None
+
+
+def test_a_live_id_wins_over_a_superseded_one(tmp_path):
+    # Given one note whose live id is what another note lists as superseded -
+    # possible only through a bad merge, but it must resolve predictably
+    live = create_book_note(_candidate(title="Live"), tmp_path)
+    live_id = BookNote.read(live).libris_id
+
+    other = create_book_note(_candidate(title="Other"), tmp_path)
+    text = other.read_text(encoding="utf-8")
+    other.write_text(
+        text.replace("title:", f"superseded_ids:\n- {live_id}\ntitle:", 1),
+        encoding="utf-8",
+    )
+
+    # When that id is resolved
+    found = find_by_libris_id(tmp_path, live_id)
+
+    # Then the note that actually holds the identity wins
+    assert found.path == live


### PR DESCRIPTION
Closes #64. Implements ADR 0014. Unblocks the bulk merging that #72 enables.

`merge.py` had no knowledge of `libris_id`. `delete_secondary_file` removed the losing note and its identity went with it, with nothing recording what the note had become.

That is harmless while the Shelf is the only replica, because no other Surface has ever seen the id. It stops being harmless once Intents exist: a person marks a book Read from their phone, the desktop merges that book's duplicate before sync runs, and the note they referred to is the one that lost. Libris would then reject an Intent for a note **it destroyed itself**, unable to say what it became.

The survivor now carries `superseded_ids`, and resolution by Libris ID looks through it.

## Two decisions worth a reviewer's attention

**The field is deliberately not in `MODELLED_FIELDS`.** It is absent on a note that has never absorbed another — all but a handful — and adding it to the canonical shape would write `superseded_ids: null` into 3,136 notes to say nothing. Before relying on that I checked both paths that could have silently eaten a non-modelled key: `ensure_frontmatter_fields` dumps the dict it read rather than rebuilding from the schema, and `migrate.py:107` explicitly re-appends keys it does not model. A constant in `note_format.py` says why, so it doesn't get "fixed" later.

**The chain carries forward.** A note that had itself absorbed others passes them all to the new survivor. Without that, a second merge silently breaks what the first one preserved — which is the failure mode this whole change exists to prevent, arriving one merge later.

## Verified against a copy of the real Shelf

Fixtures cannot tell you what your data actually contains, and this turned up two things.

**Your vault holds exactly one Libris ID collision.** The two *A Calendar of Wisdom* notes share `01M0WQEHRZ...`, along with the same ISBN — 3,135 distinct ids across 3,136 notes. That looks like one note having been copied rather than the migration minting duplicates, and merging that pair resolves it. The code handled it correctly by refusing to list the survivor as superseding its own live identity, but that test exists because the real data produced the case.

**Resolving an identity that is superseded or unknown reads every note — measured at 13.75s.** That is inherent to the guarantee that a live id beats a superseded one: the scan cannot stop at the first superseded match. Fine for one Intent, ruinous for a queue of them, so the measured cost is in the docstring rather than left for whoever writes sync to discover. The fix when it is needed is an index built once per run, which is consistent with ADR 0015 already hashing the whole Shelf each run.

End to end on real notes: merging two notes records the loser's id on the survivor, the destroyed id resolves to the survivor across 3,135 notes, a second merge carries both ids, and both still resolve.

291 tests (was 279). `ruff check` and `ruff format --check` clean, green in both matrix install states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
