### PR TITLE
feat: format is a list from a closed vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,12 @@ Where a book sits in the reading cycle: To Read, Reading, Read, or Not To Read.
 **Priority**: 
 How much a To Read book is wanted: Low, Medium, or High. Absent on books never triaged.
 
+**Format**:
+The media the reader has a Book in - Physical, Ebook, or Audiobook. Several at once is normal:
+a book owned on paper and listened to as an audiobook is both. Reading state, not a property of
+the work or of any edition.
+_Avoid_: medium, edition, binding
+
 **Series**:
 A link to the note for the series a book belongs to. A relationship within the Vault, not a
 text label, and meaningless outside it.

--- a/docs/adr/0017-format-is-a-list-from-a-closed-vocabulary.md
+++ b/docs/adr/0017-format-is-a-list-from-a-closed-vocabulary.md
@@ -1,0 +1,40 @@
+# Format is a list of media, drawn from a closed vocabulary
+
+`format` records how the reader has this Book: on paper, as an ebook, as an audiobook. It is
+reading state rather than metadata about the work, so it belongs to the reader and not to the
+edition.
+
+It arrived at this decision holding eleven shapes across two types. Measuring the Shelf showed
+why, and the answer was not drift that happened once:
+
+- **1,341 notes hold a bare string**, only ever `Audiobook`, `audiobook` or `ebook`, and 1,280 of
+  them were added in a single month. That is the Audible import: `importer.py` writes
+  `format="Audiobook"` as a scalar.
+- **873 notes hold a list**, only ever `Physical`, `Ebook` or `Audiobook`. No Libris code writes
+  `Physical` at all, so these came from Obsidian's own property editor, which writes YAML lists.
+
+Two writers, two shapes, both still running. A migration alone would have been undone by the next
+import.
+
+**Format is a list.** The only notes carrying deliberate human input about more than one medium
+are lists - three of them say `['Physical', 'Audiobook']` and the like - and owning the hardback
+while listening to the audiobook is ordinary rather than exceptional. Flattening to a scalar would
+match what Libris happens to write, at the cost of information a person entered on purpose.
+
+**The vocabulary is closed at `Physical`, `Ebook`, `Audiobook`** - exactly what the vault holds
+(ADR 0005). It joins the field vocabularies introduced for `status` and `priority`, so an
+unknown value is refused rather than written. We considered adding `Hardcover` and `Paperback`
+up front and rejected it: 538 notes have managed without the distinction, and two overlapping
+values on day one is how a vocabulary rots. Adding a fourth later is a line in a tuple and a test.
+
+**Both writers change, or the vault re-drifts.** The importer writes `["Audiobook"]`. `libris add`
+takes `--format` repeatably, so the CLI can express everything the field can hold and no shape
+exists that the daemon accepts and the CLI cannot produce. The old help text advertised
+"paperback, kindle, audiobook" in lowercase, which is where the 35 lowercase values came from -
+the code was generating the drift it then could not validate.
+
+**Obsidian is a writer Libris cannot guard**, and it is where these notes are actually edited. So
+`ensure_frontmatter_fields` normalises shape and case on every `cleanup`, exactly as it already
+does for `authors`. The migration is the first run of a rule that keeps applying, rather than a
+one-off. A value outside the vocabulary cannot be repaired by guessing, so those are reported
+instead of silently rewritten.

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -1,5 +1,6 @@
 import ipaddress
 import re
+import sys
 import time
 from pathlib import Path
 
@@ -41,8 +42,25 @@ from .merge import (
     merge_two_books,
     write_merged_book,
 )
-from .migrate import apply_migration, plan_migration
-from .note_format import InvalidFieldValue, validate_field_value
+from .migrate import apply_migration, plan_format_migration, plan_migration
+from .note_format import (
+    InvalidFieldValue,
+    normalize_field_value,
+    validate_field_value,
+)
+
+# Windows consoles and redirected output default to cp1252, which cannot encode
+# 39 of this Shelf's filenames - they carry U+FFFD where an accent was lost. A
+# command that dies while printing a book's name is never the right answer, so
+# output is UTF-8 and unencodable characters are replaced rather than fatal.
+for _stream in (sys.stdout, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        try:
+            _reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):  # a stream that cannot be reconfigured
+            pass
+
 
 app = typer.Typer()
 
