### PR TITLE
docs: make the pre-commit routine match what CI enforces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ uv run ruff format --check .  # Format check (CI mode)
 ## Workflow
 
 - **Branching:** Always create a feature branch from `main`. Never commit directly to `main`.
-- **Pre-commit:** Run `uv run ruff check --fix .` (auto-fix lint issues, including import sorting) and `uv run pytest` before every commit. Fix any remaining failures.
+- **Pre-commit:** Run `uv run ruff check --fix .` (auto-fix lint issues, including import sorting), `uv run ruff format .`, and `uv run pytest` before every commit. Fix any remaining failures. All three are needed: CI lints and checks formatting as separate steps, so a commit that ran only `ruff check` still fails `ruff format --check .`.
 - **Commit messages:** Use [Conventional Commits](https://www.conventionalcommits.org/):
   - `feat: add book export command`
   - `fix: handle missing ISBN in frontmatter`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,9 @@ See also: [AGENTS.md](AGENTS.md)
 - When starting on a new task, ask the user if a branch already exists. If it doesn't, create a new branch.
 - When feature development/bug fix is complete, ask user if they would like a PR.
 - Use GitHub Issues for issue tracking — reference issues in commits and PRs.
+- When the user relays feedback from a code review, read the whole review before acting:
+  `gh api repos/tjsullivan1/libris/pulls/<N>/comments` lists every inline comment. A relayed
+  comment is usually one of several, and findings that share a root cause are best fixed
+  together rather than one at a time.
+- After a PR merges, check `git log` on `main`. Review suggestions accepted in the GitHub UI
+  land as commits nobody in the session wrote, and later work is built on top of them.


### PR DESCRIPTION
Two conventions, both written because the same thing went wrong twice.

## The pre-commit instruction was incomplete

`AGENTS.md` said:

> **Pre-commit:** Run `uv run ruff check --fix .` … and `uv run pytest` before every commit.

CI's lint job runs **three** steps: `ruff format --check .`, then `ruff check .`, then the tests. So an agent following the documented routine exactly still fails CI — which is exactly what happened on #67, where formatting caught one test file needing a call wrapped across three lines, after `ruff check --fix` had reported everything clean.

The routine now names `ruff format .` too, and says why all three are needed rather than leaving it as a list to be trusted.

## Two facts about reviews in this repo

**A relayed review comment is usually one of several.** Twice now a Copilot review has been passed on a comment at a time: on #68 that left a real loopback-range bug unmentioned, and on #74 three further findings — including one that shared a root cause with the comment that *was* relayed, and was better fixed once at the cause than three times at the symptoms. `CLAUDE.md` now says to read the whole review first, with the command that lists them.

**Suggestions accepted in the GitHub UI land as commits on merge.** This has happened twice, and both times the change was reasonable — but it means `main` carries commits nobody in the session wrote, and later work is built on top of them. Worth a glance at `git log` after pulling.

No code changes. 279 tests pass, `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
