### PR TITLE
fix: duplicate detection, and applying a reviewed set of merges

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,12 @@ A Libris ID that identified a Book Note which has since merged into another. It 
 reused and never dangles: it resolves to the surviving note.
 _Avoid_: dead id, old id, tombstone
 
+**Duplicate Candidate**:
+Two Book Notes that may describe one Book, matched by title rather than by a shared identifier.
+A candidate is offered to a person to confirm and never merged on its own, because titles are
+compared loosely and a wrong answer merges two different Books.
+_Avoid_: possible duplicate, near duplicate
+
 **Matching**:
 Deciding whether two Book Notes describe the same book — the judgement behind duplicate
 detection and import de-duplication. Deliberately separate from identity, and allowed to be

--- a/docs/adr/0018-merging-asks-only-what-needs-a-person.md
+++ b/docs/adr/0018-merging-asks-only-what-needs-a-person.md
@@ -4,18 +4,34 @@ Merging destroys a Book Note, so the questions it asks have to be worth stopping
 that wrong in either direction is expensive: a merge that asks nothing loses data quietly, and
 one that asks about everything trains the reader to wave it through.
 
-## A conflict means a modelled field disagrees
+## A conflict means the reader's own value disagrees
 
 `merge_two_books` compared every key in either note. 414 notes carry `date_created` and
 `date_modified`, which Obsidian writes and Libris does not model, and two different files never
 agree on them. So most merges reported a conflict, and the only way past was
 `allow_conflicts=True` - a flag that also suppresses a genuine disagreement about an ISBN.
 
-Noise that trains someone to disable a safety check is worse than no check. Conflicts are now
-reported only for fields in the canonical schema. Fields outside it take the surviving note's
+Noise that trains someone to disable a safety check is worse than no check.
+
+Restricting conflicts to the canonical schema was the first attempt, and measuring it showed the
+cut was in the wrong place: **0 of 83 Duplicate Candidate pairs merged cleanly**. Every pair
+disagreed on `libris_id`, because two notes always hold different ones; on `title`, because a
+containing title is what made them a candidate; and on `isbn`, `page_count`, `date_published` or
+`cover_thumbnail`, because two editions of one work differ. Exactly one pair disagreed about a
+`rating`.
+
+So the question is not whether the Library models a field, but whose fact it is. An ISBN belongs
+to the edition and the surviving note's will do. A Libris ID is not contested at all - the other
+is recorded as superseded (ADR 0014). A rating belongs to the reader, and two different ratings
+means they rated the same book twice; nobody else can say which stands.
+
+A merge therefore stops only for the reader's own fields: status, priority, rating, referred_by,
+the dates read, and the multi-valued format and tags. Everything else takes the surviving note's
 value without comment, and `aliases`, which is genuinely multi-valued, is unioned like the
 others. Obsidian rewrites `date_modified` on the next edit anyway, so nothing is lost that the
 editor will not restore.
+
+Under this rule 82 of the 83 pairs merge unattended and the one real question surfaces.
 
 ## Fields that hold several values are combined, and sameness is judged loosely
 

--- a/docs/adr/0018-merging-asks-only-what-needs-a-person.md
+++ b/docs/adr/0018-merging-asks-only-what-needs-a-person.md
@@ -1,4 +1,4 @@
-# Merging asks a person only what only a person can answer
+# A merge asks only what a person can settle
 
 Merging destroys a Book Note, so the questions it asks have to be worth stopping for. Getting
 that wrong in either direction is expensive: a merge that asks nothing loses data quietly, and