@@ -168,11 +186,12 @@ def search(
 def add(
     query: str = typer.Argument(..., help="Title, author, or ISBN to search for"),
     status: str = typer.Option("To Read", "--status", "-s", help="Reading status"),
-    medium: str | None = typer.Option(
+    medium: list[str] = typer.Option(
         None,
         "--format",
         "-f",
-        help="Reading format (e.g., paperback, kindle, audiobook)",
+        help="Format you have this book in; repeat for more than one "
+        "(Physical, Ebook, Audiobook)",
     ),
     rating: int | None = typer.Option(
         None, "--rating", "-r", help="Rating (1-5)", min=1, max=5
@@ -193,6 +212,10 @@ def add(
     # network round trip and a book picker.
     try:
         validate_field_value("status", status)
+        if medium:
+            validate_field_value(
+                "format", normalize_field_value("format", list(medium))
+            )
     except InvalidFieldValue as exc:
         typer.echo(str(exc))
         raise typer.Exit(code=1) from None
@@ -220,8 +243,8 @@ def add(
 
     # Build overrides from CLI options
     overrides = {"status": status}
-    if medium is not None:
-        overrides["format"] = medium
+    if medium:
+        overrides["format"] = list(medium)
     if rating is not None:
         overrides["rating"] = rating
     if referred_by is not None:
@@ -343,6 +366,9 @@ def cleanup(
     limit: int = typer.Option(
         0, "--limit", "-n", help="Stop after N files that needed action (0 = unlimited)"
     ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Report what would change without writing anything"
+    ),
 ):
     """Ensure all books in the vault have the correct frontmatter fields."""
     vault_path = get_vault_path()
@@ -369,7 +395,7 @@ def cleanup(
 
         file_had_action = False
 
-        updated, fm = ensure_frontmatter_fields(book_file)
+        updated, fm = ensure_frontmatter_fields(book_file, dry_run=dry_run)
         if updated:
             updated_count += 1
             file_had_action = True
@@ -987,6 +1013,11 @@ def migrate(
     out: str | None = typer.Option(
         None, "--out", help="Write the full diff to this file for review"
     ),
+    formats: bool = typer.Option(
+        False,
+        "--formats",
+        help="Migrate only the format field, leaving every other field alone",
+    ),
 ):
     """Migrate the Shelf to the canonical Book Note shape.
 
@@ -999,7 +1030,7 @@ def migrate(
         raise typer.Exit(code=1)
 
     typer.echo(f"Planning migration for {vault_path}...")
-    plans = plan_migration(vault_path)
+    plans = plan_format_migration(vault_path) if formats else plan_migration(vault_path)
     changing = [plan for plan in plans if plan.changed]
 
     change_counts: dict[str, int] = {}

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -378,6 +378,16 @@ def cleanup(
         typer.echo("No books found in vault.")
         return
 
+    if dry_run and (rename or auto_enrich):
+        # Renaming rewrites wikilinks and enrichment writes frontmatter, and
+        # neither has a preview mode. A flag that says it writes nothing has to
+        # mean it, so the combination is refused rather than half-honoured.
+        typer.echo(
+            "--dry-run covers frontmatter only. It cannot preview --rename or "
+            "--auto-enrich, which write as they go."
+        )
+        raise typer.Exit(code=1)
+
     vault_root = get_obsidian_vault_root() or vault_path if rename else None
 
     updated_count = 0

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -29,7 +29,7 @@ class ImportBook:
 
     candidate: BookCandidate
     status: str  # "Read", "To Read", "Reading"
-    format: str | None = None  # "Audiobook", "Hardcover", "Paperback", "eBook"
+    format: list[str] = field(default_factory=list)  # see note_format.FORMAT_VALUES
     source_format: str = ""
 
     @property
@@ -71,7 +71,7 @@ def parse_audible_json(path: Path) -> List[ImportBook]:
             ImportBook(
                 candidate=BookCandidate(title=title, authors=authors, source="audible"),
                 status=status,
-                format="Audiobook",
+                format=["Audiobook"],
                 source_format="audible-json",
             )
         )

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -184,43 +184,47 @@ def _check_duplicate(
     return (note.path, fm, updates)
 
 
-def _apply_updates(path: Path, book: ImportBook, updates: List[str]):
-    """Apply field updates to an existing vault note."""
+def _apply_updates(path: Path, book: ImportBook, updates: List[str]) -> bool:
+    """Apply field updates to an existing vault note.
+
+    Args:
+        path: The Book Note to update.
+        book: The imported book carrying the new values.
+        updates: Which fields to apply.
+
+    Returns:
+        True when the note was updated, False when its frontmatter could not be
+        read - in which case nothing was written to it.
+    """
     if "status" in updates:
         update_book_status(path, book.status)
 
-    if "format" in updates:
-        content = path.read_text(encoding="utf-8")
-        # Parse frontmatter using YAML to properly handle missing fields
-        match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+    if "format" not in updates:
+        return True
 
-        if match:
-            frontmatter_yaml = match.group(1)
-            rest_of_content = match.group(2)
+    content = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+    if match is None:
+        return False
 
-            try:
-                data = yaml.safe_load(frontmatter_yaml)
-                if isinstance(data, dict):
-                    # Update the format field
-                    data["format"] = book.format
-                    # Write back the updated frontmatter
-                    new_frontmatter = yaml.dump(
-                        data, sort_keys=False, allow_unicode=True
-                    ).strip()
-                    # Preserve content structure: remove only leading newlines
-                    content_part = rest_of_content.lstrip("\n")
-                    new_content = f"---\n{new_frontmatter}\n---\n{content_part}"
-                    path.write_text(new_content, encoding="utf-8")
-            except yaml.YAMLError:
-                # Fallback to regex replacement if YAML parsing fails
-                pattern = r"(format:\s*)(.*)"
-                new_content = re.sub(pattern, f"\\1{book.format}", content)
-                if new_content == content:
-                    # format field might be null — replace the null value
-                    new_content = content.replace(
-                        "format: null", f"format: {book.format}"
-                    )
-                path.write_text(new_content, encoding="utf-8")
+    frontmatter_yaml, rest_of_content = match.group(1), match.group(2)
+    try:
+        data = yaml.safe_load(frontmatter_yaml)
+    except yaml.YAMLError:
+        # Deliberately no regex fallback. format is a list (ADR 0017), so a
+        # line-level substitution would write a Python repr and strand any
+        # existing block items below it, turning a note we could not parse into
+        # one nobody can. It is left alone instead.
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    data["format"] = book.format
+    new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
+    content_part = rest_of_content.lstrip("\n")
+    path.write_text(f"---\n{new_frontmatter}\n---\n{content_part}", encoding="utf-8")
+    return True
 
 
 def run_import(
@@ -259,7 +263,8 @@ def run_import(
             if updates:
                 result.updated_books.append((book, dup_path, updates))
                 if apply:
-                    _apply_updates(dup_path, book, updates)
+                    if not _apply_updates(dup_path, book, updates):
+                        result.skipped_books.append(book)
             else:
                 result.skipped_books.append(book)
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -16,6 +16,8 @@ from .note_format import (
     SUPERSEDED_IDS_FIELD,
     has_description_callout,
     mint_libris_id,
+    normalize_field_value,
+    read_formats,
     read_superseded_ids,
     render_body,
     render_description_callout,
@@ -223,6 +225,7 @@ def create_book_note(
                     f"Unknown frontmatter field: '{key}'. "
                     f"Valid fields: {', '.join(DEFAULT_FRONTMATTER.keys())}"
                 )
+            value = normalize_field_value(key, value)
             validate_field_value(key, value)
             frontmatter[key] = value
 
@@ -259,12 +262,21 @@ def list_books(vault_path: Path):
     ]
 
 
-def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str, Any]]]:
+def ensure_frontmatter_fields(
+    file_path: Path, dry_run: bool = False
+) -> tuple[bool, Optional[Dict[str, Any]]]:
     """Ensures that all current fields exist in the note's frontmatter.
 
-    Returns a tuple of (updated, frontmatter_dict). The dict is the cleaned
-    frontmatter data (whether or not it was written back), or None if the
-    frontmatter could not be parsed.
+    Args:
+        file_path: The Book Note to repair.
+        dry_run: Report what would change without writing it. This pass is what
+            migrates `format` across the Shelf (ADR 0017), so it can be
+            previewed before it rewrites anything.
+
+    Returns:
+        A tuple of (updated, frontmatter_dict). The dict is the cleaned
+        frontmatter data, whether or not it was written back, or None if the
+        frontmatter could not be parsed.
     """
     content = file_path.read_text(encoding="utf-8")
 
@@ -318,6 +330,15 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         data["authors"] = [data["authors"]]
         updated = True
 
+    # Repair format's shape and case, the same way authors is repaired above.
+    # Obsidian writes this field too and Libris cannot guard it there, so the
+    # rule is applied on every pass rather than once in a migration (ADR 0017).
+    if "format" in data:
+        formats = read_formats(data["format"]) or None
+        if formats != data["format"]:
+            data["format"] = formats
+            updated = True
+
     # Standardize title casing and strip annotations
     title_val = data.get("title")
     if title_val and isinstance(title_val, str):
@@ -337,7 +358,7 @@ def ensure_frontmatter_fields(file_path: Path) -> tuple[bool, Optional[Dict[str,
         rest_of_content = f"# {title}\n\n{rest_of_content.lstrip()}"
         updated = True
 
-    if updated:
+    if updated and not dry_run:
         # Use dump but ensure we don't add unnecessary trailing newlines or spaces
         new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
         # Ensure there is exactly one newline before and after the rest of the content

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -16,13 +16,17 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 from .markdown import BookNote, list_books
 from .note_format import (
+    FORMAT_VALUES,
     LEAKED_HEADINGS,
     MODELLED_FIELDS,
     has_description_callout,
     has_title_heading,
     mint_libris_id,
+    read_formats,
     render_body,
     split_body,
 )
@@ -290,6 +294,87 @@ def plan_migration(vault_path: Path) -> list[NoteMigration]:
         One plan per note, including notes that need no change.
     """
     return [plan_note_migration(path) for path in list_books(vault_path)]
+
+
+def _render_formats(formats: list[str]) -> str:
+    """Render a format value the way the vault already writes lists."""
+    if not formats:
+        return "format:"
+    # Two-space indent, which is how every list in this vault is already
+    # written - anything else rewrites 873 notes to say the same thing.
+    lines = ["format:"]
+    lines.extend(f"  - {name}" for name in formats)
+    return "\n".join(lines)
+
+
+def plan_note_format_migration(path: Path) -> NoteMigration:
+    """Plan the format rewrite for one Book Note (ADR 0017).
+
+    Touches `format` and nothing else. Running the whole `cleanup` pass would
+    also restandardise titles - measured at 41 notes on this Shelf, seven of
+    them lowercasing a word that should not be - and a format migration is no
+    place to decide that.
+
+    Args:
+        path: The Book Note to plan.
+
+    Returns:
+        The plan, unchanged when the note's format is already canonical.
+    """
+    # Read through universal newlines and write plain ones, exactly as
+    # plan_note_migration does. The Shelf is stored CRLF, and the platform adds
+    # that back on write - emitting it here too produced \r\r\n on 1,345 notes.
+    original = path.read_text(encoding="utf-8")
+
+    match = re.match(r"^---\n(.*?)\n---\n(.*)$", original, re.DOTALL)
+    if match is None:
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=["no parseable frontmatter"],
+        )
+
+    frontmatter_text, body = match.group(1), match.group(2)
+    blocks = split_frontmatter_blocks(frontmatter_text)
+    if not any(key == "format" for key, _ in blocks):
+        return NoteMigration(path=path, original=original, migrated=original)
+
+    current = yaml.safe_load(frontmatter_text) or {}
+    formats = read_formats(current.get("format"))
+
+    unknown = [name for name in formats if name not in FORMAT_VALUES]
+    if unknown:
+        # Guessing what an unknown format meant is exactly the silent wrongness
+        # ADR 0003 refuses, so it is reported and left alone.
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=[f"format not in the vocabulary: {', '.join(unknown)}"],
+        )
+
+    rendered = _render_formats(formats)
+    rebuilt = [(key, rendered if key == "format" else raw) for key, raw in blocks]
+    new_frontmatter = "\n".join(raw for _, raw in rebuilt)
+    migrated = f"---\n{new_frontmatter}\n---\n{body}"
+
+    changes = ["format"] if migrated != original else []
+    return NoteMigration(
+        path=path, original=original, migrated=migrated, changes=changes
+    )
+
+
+def plan_format_migration(vault_path: Path) -> list[NoteMigration]:
+    """Plan the format rewrite for every Book Note on the Shelf.
+
+    Args:
+        vault_path: The Shelf to migrate.
+
+    Returns:
+        One plan per note, including notes that need no change.
+    """
+    return [plan_note_format_migration(path) for path in list_books(vault_path)]
 
 
 def apply_migration(plans: list[NoteMigration]) -> int:

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -336,11 +336,33 @@ def plan_note_format_migration(path: Path) -> NoteMigration:
         )
 
     frontmatter_text, body = match.group(1), match.group(2)
+
+    # Parsed before anything else: one unparseable note must not abort a
+    # 3,136-note run, so it is reported and left alone, the same way
+    # plan_note_migration treats a note it cannot read.
+    try:
+        current = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=[f"frontmatter is not valid YAML: {type(exc).__name__}"],
+        )
+    if not isinstance(current, dict):
+        return NoteMigration(
+            path=path,
+            original=original,
+            migrated=original,
+            warnings=["frontmatter is not a mapping"],
+        )
+
     blocks = split_frontmatter_blocks(frontmatter_text)
-    if not any(key == "format" for key, _ in blocks):
+    if "format" not in current or not any(key == "format" for key, _ in blocks):
+        # Nothing to migrate, or the key exists only in a shape this cannot
+        # rewrite safely.
         return NoteMigration(path=path, original=original, migrated=original)
 
-    current = yaml.safe_load(frontmatter_text) or {}
     formats = read_formats(current.get("format"))
 
     unknown = [name for name in formats if name not in FORMAT_VALUES]

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -38,6 +38,11 @@ FIELD_VOCABULARIES = {
     "priority": PRIORITY_VALUES,
     "format": FORMAT_VALUES,
 }
+
+# Fields that hold several values at once. Everything else is a scalar, and a
+# list arriving for one of them is the wrong shape rather than a set of values
+# to check one by one - `status: [Read]` must be refused, not accepted.
+MULTI_VALUED_FIELDS = frozenset({"format"})
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
 # The identities of Book Notes merged into this one (ADR 0014). Deliberately
@@ -91,9 +96,18 @@ def validate_field_value(field: str, value: object) -> None:
     if allowed is None or value is None:
         return
 
-    # A multi-valued field is checked entry by entry, so the message names the
-    # value that is wrong rather than the whole list.
-    proposed = value if isinstance(value, list) else [value]
+    if isinstance(value, list):
+        if field not in MULTI_VALUED_FIELDS:
+            raise InvalidFieldValue(
+                f"Invalid {field}: {value!r} is a list, but {field} holds a "
+                f"single value. Valid values: {', '.join(allowed)}."
+            )
+        # A multi-valued field is checked entry by entry, so the message names
+        # the value that is wrong rather than the whole list.
+        proposed = list(value)
+    else:
+        proposed = [value]
+
     for item in proposed:
         if item not in allowed:
             raise InvalidFieldValue(

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -28,14 +28,15 @@ READING_FIELDS = ("status", "priority", "rating", "format", "tags", "referred_by
 
 # The values these fields may hold, taken from the vault rather than from what
 # the code used to assume (ADR 0005). Measured across all 3,136 notes: status
-# and priority already hold nothing else. `format` is absent on purpose - it
-# holds eleven shapes across two types today and needs a migration before it
-# can be constrained.
+# and priority already held nothing else. `format` held eleven shapes across
+# two types and joined them once ADR 0017 settled what it is.
 STATUS_VALUES = ("To Read", "Reading", "Read", "Not To Read")
 PRIORITY_VALUES = ("Low", "Medium", "High")
+FORMAT_VALUES = ("Physical", "Ebook", "Audiobook")
 FIELD_VOCABULARIES = {
     "status": STATUS_VALUES,
     "priority": PRIORITY_VALUES,
+    "format": FORMAT_VALUES,
 }
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
@@ -89,10 +90,15 @@ def validate_field_value(field: str, value: object) -> None:
     allowed = FIELD_VOCABULARIES.get(field)
     if allowed is None or value is None:
         return
-    if value not in allowed:
-        raise InvalidFieldValue(
-            f"Invalid {field}: {value!r}. Valid values: {', '.join(allowed)}."
-        )
+
+    # A multi-valued field is checked entry by entry, so the message names the
+    # value that is wrong rather than the whole list.
+    proposed = value if isinstance(value, list) else [value]
+    for item in proposed:
+        if item not in allowed:
+            raise InvalidFieldValue(
+                f"Invalid {field}: {item!r}. Valid values: {', '.join(allowed)}."
+            )
 
 
 def read_superseded_ids(value: object) -> list[str]:
@@ -115,6 +121,56 @@ def read_superseded_ids(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def read_formats(value: object) -> list[str]:
+    """Read a `format` value into the list of media it means (ADR 0017).
+
+    The Shelf holds this field in two shapes, written by two different tools:
+    Libris wrote a bare string, Obsidian's property editor writes a list. Both
+    read the same way here, and case is repaired, because "audiobook" names a
+    real format and refusing it would only punish the reader for the help text
+    Libris used to print.
+
+    Args:
+        value: Whatever the frontmatter or a caller held.
+
+    Returns:
+        The formats named, title-cased and without blanks. Anything that is
+        neither a string nor a list names no format at all.
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+
+    formats: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        name = item.strip().title()
+        if name and name not in formats:
+            formats.append(name)
+    return formats
+
+
+def normalize_field_value(field: str, value: object) -> object:
+    """Put a value into the shape the Library stores it in.
+
+    Shape and case are repaired; meaning is not guessed at. A value that names
+    nothing the Library defines is left alone for validation to refuse.
+
+    Args:
+        field: The frontmatter field being written.
+        value: The value proposed for it.
+
+    Returns:
+        The normalized value, or the original for fields with no shape rule.
+    """
+    if field != "format":
+        return value
+    formats = read_formats(value)
+    return formats or None
 
 
 def mint_libris_id(date_added: object) -> str:

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -520,3 +520,24 @@ def test_cleanup_dry_run_reports_without_writing(tmp_path):
     # And the note on disk is untouched, so 1,341 of these can be previewed
     # before any of them is rewritten
     assert path.read_text(encoding="utf-8") == before
+
+
+def test_a_list_is_refused_for_a_single_valued_field(tmp_path):
+    # Given status arriving as a list, which a browser client could send
+    # When it is written
+    # Then the shape is refused rather than the entries being checked one by
+    # one and the list written into frontmatter
+    with pytest.raises(InvalidFieldValue) as excinfo:
+        create_book_note(_candidate(), tmp_path, overrides={"status": ["Read"]})
+
+    assert "single value" in str(excinfo.value)
+
+
+def test_a_list_is_still_accepted_for_format(tmp_path):
+    # Given the one field that does hold several values
+    path = create_book_note(
+        _candidate(), tmp_path, overrides={"format": ["Physical", "Audiobook"]}
+    )
+
+    # Then it is written
+    assert read_frontmatter(path)["format"] == ["Physical", "Audiobook"]

--- a/tests/test_canonical_schema.py
+++ b/tests/test_canonical_schema.py
@@ -16,11 +16,13 @@ from libris.importer import _build_vault_index
 from libris.markdown import (
     compute_canonical_filename,
     create_book_note,
+    ensure_frontmatter_fields,
     find_duplicates,
+    read_frontmatter,
     rename_book_file,
     update_book_status,
 )
-from libris.note_format import InvalidFieldValue
+from libris.note_format import InvalidFieldValue, read_formats
 
 # The exact key set present on all 3,137 notes in the vault.
 CANONICAL_FRONTMATTER = {
@@ -353,11 +355,168 @@ def test_updating_to_a_known_status_is_allowed(tmp_path):
     assert "status: Read" in path.read_text(encoding="utf-8")
 
 
-def test_format_is_not_validated_yet(tmp_path):
-    # Given the vault holds format as both string and list, in mixed case
-    # When a note is created with a bare string, as `libris add -f` writes today
+def test_format_is_normalised_rather_than_taken_as_given(tmp_path):
+    # Given a bare string, as `libris add -f` used to write
     path = create_book_note(_candidate(), tmp_path, overrides={"format": "Audiobook"})
 
-    # Then it is accepted. Validating this needs the field's type settled and
-    # 1,341 notes migrated first, which is its own piece of work.
-    assert path.exists()
+    # Then it is stored as the list the Library defines (#69, ADR 0017). This
+    # test used to assert the opposite, pinning the gap until it was closed.
+    assert read_frontmatter(path)["format"] == ["Audiobook"]
+
+
+# --- format is a list from a closed vocabulary (#69, ADR 0017) ---
+#
+# Measured before writing these. The vault holds eleven shapes across two types:
+# 1,341 bare strings (only Audiobook variants, 1,280 from one Audible import),
+# 873 lists (only Physical/Ebook/Audiobook, written by Obsidian), 35 lowercase,
+# 4 empty lists, and 3 genuinely multi-valued notes.
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Audiobook", ["Audiobook"]),
+        ("audiobook", ["Audiobook"]),
+        ("ebook", ["Ebook"]),
+        (["Physical"], ["Physical"]),
+        (["Physical", "Audiobook"], ["Physical", "Audiobook"]),
+        ([], []),
+        (None, []),
+        (42, []),
+        (["Physical", "", None], ["Physical"]),
+    ],
+)
+def test_every_shape_the_vault_holds_reads_as_a_list(raw, expected):
+    # Given each shape measured in the vault
+    # When it is read
+    # Then it becomes the list of formats it meant
+    assert read_formats(raw) == expected
+
+
+def test_a_multi_format_note_keeps_both(tmp_path):
+    # Given a book owned on paper and listened to - three notes say this
+    path = create_book_note(
+        BookCandidate(title="Changes", authors=["Jim Butcher"]),
+        tmp_path,
+        overrides={"format": ["Physical", "Audiobook"]},
+    )
+
+    # Then nothing is lost
+    assert read_frontmatter(path)["format"] == ["Physical", "Audiobook"]
+
+
+def test_a_bare_string_format_is_stored_as_a_list(tmp_path):
+    # Given a writer that still sends a scalar, as the importer did
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]),
+        tmp_path,
+        overrides={"format": "Audiobook"},
+    )
+
+    # Then the note holds the shape the Library defines
+    assert read_frontmatter(path)["format"] == ["Audiobook"]
+
+
+def test_a_lowercase_format_is_corrected(tmp_path):
+    # Given the lowercase the old help text invited - 35 notes carry it
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]),
+        tmp_path,
+        overrides={"format": "audiobook"},
+    )
+
+    # Then case is repaired rather than refused; it names a real format
+    assert read_frontmatter(path)["format"] == ["Audiobook"]
+
+
+def test_a_format_outside_the_vocabulary_is_refused(tmp_path):
+    # Given a value no note in the vault holds, and which guessing cannot repair
+    # When it is written
+    # Then it is refused (ADR 0017)
+    with pytest.raises(InvalidFieldValue):
+        create_book_note(
+            BookCandidate(title="Dune", authors=["Frank Herbert"]),
+            tmp_path,
+            overrides={"format": "Kindle"},
+        )
+
+
+def test_one_bad_format_among_good_ones_is_refused(tmp_path):
+    # Given a list where only one entry is wrong
+    with pytest.raises(InvalidFieldValue) as excinfo:
+        create_book_note(
+            BookCandidate(title="Dune", authors=["Frank Herbert"]),
+            tmp_path,
+            overrides={"format": ["Physical", "Kindle"]},
+        )
+
+    # Then the message names the offending value, not the whole list
+    assert "Kindle" in str(excinfo.value)
+
+
+def test_cleanup_repairs_a_format_obsidian_could_have_written(tmp_path):
+    # Given a note edited outside Libris into the old scalar shape
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path
+    )
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.replace("format: null", "format: audiobook"), encoding="utf-8")
+
+    # When cleanup runs
+    updated, data = ensure_frontmatter_fields(path)
+
+    # Then shape and case are repaired, because Obsidian is a writer Libris
+    # cannot guard and this is where notes are actually edited (ADR 0017)
+    assert updated is True
+    assert data["format"] == ["Audiobook"]
+
+
+def test_cleanup_leaves_a_conforming_format_alone(tmp_path):
+    # Given a note already in the right shape
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]),
+        tmp_path,
+        overrides={"format": ["Physical"]},
+    )
+
+    # When cleanup runs
+    _, data = ensure_frontmatter_fields(path)
+
+    # Then it is unchanged
+    assert data["format"] == ["Physical"]
+
+
+def test_cleanup_turns_an_empty_format_list_into_unset(tmp_path):
+    # Given the four notes in the vault holding an empty list
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path
+    )
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.replace("format: null", "format: []"), encoding="utf-8")
+
+    # When cleanup runs
+    _, data = ensure_frontmatter_fields(path)
+
+    # Then it is unset: an empty list and no value say the same thing
+    assert data["format"] is None
+
+
+def test_cleanup_dry_run_reports_without_writing(tmp_path):
+    # Given a note Obsidian left in the old scalar shape
+    path = create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path
+    )
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.replace("format: null", "format: audiobook"), encoding="utf-8")
+    before = path.read_text(encoding="utf-8")
+
+    # When cleanup is asked what it would do
+    updated, data = ensure_frontmatter_fields(path, dry_run=True)
+
+    # Then it reports the repair it would make
+    assert updated is True
+    assert data["format"] == ["Audiobook"]
+
+    # And the note on disk is untouched, so 1,341 of these can be previewed
+    # before any of them is rewritten
+    assert path.read_text(encoding="utf-8") == before

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,7 +279,7 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
             "--status",
             "Read",
             "--format",
-            "kindle",
+            "Audiobook",
             "--rating",
             "5",
             "--referred-by",
@@ -299,7 +299,7 @@ def test_add_command_passes_cli_overrides(monkeypatch, tmp_path):
     assert captured["status"] == "Read"
     assert captured["overrides"] == {
         "status": "Read",
-        "format": "kindle",
+        "format": ["Audiobook"],
         "rating": 5,
         "referred_by": "Alice",
         "tags": "Sci-Fi,Classic",
@@ -407,4 +407,52 @@ def test_add_refuses_an_unknown_status_before_searching(monkeypatch):
     assert result.exit_code != 0
     assert "finished" in result.output
     assert "To Read" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_add_accepts_more_than_one_format(monkeypatch, tmp_path):
+    # Given a book owned on paper and listened to
+    from libris.api import BookCandidate
+
+    monkeypatch.setattr(
+        "libris.cli.GoogleBooksClient.search",
+        lambda self, q: [BookCandidate(title="Changes", authors=["Jim Butcher"])],
+    )
+
+    class _Selection:
+        def ask(self):
+            return "Changes by Jim Butcher"
+
+    monkeypatch.setattr("libris.cli.questionary.select", lambda *a, **k: _Selection())
+    monkeypatch.setattr("libris.cli.get_vault_path", lambda: tmp_path)
+
+    captured = {}
+
+    def fake_create(book, vault_path, status, overrides):
+        captured["overrides"] = overrides
+        return vault_path / "Changes.md"
+
+    monkeypatch.setattr("libris.cli.create_book_note", fake_create)
+
+    # When both are given
+    result = runner.invoke(app, ["add", "Changes", "-f", "Physical", "-f", "Audiobook"])
+
+    # Then the CLI can express everything the field holds (ADR 0017)
+    assert result.exit_code == 0
+    assert captured["overrides"]["format"] == ["Physical", "Audiobook"]
+
+
+def test_add_refuses_an_unknown_format_before_searching(monkeypatch):
+    # Given a search that would fail loudly if it ran
+    def _never(*args, **kwargs):
+        raise AssertionError("the API was called despite an invalid format")
+
+    monkeypatch.setattr("libris.cli.GoogleBooksClient.search", _never)
+
+    # When a book is added with a format the Library does not define
+    result = runner.invoke(app, ["add", "Dune", "-f", "kindle"])
+
+    # Then it is refused up front, and the message says what is allowed
+    assert result.exit_code != 0
+    assert "Physical" in result.output
     assert "Traceback" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,3 +456,20 @@ def test_add_refuses_an_unknown_format_before_searching(monkeypatch):
     assert result.exit_code != 0
     assert "Physical" in result.output
     assert "Traceback" not in result.output
+
+
+def test_cleanup_dry_run_refuses_to_combine_with_rename(tmp_path, monkeypatch):
+    # Given a dry run asked to also rename files
+    monkeypatch.setattr("libris.cli.get_vault_path", lambda: tmp_path)
+    (tmp_path / "Dune - Frank Herbert.md").write_text(
+        "---\ntitle: Dune\nauthors:\n  - Frank Herbert\n---\n\n# Dune\n",
+        encoding="utf-8",
+    )
+
+    # When cleanup runs
+    result = runner.invoke(app, ["cleanup", "--dry-run", "--rename"])
+
+    # Then it refuses, because renaming rewrites wikilinks and has no preview:
+    # a flag that says it writes nothing has to mean it
+    assert result.exit_code != 0
+    assert "--rename" in result.output

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -86,7 +86,8 @@ def test_parse_audible_json_basic(tmp_path):
     assert books[0].title == "The Great Book"
     assert books[0].authors == ["Jane Smith"]
     assert books[0].status == "Read"
-    assert books[0].format == "Audiobook"
+    # A list since ADR 0017: the reader may have a book in more than one medium.
+    assert books[0].format == ["Audiobook"]
     assert books[0].source_format == "audible-json"
 
     assert books[1].title == "Another Book"
@@ -170,10 +171,10 @@ def test_import_new_books_apply(tmp_path):
         content = f.read_text(encoding="utf-8")
         if "Book One" in content:
             assert "status: To Read" in content
-            assert "format: Audiobook" in content
+            assert "format:\n- Audiobook" in content
         elif "Book Two" in content:
             assert "status: Read" in content
-            assert "format: Audiobook" in content
+            assert "format:\n- Audiobook" in content
 
 
 def test_import_detects_duplicates(tmp_path):
@@ -188,7 +189,7 @@ def test_import_detects_duplicates(tmp_path):
         title="Existing Book",
         authors=["Author A"],
         status="Read",
-        format="Audiobook",
+        format=["Audiobook"],
     )
 
     data = [
@@ -252,7 +253,7 @@ def test_import_updates_format_on_duplicate(tmp_path):
     assert "format" in result.updated_books[0][2]
 
     content = existing.read_text(encoding="utf-8")
-    assert "format: Audiobook" in content
+    assert "format:\n- Audiobook" in content
 
 
 def test_import_updates_format_when_field_missing(tmp_path):
@@ -276,7 +277,7 @@ def test_import_updates_format_when_field_missing(tmp_path):
     assert "format" in result.updated_books[0][2]
 
     content = existing.read_text(encoding="utf-8")
-    assert "format: Audiobook" in content
+    assert "format:\n- Audiobook" in content
 
 
 def test_import_updates_both_status_and_format(tmp_path):
@@ -304,7 +305,7 @@ def test_import_updates_both_status_and_format(tmp_path):
 
     content = existing.read_text(encoding="utf-8")
     assert "status: Read" in content
-    assert "format: Audiobook" in content
+    assert "format:\n- Audiobook" in content
 
 
 def test_import_skips_up_to_date_duplicate(tmp_path):
@@ -318,7 +319,7 @@ def test_import_skips_up_to_date_duplicate(tmp_path):
         title="My Book",
         authors=["Author A"],
         status="Read",
-        format="Audiobook",
+        format=["Audiobook"],
     )
 
     data = [{"title": "My Book", "author": "Author A", "finished": "Yes"}]
@@ -356,7 +357,7 @@ def test_import_case_insensitive_duplicate(tmp_path):
         title="The Great Book",
         authors=["Jane Smith"],
         status="Read",
-        format="Audiobook",
+        format=["Audiobook"],
     )
 
     # Same book with different casing

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -4,9 +4,12 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from libris.api import BookCandidate
 from libris.cli import app
 from libris.config import set_config
 from libris.importer import (
+    ImportBook,
+    _apply_updates,
     normalize_for_match,
     parse_audible_json,
     run_import,
@@ -441,3 +444,25 @@ def test_cli_import_unknown_format(tmp_path):
     result = runner.invoke(app, ["import", str(csv_file)])
     assert result.exit_code == 1
     assert "Cannot detect format" in result.output
+
+
+def test_apply_updates_leaves_unparseable_frontmatter_alone(tmp_path):
+    # Given a note whose frontmatter is not valid YAML
+    path = tmp_path / "Broken.md"
+    original = "---\ntitle: [unclosed\nformat: null\n---\n\n# Broken\n"
+    path.write_text(original, encoding="utf-8")
+
+    book = ImportBook(
+        candidate=BookCandidate(title="Broken", authors=["Someone"]),
+        status="Read",
+        format=["Audiobook"],
+    )
+
+    # When an import tries to update its format
+    applied = _apply_updates(path, book, ["format"])
+
+    # Then nothing is written: a line-level substitution would write a Python
+    # repr and strand existing block items, turning a note we cannot parse into
+    # one nobody can
+    assert applied is False
+    assert path.read_text(encoding="utf-8") == original

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -63,7 +63,7 @@ def test_create_book_note_with_overrides(tmp_path):
 
     # Given overrides for format, rating, and referred_by
     overrides = {
-        "format": "kindle",
+        "format": "Audiobook",
         "rating": 4,
         "referred_by": "A Friend",
     }
@@ -73,7 +73,7 @@ def test_create_book_note_with_overrides(tmp_path):
 
     # Then the overrides appear in frontmatter
     content = file_path.read_text()
-    assert "format: kindle" in content
+    assert "format:\n- Audiobook" in content
     assert "rating: 4" in content
     assert "referred_by: A Friend" in content
 
@@ -313,7 +313,7 @@ rating: 5
     assert "Type Read" not in content
     assert "Rating out of 5" not in content
     # Existing canonical values should be preserved (not overwritten)
-    assert "format: Audiobook" in content
+    assert "format:\n- Audiobook" in content
     assert "rating: 5" in content
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -5,6 +5,7 @@ from datetime import date
 from libris.markdown import BookNote
 from libris.migrate import (
     leaked_alias_keys,
+    plan_note_format_migration,
     plan_note_migration,
     recover_title,
     reorder_frontmatter,
@@ -292,3 +293,119 @@ def test_a_note_without_frontmatter_is_skipped_not_mangled(tmp_path):
     # Then it is left exactly as it was, and says why
     assert not plan.changed
     assert plan.warnings == ["no parseable frontmatter; skipped"]
+
+
+# --- targeted format migration (#69, ADR 0017) ---
+
+
+def _note_with_format(tmp_path, name, format_block):
+    """Write a Book Note whose frontmatter carries the given format lines."""
+    path = tmp_path / f"{name}.md"
+    path.write_text(
+        "---\n"
+        "libris_id: 01TEST\n"
+        f"title: {name}\n"
+        "authors:\n"
+        "  - Frank Herbert\n"
+        "status: Read\n"
+        f"{format_block}\n"
+        "tags: Book\n"
+        "---\n"
+        "\n"
+        f"# {name}\n"
+        "\n"
+        "## Notes\n"
+        "\n"
+        "Mine, and not to be touched.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_a_bare_string_format_is_planned_as_a_list(tmp_path):
+    # Given the shape the Audible import wrote 1,306 times
+    path = _note_with_format(tmp_path, "Dune", "format: Audiobook")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then it becomes the list the Library defines, indented the way this vault
+    # already writes lists
+    assert plan.changed is True
+    assert "format:\n  - Audiobook" in plan.migrated
+    assert plan.changes == ["format"]
+
+
+def test_a_lowercase_format_is_planned_as_title_case(tmp_path):
+    # Given the lowercase the old help text invited
+    path = _note_with_format(tmp_path, "Dune", "format: audiobook")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then case is repaired
+    assert "format:\n  - Audiobook" in plan.migrated
+
+
+def test_an_already_canonical_format_is_left_alone(tmp_path):
+    # Given a note Obsidian wrote correctly - 873 of them
+    path = _note_with_format(tmp_path, "Dune", "format:\n  - Physical")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then nothing is rewritten, so the run touches only what needs it
+    assert plan.changed is False
+
+
+def test_an_empty_format_list_becomes_unset(tmp_path):
+    # Given one of the four notes holding an empty list
+    path = _note_with_format(tmp_path, "Dune", "format: []")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then it is unset: an empty list and no value say the same thing
+    assert plan.changed is True
+    assert "format:\n" in plan.migrated
+    assert "- " not in plan.migrated.split("tags:")[0].split("format:")[1]
+
+
+def test_an_unknown_format_is_reported_not_guessed_at(tmp_path):
+    # Given a value the vocabulary does not define
+    path = _note_with_format(tmp_path, "Dune", "format: Kindle")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then the note is left alone and the reason is reported, because guessing
+    # what it meant is the silent wrongness ADR 0003 refuses
+    assert plan.changed is False
+    assert plan.warnings
+    assert "Kindle" in plan.warnings[0]
+
+
+def test_the_body_is_never_touched(tmp_path):
+    # Given a note with the reader's own writing in it
+    path = _note_with_format(tmp_path, "Dune", "format: Audiobook")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then only the frontmatter moves
+    assert "Mine, and not to be touched." in plan.migrated
+    assert plan.migrated.split("---", 2)[2] == plan.original.split("---", 2)[2]
+
+
+def test_a_note_without_a_format_field_is_left_alone(tmp_path):
+    # Given a note predating the field
+    path = tmp_path / "Old.md"
+    path.write_text(
+        "---\nlibris_id: 01TEST\ntitle: Old\n---\n\n# Old\n", encoding="utf-8"
+    )
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then nothing is invented
+    assert plan.changed is False

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -409,3 +409,33 @@ def test_a_note_without_a_format_field_is_left_alone(tmp_path):
 
     # Then nothing is invented
     assert plan.changed is False
+
+
+def test_a_note_with_unparseable_frontmatter_is_reported_not_fatal(tmp_path):
+    # Given a note whose frontmatter is not valid YAML
+    path = tmp_path / "Broken.md"
+    path.write_text(
+        "---\ntitle: [unclosed\nformat: Audiobook\n---\n\n# Broken\n",
+        encoding="utf-8",
+    )
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then it is reported and left alone, so one bad note cannot abort a run
+    # across the whole Shelf
+    assert plan.changed is False
+    assert plan.warnings
+
+
+def test_frontmatter_that_is_not_a_mapping_is_reported(tmp_path):
+    # Given frontmatter that parses but is a list rather than a mapping
+    path = tmp_path / "Odd.md"
+    path.write_text("---\n- format: Audiobook\n---\n\n# Odd\n", encoding="utf-8")
+
+    # When the migration is planned
+    plan = plan_note_format_migration(path)
+
+    # Then it is reported rather than raising an AttributeError mid-run
+    assert plan.changed is False
+    assert plan.warnings


### PR DESCRIPTION
Closes #69. Implements ADR 0017. Unblocks the `format` half of #72.

`format` held **eleven shapes across two types**. The reason turned out not to be drift that happened once:

- **1,341 notes held a bare string**, only ever `Audiobook`/`audiobook`/`ebook`, and **1,280 of them were added in a single month** — the Audible import, which writes `format="Audiobook"` as a scalar.
- **873 notes held a list**, only ever `Physical`/`Ebook`/`Audiobook`. No Libris code writes `Physical` at all, so those came from **Obsidian's property editor**, which writes YAML lists.

Two writers, two shapes, both still running. Migrating the notes without changing the writers would have been undone by your next Audible export.

## What changed

- `FORMAT_VALUES` joins `FIELD_VOCABULARIES`, so an unknown format is refused like an unknown status (#65). Validation now checks a list entry by entry, so the message names the offending value rather than the whole list.
- `read_formats` reads either shape and repairs case. `audiobook` names a real format; refusing it would only punish the reader for the help text Libris itself printed — `cli.py:174` advertised "paperback, kindle, audiobook" in lowercase, which is exactly where the 35 lowercase values came from.
- The importer writes `["Audiobook"]`. **`libris add --format` is repeatable**, so the CLI can express everything the field holds and no shape exists that the daemon accepts and the CLI cannot send.
- `cleanup` normalises shape and case on every run, as it already does for `authors` — Obsidian is a writer Libris cannot guard, and it's where these notes are actually edited.
- `cleanup` gains `--dry-run`.

## The migration is targeted, and here's why

`libris migrate --formats` touches that field and nothing else, rather than riding the full `cleanup` pass.

Running `cleanup` across the Shelf **also restandardises 41 titles**. 33 look like improvements (`Head on` → `Head On`, `The Canterbury Tales [Blackstone]` → `The Canterbury Tales`), but **7 lowercase a word that shouldn't be**, including `Isaac Newton, The Royal Society` → `the Royal Society` and `The Punic Wars 265-146BC` → `265-146bc`. A format migration is no place to decide that, so it doesn't.

## Verified against a copy of the real Shelf

**1,345 notes change** — the 1,341 bare strings plus the 4 empty lists. **Zero** fall outside the vocabulary. Bodies untouched, CRLF preserved, and every count reconciles:

| Before | After |
|---|---|
| 1,306 `'Audiobook'` + 34 `'audiobook'` + 192 `['Audiobook']` | 1,532 `['Audiobook']` |
| 922 unset + 4 `[]` | 926 unset |
| 139 `['Ebook']` + 1 `'ebook'` | 140 `['Ebook']` |
| 535 `['Physical']` | 535 `['Physical']` |
| 3 multi-format | 3 multi-format, intact |

Two notes were LF-only and are now CRLF like the other 3,134 — content byte-identical, endings aligned.

## A crash the migration exposed

`libris cleanup` was **dying 185 files in** whenever output was redirected. **39 of this Shelf's filenames cannot be encoded in cp1252** — they carry U+FFFD where an accent was lost (`S�ren Kierkegaard`, `Ram�n G�mez`) — and `typer.echo` raised `UnicodeEncodeError` on the first one. Pre-existing, and it affects `list`, `autoenrich` and `duplicates` too. Output is now UTF-8 with unencodable characters replaced.

**No test asserts this**: reproducing it needs Windows *and* a redirected stream, so CI (Linux, UTF-8) cannot. Verified by hand — the same command that died at file 185 now completes all 3,136.

The underlying data problem is separate and not fixed here: 41 notes carry U+FFFD, in 38 filenames, 35 author names and 9 titles. Worth its own issue.

322 tests (was 315). `ruff check` and `ruff format --check` clean, green in both matrix install states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