--- a/docs/adr/0018-merging-asks-only-what-needs-a-person.md
+++ b/docs/adr/0018-merging-asks-only-what-needs-a-person.md
@@ -1,0 +1,51 @@
+# Merging asks a person only what only a person can answer
+
+Merging destroys a Book Note, so the questions it asks have to be worth stopping for. Getting
+that wrong in either direction is expensive: a merge that asks nothing loses data quietly, and
+one that asks about everything trains the reader to wave it through.
+
+## A conflict means a modelled field disagrees
+
+`merge_two_books` compared every key in either note. 414 notes carry `date_created` and
+`date_modified`, which Obsidian writes and Libris does not model, and two different files never
+agree on them. So most merges reported a conflict, and the only way past was
+`allow_conflicts=True` - a flag that also suppresses a genuine disagreement about an ISBN.
+
+Noise that trains someone to disable a safety check is worse than no check. Conflicts are now
+reported only for fields in the canonical schema. Fields outside it take the surviving note's
+value without comment, and `aliases`, which is genuinely multi-valued, is unioned like the
+others. Obsidian rewrites `date_modified` on the next edit anyway, so nothing is lost that the
+editor will not restore.
+
+## Fields that hold several values are combined, and sameness is judged loosely
+
+`authors`, `genres`, `tags` and `format` hold several values, so a merge unions them rather than
+picking a winner. Two notes crediting different authors describe one book by both of them.
+
+Deduplicating that union on exact strings would not work here: 185 notes carry irregular
+whitespace in an author name and 8 write authors as wikilinks, so `Dan   Harris` and
+`Dan Harris`, or `[[Leo Tolstoy]]` and `Leo Tolstoy`, would each survive as two people. Sameness
+is therefore judged on the fully normalized name - wikilink unwrapped, whitespace collapsed.
+
+What gets *written* is narrower than what gets compared. The surviving value has its whitespace
+collapsed but keeps its wikilink, because in Obsidian a wikilink is the graph edge to that
+author's note and unwrapping it would quietly delete a connection. Comparing loosely and writing
+conservatively is deliberate: the loose half prevents doubles, and the conservative half keeps a
+merge from editing values nobody asked it to touch.
+
+## Judgement happens where the evidence is; merging happens where the data is fresh
+
+Roughly seventy-four of the Shelf's duplicate pairs are Duplicate Candidates - matched by title
+containment rather than by an identifier - and each needs a person to say whether two notes
+describe one book. A terminal is a poor place to compare two notes and a fine place to merge
+them.
+
+So the two halves are split. A person triages on a surface built for it, and `libris merge`
+consumes the exported decisions, which are keyed by Libris ID rather than by title or path.
+Before acting the command re-derives the candidate pairs from the live Shelf and applies a
+decision only where the file and the vault still agree, reporting anything that has drifted
+instead of acting on a stale answer. A Libris ID that was merged away in the meantime still
+resolves, because the survivor records it (ADR 0014).
+
+Nothing in this path merges without an answer. A candidate with no decision recorded is left
+alone.

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -1014,9 +1014,10 @@ def _merge_from_decisions(
 
     counts: dict[str, int] = {}
     for outcome in outcomes:
-        counts[outcome.status] = counts.get(outcome.status, 0) + 1
-        if outcome.status != "skipped":
-            typer.echo(f"  {_DECISION_LABELS[outcome.status]}: {outcome.detail}")
+        status = outcome.status.value
+        counts[status] = counts.get(status, 0) + 1
+        if status != "skipped":
+            typer.echo(f"  {_DECISION_LABELS[status]}: {outcome.detail}")
 
     typer.echo("")
     for status in ("merged", "would_merge", "conflicted", "drifted", "skipped"):

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import re
 import sys
 import time
@@ -21,6 +22,7 @@ from .markdown import (
     RenameResult,
     create_book_note,
     ensure_frontmatter_fields,
+    find_duplicate_candidates,
     find_duplicates,
     list_books,
     read_frontmatter,
@@ -48,6 +50,7 @@ from .note_format import (
     normalize_field_value,
     validate_field_value,
 )
+from .service import apply_decisions
 
 # Windows consoles and redirected output default to cp1252, which cannot encode
 # 39 of this Shelf's filenames - they carry U+FFFD where an accent was lost. A
@@ -808,13 +811,13 @@ def enrich(
 def duplicates():
     """Find and report duplicate books in the vault."""
     vault_path = get_vault_path()
+
     groups = find_duplicates(vault_path)
 
     if not groups:
         typer.echo("No duplicates found.")
-        return
-
-    typer.echo(f"Found {len(groups)} group(s) of duplicates:\n")
+    else:
+        typer.echo(f"Found {len(groups)} group(s) of duplicates:\n")
     for i, group in enumerate(groups, 1):
         typer.echo(f"Group {i}:")
         for path in group:
@@ -830,6 +833,19 @@ def duplicates():
             typer.echo(f"  - {path.name}{detail_str}")
         typer.echo()
 
+    candidates = find_duplicate_candidates(vault_path)
+    if candidates:
+        typer.echo(f"\n{len(candidates)} duplicate candidate(s) need a person:")
+        typer.echo(
+            "  One title contains the other, which is a judgement rather than a "
+            "fact.\n  Nothing here is merged without an answer."
+        )
+        for first, second in candidates:
+            typer.echo(f"\n  {first.title}")
+            typer.echo(f"  {second.title}")
+            typer.echo(f"    {first.path.name}")
+            typer.echo(f"    {second.path.name}")
+
 
 @app.command()
 def merge(
@@ -838,6 +854,21 @@ def merge(
         "--auto",
         help="Auto-merge duplicates when ISBN and Google ID match (no conflicts)",
     ),
+    decisions: str | None = typer.Option(
+        None,
+        "--decisions",
+        help="Apply an exported duplicate review (JSON) instead of prompting",
+    ),
+    allow_conflicts: bool = typer.Option(
+        False,
+        "--allow-conflicts",
+        help="With --decisions, merge even when the reader's own values disagree",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="With --decisions, report what would happen and write nothing",
+    ),
 ):
     """Merge duplicate books in the vault.
 
@@ -845,6 +876,10 @@ def merge(
     With --auto: Automatically merge books when ISBN + Google ID match and no metadata conflicts exist.
     """
     vault_path = get_vault_path()
+
+    if decisions is not None:
+        _merge_from_decisions(vault_path, Path(decisions), allow_conflicts, dry_run)
+        return
     groups = find_duplicates(vault_path)
 
     if not groups:
@@ -941,6 +976,61 @@ def merge(
                 continue
 
     typer.echo(f"\nMerge complete: {total_merged} duplicate(s) merged")
+
+
+_DECISION_LABELS = {
+    "merged": "Merged",
+    "would_merge": "Would merge",
+    "skipped": "Left alone",
+    "conflicted": "Needs you",
+    "drifted": "Moved on",
+}
+
+
+def _merge_from_decisions(
+    vault_path: Path, path: Path, allow_conflicts: bool, dry_run: bool = False
+) -> None:
+    """Apply a duplicate review exported from the review page."""
+    if not path.exists():
+        typer.echo(f"No such decisions file: {path}")
+        raise typer.Exit(code=1)
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Could not read {path.name}: {exc}")
+        raise typer.Exit(code=1) from None
+
+    records = payload.get("decisions") if isinstance(payload, dict) else payload
+    if not isinstance(records, list):
+        typer.echo(f"{path.name} holds no decisions.")
+        raise typer.Exit(code=1)
+
+    verb = "Planning" if dry_run else "Applying"
+    typer.echo(f"{verb} {len(records)} decision(s) for {vault_path}...")
+    outcomes = apply_decisions(
+        vault_path, records, allow_conflicts=allow_conflicts, dry_run=dry_run
+    )
+
+    counts: dict[str, int] = {}
+    for outcome in outcomes:
+        counts[outcome.status] = counts.get(outcome.status, 0) + 1
+        if outcome.status != "skipped":
+            typer.echo(f"  {_DECISION_LABELS[outcome.status]}: {outcome.detail}")
+
+    typer.echo("")
+    for status in ("merged", "would_merge", "conflicted", "drifted", "skipped"):
+        if counts.get(status):
+            typer.echo(f"  {_DECISION_LABELS[status]}: {counts[status]}")
+
+    if dry_run and counts.get("would_merge"):
+        typer.echo("\nDry run. Nothing written. Re-run without --dry-run to merge.")
+
+    if counts.get("conflicted"):
+        typer.echo(
+            "\nA pair that needs you disagrees about something only you can settle -"
+            "\na rating, a status, when you read it. Merge those with `libris merge`."
+        )
 
 
 @app.command(name="import")

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -64,6 +64,23 @@ def _normalize_author(name: str) -> str:
     return re.sub(r"\s+", " ", unlinked).strip()
 
 
+def tidy_author(name: str) -> str:
+    """Collapse whitespace in an author value, leaving a wikilink intact.
+
+    Narrower than `_normalize_author` on purpose. That one is for deciding
+    whether two spellings mean the same person; this is for deciding what to
+    write, and unwrapping a wikilink would delete the edge to an author's note
+    (ADR 0018).
+
+    Args:
+        name: The value as it appears in frontmatter.
+
+    Returns:
+        The value with runs of whitespace collapsed.
+    """
+    return re.sub(r"\s+", " ", name).strip()
+
+
 @dataclass
 class BookNote:
     """A book on the Shelf: the file it lives in, its frontmatter, and its body.

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -11,6 +11,7 @@ import yaml
 from titlecase import titlecase
 
 from .api import BookCandidate
+from .matching import normalize_for_match
 from .note_format import (
     MODELLED_FIELDS,
     SUPERSEDED_IDS_FIELD,
@@ -279,6 +280,64 @@ def list_books(vault_path: Path):
     ]
 
 
+def find_duplicate_candidates(vault_path: Path) -> list[list[BookNote]]:
+    """Find pairs of Book Notes that may describe one Book.
+
+    Matched by title containment rather than by a shared identifier, which is a
+    judgement rather than a fact: measured against the real Shelf, containment
+    conflates 83 pairs, of which roughly nine are different books - "Mercy" and
+    "Long Road to Mercy", "Freakonomics" and "SuperFreakonomics". So these are
+    offered to a person and never merged automatically (ADR 0018).
+
+    Pairs that `find_duplicates` already reports are left out; they are settled,
+    not candidates.
+
+    Args:
+        vault_path: The Shelf to search.
+
+    Returns:
+        Pairs of Book Notes, shorter title first, ordered by author then title.
+    """
+    notes: list[BookNote] = []
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is not None and note.title and note.first_author:
+            notes.append(note)
+
+    settled = set()
+    for group in find_duplicates(vault_path):
+        for a in group:
+            for b in group:
+                if a != b:
+                    settled.add(frozenset((str(a), str(b))))
+
+    by_author: dict[str, list[BookNote]] = {}
+    for note in notes:
+        by_author.setdefault(normalize_for_match(note.first_author), []).append(note)
+
+    seen = set()
+    pairs: list[list[BookNote]] = []
+    for group in by_author.values():
+        for a in group:
+            for b in group:
+                if a.path == b.path:
+                    continue
+                title_a = normalize_for_match(a.title)
+                title_b = normalize_for_match(b.title)
+                if title_a == title_b or title_a not in title_b:
+                    continue
+                key = frozenset((str(a.path), str(b.path)))
+                if key in seen or key in settled:
+                    continue
+                seen.add(key)
+                pairs.append([a, b])
+
+    pairs.sort(
+        key=lambda pair: ((pair[0].first_author or "").lower(), pair[0].title or "")
+    )
+    return pairs
+
+
 def ensure_frontmatter_fields(
     file_path: Path, dry_run: bool = False
 ) -> tuple[bool, Optional[Dict[str, Any]]]:
@@ -427,7 +486,10 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
 
     for idx, note in enumerate(notes):
         if note.title is not None:
-            title_groups.setdefault(note.title.lower(), []).append(idx)
+            # Normalized rather than lowercased: punctuation is not meaning
+            # here, and "Crucial Conversations- Tools" and "Crucial
+            # Conversations: Tools" are one Book (#72).
+            title_groups.setdefault(normalize_for_match(note.title), []).append(idx)
 
         isbn = note.frontmatter.get("isbn")
         if isbn:

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -13,8 +13,8 @@ import yaml
 
 from .markdown import _normalize_author, read_frontmatter, tidy_author
 from .note_format import (
-    MODELLED_FIELDS,
     MULTI_VALUED_FIELDS,
+    READER_FIELDS,
     SUPERSEDED_IDS_FIELD,
     read_superseded_ids,
 )
@@ -119,14 +119,15 @@ def _resolve_field_value(
     if field in MULTI_VALUED_FIELDS:
         return _union_values(field, primary_value, secondary_value), False
 
-    # A field the Library does not model - Obsidian's timestamps, a url - takes
-    # the keeper's value without asking. Two files never agree on a timestamp,
-    # and a merge that reports that as a conflict teaches the reader to pass
-    # --allow-conflicts, which would suppress a real one (ADR 0018).
-    if field not in MODELLED_FIELDS:
+    # Everything else takes the keeper's value without asking, unless the value
+    # is the reader's own. Obsidian's timestamps never agree between two files;
+    # an ISBN, a page count or a cover differs because two editions of one work
+    # differ; and two notes always hold different Libris IDs, which ADR 0014
+    # records as superseded rather than contested. None of those is a question
+    # for a person. A rating is (ADR 0018).
+    if field not in READER_FIELDS:
         return primary_value, False
 
-    # All other fields with different values: conflict
     return primary_value, True
 
 

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -12,7 +12,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 from .markdown import read_frontmatter
-from .note_format import SUPERSEDED_IDS_FIELD, read_superseded_ids
+from .note_format import (
+    MULTI_VALUED_FIELDS,
+    SUPERSEDED_IDS_FIELD,
+    read_superseded_ids,
+)
 
 
 @dataclass
@@ -107,8 +111,11 @@ def _resolve_field_value(
             return "Read", False  # "Read" beats everything
         return primary_value, False  # Use primary as default
 
-    # For list fields (author, genres, tags): merge unique items
-    if field in ["author", "genres", "tags"]:
+    # Fields that hold several values are combined rather than contested. The
+    # set is named once in note_format: this list used to say "author" while
+    # every note carries "authors", so author lists were reported as conflicts
+    # and the secondary's were dropped (#72). `format` was never here at all.
+    if field in MULTI_VALUED_FIELDS:
         primary_list = (
             primary_value if isinstance(primary_value, list) else [primary_value]
         )

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -11,8 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from .markdown import read_frontmatter
+from .markdown import _normalize_author, read_frontmatter, tidy_author
 from .note_format import (
+    MODELLED_FIELDS,
     MULTI_VALUED_FIELDS,
     SUPERSEDED_IDS_FIELD,
     read_superseded_ids,
@@ -116,25 +117,57 @@ def _resolve_field_value(
     # every note carries "authors", so author lists were reported as conflicts
     # and the secondary's were dropped (#72). `format` was never here at all.
     if field in MULTI_VALUED_FIELDS:
-        primary_list = (
-            primary_value if isinstance(primary_value, list) else [primary_value]
-        )
-        secondary_list = (
-            secondary_value if isinstance(secondary_value, list) else [secondary_value]
-        )
+        return _union_values(field, primary_value, secondary_value), False
 
-        # Merge and deduplicate
-        merged = []
-        seen = set()
-        for item in primary_list + secondary_list:
-            if item and str(item) not in seen:
-                merged.append(item)
-                seen.add(str(item))
-
-        return (merged if merged else primary_value), False
+    # A field the Library does not model - Obsidian's timestamps, a url - takes
+    # the keeper's value without asking. Two files never agree on a timestamp,
+    # and a merge that reports that as a conflict teaches the reader to pass
+    # --allow-conflicts, which would suppress a real one (ADR 0018).
+    if field not in MODELLED_FIELDS:
+        return primary_value, False
 
     # All other fields with different values: conflict
     return primary_value, True
+
+
+def _union_values(field: str, primary_value: Any, secondary_value: Any) -> List[Any]:
+    """Combine two multi-valued fields, keeping every distinct value once.
+
+    Authors are compared on their fully normalized name, so one person spelled
+    `Dan   Harris` in one note and `[[Dan Harris]]` in the other survives once
+    rather than twice. What is written is only whitespace-collapsed, because
+    unwrapping the wikilink would delete a graph edge (ADR 0018).
+
+    Args:
+        field: The field being combined.
+        primary_value: The keeper's value, which may be a bare string.
+        secondary_value: The value from the note being merged away.
+
+    Returns:
+        The combined values, keeper's first.
+    """
+    primary_list = primary_value if isinstance(primary_value, list) else [primary_value]
+    secondary_list = (
+        secondary_value if isinstance(secondary_value, list) else [secondary_value]
+    )
+
+    merged: List[Any] = []
+    seen = set()
+    for item in list(primary_list) + list(secondary_list):
+        if not item:
+            continue
+        if field == "authors" and isinstance(item, str):
+            written = tidy_author(item)
+            identity = _normalize_author(item)
+        else:
+            written = item
+            identity = str(item)
+        if identity in seen:
+            continue
+        merged.append(written)
+        seen.add(identity)
+
+    return merged if merged else primary_value
 
 
 def _collect_superseded_ids(

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -43,6 +43,25 @@ FIELD_VOCABULARIES = {
 # list arriving for one of them is the wrong shape rather than a set of values
 # to check one by one - `status: [Read]` must be refused, not accepted - and a
 # merge unions these rather than reporting a conflict and keeping one side.
+# Fields whose value belongs to the reader rather than to the edition. A merge
+# stops only for these: an ISBN or a page count differs because two editions of
+# one work differ, and the surviving note's will do, but two different ratings
+# means the reader rated the same book twice and only they can say which stands
+# (ADR 0018). Measured on the real Shelf: under the old rule, where every
+# modelled field could conflict, 0 of 83 candidate pairs merged cleanly.
+READER_FIELDS = frozenset(
+    {
+        "status",
+        "priority",
+        "rating",
+        "referred_by",
+        "date_started",
+        "date_finished",
+        "format",
+        "tags",
+    }
+)
+
 # `aliases` is Obsidian's, not modelled here, but it genuinely holds several
 # values and a merge should combine them rather than keep one side's.
 MULTI_VALUED_FIELDS = frozenset({"authors", "genres", "tags", "format", "aliases"})

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -39,10 +39,11 @@ FIELD_VOCABULARIES = {
     "format": FORMAT_VALUES,
 }
 
-# Fields that hold several values at once. Everything else is a scalar, and a
+# Fields that hold several values at once. Everything else is a scalar, so a
 # list arriving for one of them is the wrong shape rather than a set of values
-# to check one by one - `status: [Read]` must be refused, not accepted.
-MULTI_VALUED_FIELDS = frozenset({"format"})
+# to check one by one - `status: [Read]` must be refused, not accepted - and a
+# merge unions these rather than reporting a conflict and keeping one side.
+MULTI_VALUED_FIELDS = frozenset({"authors", "genres", "tags", "format"})
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
 # The identities of Book Notes merged into this one (ADR 0014). Deliberately

--- a/src/libris/note_format.py
+++ b/src/libris/note_format.py
@@ -43,7 +43,9 @@ FIELD_VOCABULARIES = {
 # list arriving for one of them is the wrong shape rather than a set of values
 # to check one by one - `status: [Read]` must be refused, not accepted - and a
 # merge unions these rather than reporting a conflict and keeping one side.
-MULTI_VALUED_FIELDS = frozenset({"authors", "genres", "tags", "format"})
+# `aliases` is Obsidian's, not modelled here, but it genuinely holds several
+# values and a merge should combine them rather than keep one side's.
+MULTI_VALUED_FIELDS = frozenset({"authors", "genres", "tags", "format", "aliases"})
 DATE_FIELDS = ("date_added", "date_started", "date_finished")
 
 # The identities of Book Notes merged into this one (ADR 0014). Deliberately

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -13,6 +13,12 @@ from pathlib import Path
 from .api import BookCandidate, GoogleBooksClient
 from .markdown import BookNote, create_book_note, list_books
 from .matching import best_match, normalize_for_match, titles_match
+from .merge import (
+    delete_secondary_file,
+    get_primary_book,
+    merge_two_books,
+    write_merged_book,
+)
 
 
 class Outcome(Enum):
@@ -331,3 +337,85 @@ def add_book(
         path=path,
         outcome=Outcome.CREATED,
     )
+
+
+@dataclass
+class DecisionOutcome:
+    """What became of one decision from an exported review."""
+
+    status: str  # merged, skipped, conflicted, drifted, undecided
+    detail: str
+
+
+def _resolve_pair(vault_path: Path, first_id: str, second_id: str):
+    """Find the two Book Notes a decision names, following superseded IDs."""
+    first = find_by_libris_id(vault_path, first_id)
+    second = find_by_libris_id(vault_path, second_id)
+    return first, second
+
+
+def apply_decisions(
+    vault_path: Path, decisions: list[dict], allow_conflicts: bool = False
+) -> list[DecisionOutcome]:
+    """Merge the pairs an exported review marked as one Book.
+
+    The file records a judgement made against the Shelf as it was. Rather than
+    trusting it, every pair is resolved against the Shelf as it is now, by
+    Libris ID - which survives a rename and, since ADR 0014, a merge. A pair
+    that no longer resolves has drifted and is reported rather than acted on.
+
+    Args:
+        vault_path: The Shelf to act on.
+        decisions: Decision records from the review export.
+        allow_conflicts: Merge even when a modelled field disagrees. Off by
+            default: the file answered "is this one Book", not "which ISBN is
+            right".
+
+    Returns:
+        One outcome per decision, in the order given.
+    """
+    outcomes: list[DecisionOutcome] = []
+
+    for decision in decisions:
+        verdict = decision.get("decision")
+        shorter = (decision.get("shorter") or {}).get("libris_id")
+        longer = (decision.get("longer") or {}).get("libris_id")
+        label = (decision.get("shorter") or {}).get("title") or "unknown"
+
+        if verdict != "same":
+            outcomes.append(
+                DecisionOutcome("skipped", f"{label}: recorded as two books")
+            )
+            continue
+
+        if not shorter or not longer:
+            outcomes.append(
+                DecisionOutcome("drifted", f"{label}: decision names no Libris ID")
+            )
+            continue
+
+        first, second = _resolve_pair(vault_path, shorter, longer)
+        if first is None or second is None or first.path == second.path:
+            outcomes.append(
+                DecisionOutcome("drifted", f"{label}: no longer two notes on the Shelf")
+            )
+            continue
+
+        primary = get_primary_book(first.path, second.path)
+        secondary = second.path if primary == first.path else first.path
+
+        merged_fm, merged_body, conflicts = merge_two_books(
+            primary, secondary, allow_conflicts=allow_conflicts
+        )
+        if conflicts and not allow_conflicts:
+            fields = ", ".join(sorted({c.field for c in conflicts}))
+            outcomes.append(
+                DecisionOutcome("conflicted", f"{label}: {fields} disagree")
+            )
+            continue
+
+        write_merged_book(primary, merged_fm, merged_body)
+        delete_secondary_file(secondary)
+        outcomes.append(DecisionOutcome("merged", f"{label} -> {primary.name}"))
+
+    return outcomes

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -339,19 +339,55 @@ def add_book(
     )
 
 
-@dataclass
-class DecisionOutcome:
+class DecisionStatus(Enum):
     """What became of one decision from an exported review."""
 
-    status: str  # merged, skipped, conflicted, drifted, undecided
+    MERGED = "merged"
+    WOULD_MERGE = "would_merge"
+    SKIPPED = "skipped"
+    CONFLICTED = "conflicted"
+    DRIFTED = "drifted"
+
+
+@dataclass
+class DecisionOutcome:
+    """The result of applying one decision, and a line explaining it."""
+
+    status: DecisionStatus
     detail: str
 
 
-def _resolve_pair(vault_path: Path, first_id: str, second_id: str):
-    """Find the two Book Notes a decision names, following superseded IDs."""
-    first = find_by_libris_id(vault_path, first_id)
-    second = find_by_libris_id(vault_path, second_id)
-    return first, second
+def build_id_index(vault_path: Path) -> dict[str, BookNote]:
+    """Map every Libris ID the Shelf answers for to the note that answers.
+
+    Includes superseded IDs, so an identity merged away still resolves
+    (ADR 0014). A live identity always wins over a superseded one.
+
+    Reading the whole Shelf once and looking up in a dict is the difference
+    between a bulk run finishing and not: resolving 83 decisions one
+    `find_by_libris_id` at a time did not complete inside ten minutes, because
+    each miss reads every note.
+
+    Args:
+        vault_path: The Shelf to index.
+
+    Returns:
+        A mapping from Libris ID to Book Note.
+    """
+    index: dict[str, BookNote] = {}
+    live: dict[str, BookNote] = {}
+
+    for book_path in list_books(vault_path):
+        note = BookNote.read(book_path)
+        if note is None:
+            continue
+        for superseded in note.superseded_ids:
+            index.setdefault(superseded, note)
+        if note.libris_id:
+            live[note.libris_id] = note
+
+    index.update(live)
+    return index
 
 
 def apply_decisions(
@@ -380,6 +416,7 @@ def apply_decisions(
         One outcome per decision, in the order given.
     """
     outcomes: list[DecisionOutcome] = []
+    index = build_id_index(vault_path)
 
     for decision in decisions:
         verdict = decision.get("decision")
@@ -389,20 +426,28 @@ def apply_decisions(
 
         if verdict != "same":
             outcomes.append(
-                DecisionOutcome("skipped", f"{label}: recorded as two books")
+                DecisionOutcome(
+                    DecisionStatus.SKIPPED, f"{label}: recorded as two books"
+                )
             )
             continue
 
         if not shorter or not longer:
             outcomes.append(
-                DecisionOutcome("drifted", f"{label}: decision names no Libris ID")
+                DecisionOutcome(
+                    DecisionStatus.DRIFTED, f"{label}: decision names no Libris ID"
+                )
             )
             continue
 
-        first, second = _resolve_pair(vault_path, shorter, longer)
+        first = index.get(shorter.strip())
+        second = index.get(longer.strip())
         if first is None or second is None or first.path == second.path:
             outcomes.append(
-                DecisionOutcome("drifted", f"{label}: no longer two notes on the Shelf")
+                DecisionOutcome(
+                    DecisionStatus.DRIFTED,
+                    f"{label}: no longer two notes on the Shelf",
+                )
             )
             continue
 
@@ -415,18 +460,33 @@ def apply_decisions(
         if conflicts and not allow_conflicts:
             fields = ", ".join(sorted({c.field for c in conflicts}))
             outcomes.append(
-                DecisionOutcome("conflicted", f"{label}: {fields} disagree")
+                DecisionOutcome(
+                    DecisionStatus.CONFLICTED, f"{label}: {fields} disagree"
+                )
             )
             continue
 
         if dry_run:
             outcomes.append(
-                DecisionOutcome("would_merge", f"{label} -> {primary.name}")
+                DecisionOutcome(
+                    DecisionStatus.WOULD_MERGE, f"{label} -> {primary.name}"
+                )
             )
             continue
 
         write_merged_book(primary, merged_fm, merged_body)
         delete_secondary_file(secondary)
-        outcomes.append(DecisionOutcome("merged", f"{label} -> {primary.name}"))
+
+        # The Shelf just changed, so the index has to change with it: the
+        # survivor now answers for the identities the deleted note held.
+        survivor = BookNote.read(primary)
+        if survivor is not None:
+            for key, note in list(index.items()):
+                if note.path in (primary, secondary):
+                    index[key] = survivor
+
+        outcomes.append(
+            DecisionOutcome(DecisionStatus.MERGED, f"{label} -> {primary.name}")
+        )
 
     return outcomes

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -355,7 +355,10 @@ def _resolve_pair(vault_path: Path, first_id: str, second_id: str):
 
 
 def apply_decisions(
-    vault_path: Path, decisions: list[dict], allow_conflicts: bool = False
+    vault_path: Path,
+    decisions: list[dict],
+    allow_conflicts: bool = False,
+    dry_run: bool = False,
 ) -> list[DecisionOutcome]:
     """Merge the pairs an exported review marked as one Book.
 
@@ -367,9 +370,11 @@ def apply_decisions(
     Args:
         vault_path: The Shelf to act on.
         decisions: Decision records from the review export.
-        allow_conflicts: Merge even when a modelled field disagrees. Off by
-            default: the file answered "is this one Book", not "which ISBN is
-            right".
+        allow_conflicts: Merge even when one of the reader's own values
+            disagrees. Off by default: the file answered "is this one Book",
+            not "which rating is yours".
+        dry_run: Report what would happen without writing or deleting anything.
+            This deletes Book Notes, so it can be previewed first.
 
     Returns:
         One outcome per decision, in the order given.
@@ -411,6 +416,12 @@ def apply_decisions(
             fields = ", ".join(sorted({c.field for c in conflicts}))
             outcomes.append(
                 DecisionOutcome("conflicted", f"{label}: {fields} disagree")
+            )
+            continue
+
+        if dry_run:
+            outcomes.append(
+                DecisionOutcome("would_merge", f"{label} -> {primary.name}")
             )
             continue
 

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -4,7 +4,7 @@ from typer.testing import CliRunner
 
 from libris.cli import app
 from libris.config import set_config
-from libris.markdown import find_duplicates
+from libris.markdown import find_duplicate_candidates, find_duplicates
 
 runner = CliRunner()
 
@@ -177,3 +177,91 @@ def test_cli_duplicates_command_no_duplicates(tmp_path):
     result = runner.invoke(app, ["duplicates"])
     assert result.exit_code == 0
     assert "No duplicates found." in result.output
+
+
+# --- detection (#72) ---
+
+
+def test_titles_differing_only_in_punctuation_are_one_group(tmp_path):
+    # Given the same Book written with different punctuation, which the vault
+    # holds as "Crucial Conversations- Tools" and "Crucial Conversations: Tools"
+    _write_book(
+        tmp_path, "A.md", title='"Crucial Conversations- Tools"', authors=["Al"]
+    )
+    _write_book(
+        tmp_path, "B.md", title='"Crucial Conversations: Tools"', authors=["Al"]
+    )
+
+    # When duplicates are found
+    groups = find_duplicates(tmp_path)
+
+    # Then they group: comparing titles with .lower() missed this entirely
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+
+
+def test_a_subtitle_is_not_treated_as_the_same_title(tmp_path):
+    # Given a title that contains another
+    _write_book(tmp_path, "A.md", title="The Brass Verdict", authors=["Michael"])
+    _write_book(
+        tmp_path, "B.md", title='"The Brass Verdict: A Novel"', authors=["Michael"]
+    )
+
+    # When duplicates are found
+    groups = find_duplicates(tmp_path)
+
+    # Then they are not merged automatically: containment is a judgement, and
+    # "Mercy" contains nothing that makes it "Long Road to Mercy"
+    assert groups == []
+
+
+def test_a_subtitle_variant_is_offered_as_a_candidate(tmp_path):
+    # Given the same two notes
+    _write_book(tmp_path, "A.md", title="The Brass Verdict", authors=["Michael"])
+    _write_book(
+        tmp_path, "B.md", title='"The Brass Verdict: A Novel"', authors=["Michael"]
+    )
+
+    # When candidates are found
+    candidates = find_duplicate_candidates(tmp_path)
+
+    # Then a person is offered the pair to settle
+    assert len(candidates) == 1
+    titles = {note.title for note in candidates[0]}
+    assert titles == {"The Brass Verdict", "The Brass Verdict: A Novel"}
+
+
+def test_a_different_book_by_the_same_author_is_not_a_candidate(tmp_path):
+    # Given two unrelated books, the case measured on the real Shelf
+    _write_book(tmp_path, "A.md", title="Freakonomics", authors=["Steven"])
+    _write_book(tmp_path, "B.md", title="Think Like a Freak", authors=["Steven"])
+
+    # When candidates are found
+    # Then nothing is offered: neither title contains the other
+    assert find_duplicate_candidates(tmp_path) == []
+
+
+def test_a_similar_title_by_another_author_is_not_a_candidate(tmp_path):
+    # Given a containing title credited to someone else
+    _write_book(tmp_path, "A.md", title="Dune", authors=["Frank Herbert"])
+    _write_book(tmp_path, "B.md", title='"Dune: Deluxe"', authors=["Someone Else"])
+
+    # When candidates are found
+    # Then the author keeps them apart
+    assert find_duplicate_candidates(tmp_path) == []
+
+
+def test_a_confirmed_duplicate_is_not_also_a_candidate(tmp_path):
+    # Given two notes that already group by an identifier
+    _write_book(tmp_path, "A.md", title="Dune", authors=["Frank"], isbn="978-0-441-0")
+    _write_book(
+        tmp_path, "B.md", title='"Dune: Deluxe"', authors=["Frank"], isbn="978-0-441-0"
+    )
+
+    # When both are computed
+    groups = find_duplicates(tmp_path)
+    candidates = find_duplicate_candidates(tmp_path)
+
+    # Then the pair is reported once, as the settled thing it is
+    assert len(groups) == 1
+    assert candidates == []

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,10 +1,11 @@
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
 
 from libris.cli import app
 from libris.config import set_config
-from libris.markdown import find_duplicate_candidates, find_duplicates
+from libris.markdown import BookNote, find_duplicate_candidates, find_duplicates
 
 runner = CliRunner()
 
@@ -265,3 +266,141 @@ def test_a_confirmed_duplicate_is_not_also_a_candidate(tmp_path):
     # Then the pair is reported once, as the settled thing it is
     assert len(groups) == 1
     assert candidates == []
+
+
+def test_duplicates_lists_candidates_separately(tmp_path):
+    # Given a subtitle variant, which is a judgement rather than a fact
+    set_config("book_vault", str(tmp_path))
+    _write_book(tmp_path, "A.md", title="The Brass Verdict", authors=["Michael"])
+    _write_book(
+        tmp_path, "B.md", title='"The Brass Verdict: A Novel"', authors=["Michael"]
+    )
+
+    # When duplicates are reported
+    result = runner.invoke(app, ["duplicates"])
+
+    # Then the pair is offered rather than counted as a duplicate
+    assert result.exit_code == 0
+    assert "candidate" in result.output.lower()
+    assert "The Brass Verdict" in result.output
+
+
+def test_merge_decisions_applies_a_reviewed_pair(tmp_path):
+    # Given two notes and a review saying they are one Book
+    set_config("book_vault", str(tmp_path))
+    a = _write_book(
+        tmp_path,
+        "A.md",
+        title="The Brass Verdict",
+        authors=["Michael"],
+        libris_id="01AAA",
+    )
+    b = _write_book(
+        tmp_path,
+        "B.md",
+        title='"The Brass Verdict: A Novel"',
+        authors=["Michael"],
+        libris_id="01BBB",
+    )
+    first, second = BookNote.read(a), BookNote.read(b)
+    decisions = tmp_path / "decisions.json"
+    decisions.write_text(
+        json.dumps(
+            {
+                "decisions": [
+                    {
+                        "decision": "same",
+                        "shorter": {
+                            "title": first.title,
+                            "libris_id": first.libris_id,
+                        },
+                        "longer": {
+                            "title": second.title,
+                            "libris_id": second.libris_id,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # When the review is applied
+    result = runner.invoke(app, ["merge", "--decisions", str(decisions)])
+
+    # Then one note remains
+    assert result.exit_code == 0
+    assert "Merged" in result.output
+    assert len(list(tmp_path.glob("*.md"))) == 1
+
+
+def test_merge_decisions_reports_a_missing_file(tmp_path):
+    # Given a path that is not there
+    set_config("book_vault", str(tmp_path))
+
+    # When it is applied
+    result = runner.invoke(app, ["merge", "--decisions", str(tmp_path / "nope.json")])
+
+    # Then it says so rather than raising
+    assert result.exit_code != 0
+    assert "No such decisions file" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_merge_decisions_reports_unreadable_json(tmp_path):
+    # Given a file that is not JSON
+    set_config("book_vault", str(tmp_path))
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json at all", encoding="utf-8")
+
+    # When it is applied
+    result = runner.invoke(app, ["merge", "--decisions", str(bad)])
+
+    # Then the failure is explained, not raised
+    assert result.exit_code != 0
+    assert "Could not read" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_merge_decisions_dry_run_writes_nothing(tmp_path):
+    # Given a review that would merge a pair
+    set_config("book_vault", str(tmp_path))
+    _write_book(
+        tmp_path,
+        "A.md",
+        title="The Brass Verdict",
+        authors=["Michael"],
+        libris_id="01AAA",
+    )
+    _write_book(
+        tmp_path,
+        "B.md",
+        title='"The Brass Verdict: A Novel"',
+        authors=["Michael"],
+        libris_id="01BBB",
+    )
+    decisions = tmp_path / "decisions.json"
+    decisions.write_text(
+        json.dumps(
+            {
+                "decisions": [
+                    {
+                        "decision": "same",
+                        "shorter": {"title": "The Brass Verdict", "libris_id": "01AAA"},
+                        "longer": {"title": "A Novel", "libris_id": "01BBB"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # When it is previewed
+    result = runner.invoke(app, ["merge", "--decisions", str(decisions), "--dry-run"])
+
+    # Then it says what it would do and both notes are still there. This
+    # command deletes Book Notes; 74 of them in one run deserves a look first.
+    assert result.exit_code == 0
+    assert "Would merge" in result.output
+    assert "Nothing written" in result.output
+    assert len(list(tmp_path.glob("*.md"))) == 2

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -965,3 +965,109 @@ def test_a_scalar_field_still_conflicts(tmp_path):
     # editions, not one value with two parts
     assert [c.field for c in conflicts] == ["isbn"]
     assert merged_fm["isbn"] == "978-0-441-01359-3"
+
+
+# --- what a merge asks a person (ADR 0018) ---
+
+
+def test_an_unmodelled_field_does_not_conflict(tmp_path):
+    # Given Obsidian's own timestamps, which two different files never share.
+    # 414 notes carry these.
+    primary = _write_book(
+        tmp_path, "A.md", title="Dune", date_modified='"2026-08-01T10:00:00"'
+    )
+    secondary = _write_book(
+        tmp_path, "B.md", title="Dune", date_modified='"2026-08-02T11:00:00"'
+    )
+
+    # When they are merged
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then nothing is asked: the keeper's value stands. Otherwise every merge
+    # prompts, and --allow-conflicts becomes routine on a bulk run - which
+    # would suppress the conflicts that matter too
+    assert conflicts == []
+    assert merged_fm["date_modified"] == "2026-08-01T10:00:00"
+
+
+def test_a_modelled_field_still_conflicts(tmp_path):
+    # Given two notes disagreeing about something the Library models
+    primary = _write_book(tmp_path, "A.md", title="Dune", isbn="978-0-441-01359-3")
+    secondary = _write_book(tmp_path, "B.md", title="Dune", isbn="978-0-441-17271-9")
+
+    # When they are merged
+    _, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then it is still reported
+    assert [c.field for c in conflicts] == ["isbn"]
+
+
+def test_aliases_are_unioned(tmp_path):
+    # Given aliases, which Obsidian writes and the Library does not model, but
+    # which genuinely holds several values
+    primary = _write_book(tmp_path, "A.md", title="Dune", aliases=["Dune 1965"])
+    secondary = _write_book(tmp_path, "B.md", title="Dune", aliases=["Herbert Dune"])
+
+    # When they are merged
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then both survive rather than the keeper's silently winning
+    assert merged_fm["aliases"] == ["Dune 1965", "Herbert Dune"]
+    assert conflicts == []
+
+
+def test_one_author_spelled_two_ways_is_not_doubled(tmp_path):
+    # Given the whitespace dirt on 185 notes
+    primary = _write_book(tmp_path, "A.md", title="10% Happier", authors=["Dan Harris"])
+    secondary = _write_book(
+        tmp_path, "B.md", title="10% Happier", authors=["Dan   Harris"]
+    )
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then one person appears once
+    assert merged_fm["authors"] == ["Dan Harris"]
+
+
+def test_a_wikilinked_author_matches_the_plain_spelling(tmp_path):
+    # Given one note linking the author and the other naming them plainly
+    primary = _write_book(
+        tmp_path, "A.md", title="A Calendar of Wisdom", authors=['"[[Leo Tolstoy]]"']
+    )
+    secondary = _write_book(
+        tmp_path, "B.md", title="A Calendar of Wisdom", authors=["Leo Tolstoy"]
+    )
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then they are one person, and the keeper's link survives: in Obsidian a
+    # wikilink is the edge to that author's note (ADR 0018)
+    assert merged_fm["authors"] == ["[[Leo Tolstoy]]"]
+
+
+def test_whitespace_is_collapsed_on_write(tmp_path):
+    # Given a keeper whose own author value carries the dirt
+    primary = _write_book(tmp_path, "A.md", title="Dune", authors=["Frank   Herbert"])
+    secondary = _write_book(tmp_path, "B.md", title="Dune", authors=["Brian Herbert"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the value written is tidied, but no further: comparing loosely and
+    # writing conservatively is the whole rule
+    assert merged_fm["authors"] == ["Frank Herbert", "Brian Herbert"]
+
+
+def test_genres_still_dedupe_on_the_exact_string(tmp_path):
+    # Given case drift in genres, which is a vocabulary question and not a
+    # merge one
+    primary = _write_book(tmp_path, "A.md", title="Dune", genres=["Science Fiction"])
+    secondary = _write_book(tmp_path, "B.md", title="Dune", genres=["science fiction"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then both are kept; merging does not quietly pick a spelling
+    assert merged_fm["genres"] == ["Science Fiction", "science fiction"]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -46,7 +46,7 @@ class TestMergeTwoBooks:
             tmp_path,
             "A.md",
             title="Test Book",
-            author=["Alice"],
+            authors=["Alice"],
             isbn="123-456",
             google_books_id="gb1",
             status="To Read",
@@ -55,7 +55,7 @@ class TestMergeTwoBooks:
             tmp_path,
             "B.md",
             title="Test Book",
-            author=["Alice"],
+            authors=["Alice"],
             isbn="123-456",
             google_books_id="gb1",
             status="To Read",
@@ -142,14 +142,19 @@ class TestMergeTwoBooks:
         assert merged_fm["page_count"] == 300
 
     def test_metadata_conflict_different_authors(self, tmp_path):
-        """Different non-null author lists should trigger conflict."""
+        """Different non-null author lists should be unioned, not contested.
+
+        Uses `authors`, the field every note carries. This test named the
+        legacy `author` key, so it asserted union behaviour on a field the
+        merge never sees (#72).
+        """
         path1 = _write_book(
             tmp_path,
             "A.md",
             title="Book",
             isbn="123",
             google_books_id="gb1",
-            author=["Alice"],
+            authors=["Alice"],
         )
         path2 = _write_book(
             tmp_path,
@@ -157,15 +162,15 @@ class TestMergeTwoBooks:
             title="Book",
             isbn="123",
             google_books_id="gb1",
-            author=["Bob"],
+            authors=["Bob"],
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
 
         # Should have conflict in author field
         conflict_fields = [c.field for c in conflicts]
-        assert "author" not in conflict_fields  # Authors should be merged as lists
-        assert len(merged_fm["author"]) == 2
+        assert "authors" not in conflict_fields  # Authors should be merged as lists
+        assert len(merged_fm["authors"]) == 2
 
     def test_metadata_conflict_different_page_count(self, tmp_path):
         """Different page counts should trigger conflict."""
@@ -253,7 +258,7 @@ class TestMergeTwoBooks:
             title="Book",
             isbn="123",
             google_books_id="gb1",
-            author=["Alice", "Charlie"],
+            authors=["Alice", "Charlie"],
         )
         path2 = _write_book(
             tmp_path,
@@ -261,16 +266,16 @@ class TestMergeTwoBooks:
             title="Book",
             isbn="123",
             google_books_id="gb1",
-            author=["Bob", "Alice"],  # Alice appears in both
+            authors=["Bob", "Alice"],  # Alice appears in both
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
 
         assert len(conflicts) == 0
-        assert len(merged_fm["author"]) == 3
-        assert "Alice" in merged_fm["author"]
-        assert "Bob" in merged_fm["author"]
-        assert "Charlie" in merged_fm["author"]
+        assert len(merged_fm["authors"]) == 3
+        assert "Alice" in merged_fm["authors"]
+        assert "Bob" in merged_fm["authors"]
+        assert "Charlie" in merged_fm["authors"]
 
     def test_merge_body_content(self, tmp_path):
         """Body content from both files should be merged."""
@@ -870,3 +875,93 @@ def test_reading_superseded_ids_from_a_bare_string(tmp_path):
 
     # Then the reader agrees with the merge helper, because both use one rule
     assert note.superseded_ids == ["GONE"]
+
+
+# --- fields that hold several values are unioned, not conflicted (#72) ---
+#
+# _resolve_field_value unioned list fields, but the list it checked named
+# "author" while the canonical field is "authors" (ADR 0005) - the same drift
+# #62 undid. So merging two notes with different author lists reported a
+# conflict and silently kept the primary's. `format` had never been in the set
+# at all, and since ADR 0017 it holds a list on 2,210 notes.
+
+
+def test_merging_unions_author_lists(tmp_path):
+    # Given two notes for one Book crediting different authors
+    primary = _write_book(
+        tmp_path, "A.md", title="The Gap and the Gain", authors=["Dan Sullivan"]
+    )
+    secondary = _write_book(
+        tmp_path, "B.md", title="The Gap and the Gain", authors=["Benjamin Hardy"]
+    )
+
+    # When they are merged
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then both survive, rather than the secondary's being reported as a
+    # conflict and dropped
+    assert merged_fm["authors"] == ["Dan Sullivan", "Benjamin Hardy"]
+    assert not [c for c in conflicts if c.field == "authors"]
+
+
+def test_merging_unions_formats(tmp_path):
+    # Given the same Book held on paper in one note and as audio in the other
+    primary = _write_book(tmp_path, "A.md", title="Changes", format=["Physical"])
+    secondary = _write_book(tmp_path, "B.md", title="Changes", format=["Audiobook"])
+
+    # When they are merged
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the reader still owns it in both media
+    assert merged_fm["format"] == ["Physical", "Audiobook"]
+    assert not [c for c in conflicts if c.field == "format"]
+
+
+def test_merging_does_not_duplicate_a_shared_value(tmp_path):
+    # Given both notes recording the same format
+    primary = _write_book(tmp_path, "A.md", title="Dune", format=["Audiobook"])
+    secondary = _write_book(tmp_path, "B.md", title="Dune", format=["Audiobook"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then it appears once
+    assert merged_fm["format"] == ["Audiobook"]
+
+
+def test_merging_unions_a_bare_string_with_a_list(tmp_path):
+    # Given tags, which this vault still holds as both shapes
+    primary = _write_book(tmp_path, "A.md", title="Dune", tags="Book")
+    secondary = _write_book(tmp_path, "B.md", title="Dune", tags=["Book", "SF"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then the shapes combine without losing either
+    assert merged_fm["tags"] == ["Book", "SF"]
+
+
+def test_merging_still_unions_genres(tmp_path):
+    # Given the field that already worked, so the fix does not regress it
+    primary = _write_book(tmp_path, "A.md", title="Dune", genres=["Science Fiction"])
+    secondary = _write_book(tmp_path, "B.md", title="Dune", genres=["Classics"])
+
+    # When they are merged
+    merged_fm, _, _ = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then both are kept
+    assert merged_fm["genres"] == ["Science Fiction", "Classics"]
+
+
+def test_a_scalar_field_still_conflicts(tmp_path):
+    # Given two notes disagreeing about a single-valued field
+    primary = _write_book(tmp_path, "A.md", title="Dune", isbn="978-0-441-01359-3")
+    secondary = _write_book(tmp_path, "B.md", title="Dune", isbn="978-0-441-17271-9")
+
+    # When they are merged
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+
+    # Then it is reported rather than silently combined: two ISBNs are two
+    # editions, not one value with two parts
+    assert [c.field for c in conflicts] == ["isbn"]
+    assert merged_fm["isbn"] == "978-0-441-01359-3"

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -181,6 +181,7 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=300,
+            rating=5,
         )
         path2 = _write_book(
             tmp_path,
@@ -189,13 +190,14 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=250,
+            rating=3,
         )
 
         merged_fm, _, conflicts = merge_two_books(path1, path2)
 
         # page_count conflict should be detected
         conflict_fields = [c.field for c in conflicts]
-        assert "page_count" in conflict_fields
+        assert "rating" in conflict_fields
 
     def test_conflicts_prevent_merge_when_not_allowed(self, tmp_path):
         """With allow_conflicts=False, conflicts should be returned."""
@@ -206,6 +208,7 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=300,
+            rating=5,
         )
         path2 = _write_book(
             tmp_path,
@@ -214,6 +217,7 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=250,
+            rating=3,
         )
 
         merged_fm, merged_body, conflicts = merge_two_books(
@@ -232,6 +236,7 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=300,
+            rating=5,
         )
         path2 = _write_book(
             tmp_path,
@@ -240,6 +245,7 @@ class TestMergeTwoBooks:
             isbn="123",
             google_books_id="gb1",
             page_count=250,
+            rating=3,
         )
 
         merged_fm, merged_body, conflicts = merge_two_books(
@@ -247,7 +253,7 @@ class TestMergeTwoBooks:
         )
 
         # Merge should proceed
-        assert merged_fm["page_count"] == 300  # Primary wins
+        assert merged_fm["rating"] == 5  # Primary wins
         assert len(conflicts) > 0  # But conflicts are still recorded
 
     def test_merge_author_lists(self, tmp_path):
@@ -400,6 +406,7 @@ class TestCheckAutoMerge:
             isbn="123",
             google_books_id="gb1",
             page_count=300,
+            rating=5,
         )
         path2 = _write_book(
             tmp_path,
@@ -408,6 +415,7 @@ class TestCheckAutoMerge:
             isbn="123",
             google_books_id="gb1",
             page_count=250,
+            rating=3,
         )
 
         can_merge, reason, merge_result = check_auto_merge(path1, path2)
@@ -697,6 +705,7 @@ class TestMergeCLI:
             isbn="123",
             google_books_id="gb1",
             page_count=300,
+            rating=5,
         )
         _write_book(
             vault,
@@ -705,6 +714,7 @@ class TestMergeCLI:
             isbn="123",
             google_books_id="gb1",
             page_count=250,
+            rating=3,
         )
         set_config("vault_path", str(vault))
 
@@ -953,18 +963,18 @@ def test_merging_still_unions_genres(tmp_path):
     assert merged_fm["genres"] == ["Science Fiction", "Classics"]
 
 
-def test_a_scalar_field_still_conflicts(tmp_path):
+def test_a_reader_field_still_conflicts(tmp_path):
     # Given two notes disagreeing about a single-valued field
-    primary = _write_book(tmp_path, "A.md", title="Dune", isbn="978-0-441-01359-3")
-    secondary = _write_book(tmp_path, "B.md", title="Dune", isbn="978-0-441-17271-9")
+    primary = _write_book(tmp_path, "A.md", title="Dune", rating=5)
+    secondary = _write_book(tmp_path, "B.md", title="Dune", rating=3)
 
     # When they are merged
     merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
 
-    # Then it is reported rather than silently combined: two ISBNs are two
-    # editions, not one value with two parts
-    assert [c.field for c in conflicts] == ["isbn"]
-    assert merged_fm["isbn"] == "978-0-441-01359-3"
+    # Then it is reported: a rating is the reader's own, and two different ones
+    # means they rated the same book twice (ADR 0018)
+    assert [c.field for c in conflicts] == ["rating"]
+    assert merged_fm["rating"] == 5
 
 
 # --- what a merge asks a person (ADR 0018) ---
@@ -990,16 +1000,20 @@ def test_an_unmodelled_field_does_not_conflict(tmp_path):
     assert merged_fm["date_modified"] == "2026-08-01T10:00:00"
 
 
-def test_a_modelled_field_still_conflicts(tmp_path):
-    # Given two notes disagreeing about something the Library models
+def test_edition_metadata_does_not_conflict(tmp_path):
+    # Given two notes describing different editions of one work, which is what
+    # every Duplicate Candidate pair is
     primary = _write_book(tmp_path, "A.md", title="Dune", isbn="978-0-441-01359-3")
     secondary = _write_book(tmp_path, "B.md", title="Dune", isbn="978-0-441-17271-9")
 
     # When they are merged
-    _, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
+    merged_fm, _, conflicts = merge_two_books(primary, secondary, allow_conflicts=True)
 
-    # Then it is still reported
-    assert [c.field for c in conflicts] == ["isbn"]
+    # Then nothing is asked: an ISBN belongs to the edition, and the keeper's
+    # will do. Measured: under the old rule 0 of 83 candidate pairs merged
+    # cleanly, so the feature was inert
+    assert conflicts == []
+    assert merged_fm["isbn"] == "978-0-441-01359-3"
 
 
 def test_aliases_are_unioned(tmp_path):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14,6 +14,7 @@ from libris.markdown import (
 )
 from libris.note_format import InvalidFieldValue
 from libris.service import (
+    DecisionStatus,
     Outcome,
     add_book,
     apply_decisions,
@@ -317,7 +318,7 @@ def test_a_pair_marked_one_book_is_merged(tmp_path):
     outcomes = apply_decisions(tmp_path, [_decision(first, second)])
 
     # Then they become one note
-    assert [o.status for o in outcomes] == ["merged"]
+    assert [o.status for o in outcomes] == [DecisionStatus.MERGED]
     assert len(list(tmp_path.glob("*.md"))) == 1
 
 
@@ -329,7 +330,7 @@ def test_a_pair_marked_two_books_is_left_alone(tmp_path):
     outcomes = apply_decisions(tmp_path, [_decision(first, second, "different")])
 
     # Then nothing is merged
-    assert [o.status for o in outcomes] == ["skipped"]
+    assert [o.status for o in outcomes] == [DecisionStatus.SKIPPED]
     assert len(list(tmp_path.glob("*.md"))) == 2
 
 
@@ -343,7 +344,7 @@ def test_a_decision_naming_a_vanished_note_is_reported(tmp_path):
 
     # Then it is reported rather than acted on: the file describes the Shelf as
     # it was, and the Shelf is what is true
-    assert [o.status for o in outcomes] == ["drifted"]
+    assert [o.status for o in outcomes] == [DecisionStatus.DRIFTED]
     assert first.path.exists()
 
 
@@ -359,7 +360,7 @@ def test_a_decision_still_applies_after_one_note_was_merged_away(tmp_path):
 
     # Then it resolves through superseded_ids rather than reporting drift
     # (ADR 0014)
-    assert [o.status for o in outcomes] == ["merged"]
+    assert [o.status for o in outcomes] == [DecisionStatus.MERGED]
 
 
 def test_a_conflicting_pair_is_reported_not_merged(tmp_path):
@@ -379,5 +380,5 @@ def test_a_conflicting_pair_is_reported_not_merged(tmp_path):
 
     # Then it stops: the review answered "is this one Book", not "which rating is
     # yours"
-    assert [o.status for o in outcomes] == ["conflicted"]
+    assert [o.status for o in outcomes] == [DecisionStatus.CONFLICTED]
     assert len(list(tmp_path.glob("*.md"))) == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16,6 +16,7 @@ from libris.note_format import InvalidFieldValue
 from libris.service import (
     Outcome,
     add_book,
+    apply_decisions,
     build_lookup_query,
     find_by_libris_id,
     find_existing,
@@ -288,3 +289,95 @@ def test_a_blank_libris_id_does_not_resolve(tmp_path):
     # Then it misses immediately rather than reading every note to find nothing
     assert find_by_libris_id(tmp_path, "") is None
     assert find_by_libris_id(tmp_path, "   ") is None
+
+
+# --- applying an exported review (#72, ADR 0018) ---
+
+
+def _pair(tmp_path):
+    """Two notes for one Book, differing by a subtitle."""
+    a = create_book_note(_candidate(title="The Brass Verdict"), tmp_path)
+    b = create_book_note(_candidate(title="The Brass Verdict: A Novel"), tmp_path)
+    return BookNote.read(a), BookNote.read(b)
+
+
+def _decision(first, second, verdict="same"):
+    return {
+        "decision": verdict,
+        "shorter": {"title": first.title, "libris_id": first.libris_id},
+        "longer": {"title": second.title, "libris_id": second.libris_id},
+    }
+
+
+def test_a_pair_marked_one_book_is_merged(tmp_path):
+    # Given two notes a person judged to be one Book
+    first, second = _pair(tmp_path)
+
+    # When the decision is applied
+    outcomes = apply_decisions(tmp_path, [_decision(first, second)])
+
+    # Then they become one note
+    assert [o.status for o in outcomes] == ["merged"]
+    assert len(list(tmp_path.glob("*.md"))) == 1
+
+
+def test_a_pair_marked_two_books_is_left_alone(tmp_path):
+    # Given a pair a person judged to be different books
+    first, second = _pair(tmp_path)
+
+    # When the decision is applied
+    outcomes = apply_decisions(tmp_path, [_decision(first, second, "different")])
+
+    # Then nothing is merged
+    assert [o.status for o in outcomes] == ["skipped"]
+    assert len(list(tmp_path.glob("*.md"))) == 2
+
+
+def test_a_decision_naming_a_vanished_note_is_reported(tmp_path):
+    # Given a decision recorded against a Shelf that has since changed
+    first, second = _pair(tmp_path)
+    second.path.unlink()
+
+    # When it is applied
+    outcomes = apply_decisions(tmp_path, [_decision(first, second)])
+
+    # Then it is reported rather than acted on: the file describes the Shelf as
+    # it was, and the Shelf is what is true
+    assert [o.status for o in outcomes] == ["drifted"]
+    assert first.path.exists()
+
+
+def test_a_decision_still_applies_after_one_note_was_merged_away(tmp_path):
+    # Given a note that has since absorbed another, so its id is superseded
+    first, second = _pair(tmp_path)
+    third = create_book_note(_candidate(title="The Brass Verdict: Deluxe"), tmp_path)
+    third_note = BookNote.read(third)
+    apply_decisions(tmp_path, [_decision(first, third_note)])
+
+    # When a decision naming the merged-away id is applied
+    outcomes = apply_decisions(tmp_path, [_decision(third_note, second)])
+
+    # Then it resolves through superseded_ids rather than reporting drift
+    # (ADR 0014)
+    assert [o.status for o in outcomes] == ["merged"]
+
+
+def test_a_conflicting_pair_is_reported_not_merged(tmp_path):
+    # Given two notes that disagree about the reader's own value
+    first, second = _pair(tmp_path)
+    second.path.write_text(
+        second.path.read_text(encoding="utf-8").replace("rating:", "rating: 3"),
+        encoding="utf-8",
+    )
+    first.path.write_text(
+        first.path.read_text(encoding="utf-8").replace("rating:", "rating: 5"),
+        encoding="utf-8",
+    )
+
+    # When the decision is applied
+    outcomes = apply_decisions(tmp_path, [_decision(first, second)])
+
+    # Then it stops: the review answered "is this one Book", not "which rating is
+    # yours"
+    assert [o.status for o in outcomes] == ["conflicted"]
+    assert len(list(tmp_path.glob("*.md"))) == 2


### PR DESCRIPTION
Closes #72. This is what stands between you and merging ~74 duplicate Books.

Five commits, each a separable idea. The design is **ADR 0018**, written before the code and then amended once measurement proved part of it wrong.

## The two field-union bugs

`_resolve_field_value` combined list fields, but the list it checked said `"author"` while every note carries `authors` — the same drift #62 undid. So merging two notes crediting different authors reported a conflict and **silently kept the primary's**. `format` was never in the set at all, and since ADR 0017 it holds a list on 2,210 notes, so merging a `['Physical']` note with an `['Audiobook']` one lost one.

The set is now named once in `note_format.MULTI_VALUED_FIELDS`. Two existing tests asserted the union on `author`, the legacy key no note carries — they passed while the real field silently conflicted.

## What a merge asks a person, decided twice

My first cut said conflicts are for fields in the canonical schema. Measuring it killed that: **0 of 83 candidate pairs merged cleanly.** Every pair disagreed on `libris_id` (two notes always do), on `title` (a containing title is what made it a candidate), and on `isbn`/`page_count`/`cover_thumbnail` (two editions of one work differ). Exactly **one** disagreed about a `rating`.

So the cut isn't whether the Library models a field, it's **whose fact it is**. An ISBN belongs to the edition and the keeper's will do. A Libris ID isn't contested at all — the other is recorded as superseded (ADR 0014). A rating belongs to the reader.

Under the corrected rule, **82 of 83 merge unattended**, and the one that stops is *A Seat at the Table* against *A Reader's Guide to a Seat at the Table* — two different books, for which the rating disagreement is exactly the evidence.

Eight existing tests built their conflict from `page_count` or `isbn`. The machinery they test is unchanged; the field is edition metadata, so they now disagree about a rating.

## Comparing loosely, writing conservatively

185 notes carry irregular whitespace in an author name and 8 write authors as wikilinks, so exact-string dedupe would list one person twice. Sameness is judged on the fully normalised name; the value **written** only has its whitespace collapsed, because unwrapping `[[Leo Tolstoy]]` would delete the graph edge to that author's note.

## Detection

`find_duplicates` groups on `normalize_for_match` rather than `title.lower()`. **This changes no grouping on your Shelf** — the punctuation variants also carry an edition suffix, so they're containment matches, not equal ones. #72 claimed otherwise and I was wrong. It's still correct and prevents a class of miss.

`find_duplicate_candidates` surfaces the 83 containment pairs as the judgement they are. `libris duplicates` reports them as a separate section from the 1 confirmed group.

## Applying a review

`libris merge --decisions <file>` consumes the JSON the review page exports. Every pair is resolved against the **live Shelf** by Libris ID rather than trusted from the file; a decision recorded against a Shelf that has since changed is reported as drifted, not acted on. Re-running the same file is idempotent — already-merged pairs resolve to one note and report as moved on.

`--dry-run` because this deletes Book Notes and 74 in one run deserves a look first.

## Verified end to end on a copy of the real Shelf

`libris duplicates` → 1 group, 83 candidates. Then a real decisions file with four entries:

| Decision | Outcome |
|---|---|
| *Act of War* / *Act of War: A Thriller* — same | Merged |
| *Black List* / *Black List: Scot Harvath, Book 11* — same | Merged |
| *Hidden Order* / *Free Fall: A Prelude to Hidden Order* — different | Left alone |
| Two invented Libris IDs | Reported as moved on |

3,136 notes → 3,134. The surviving *Black List* came out with `format: ['Physical', 'Audiobook']` — the union working on real data — both survivors recorded `superseded_ids`, and both bodies were preserved under the merge divider. A `--dry-run` re-run wrote nothing.

357 tests (was 341). `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
