### PR TITLE
docs: bump the version when behaviour changes, and say why

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,21 @@ uv run ruff format .          # Format
 uv run ruff format --check .  # Format check (CI mode)
 ```
 
+`libris` on your PATH is a `uv tool` snapshot, not the working tree. It goes stale silently:
+after landing a change, `uv tool install . --force` from the repo root refreshes it, and
+`uv cache clean libris` first if a newly added flag is still missing. Check the installed file
+rather than the install output, which says "Installed" either way:
+
+```bash
+uv run libris --help            # the working tree, always current
+uv tool install . --force       # refresh the global command
+```
+
 ## Workflow
 
 - **Branching:** Always create a feature branch from `main`. Never commit directly to `main`.
 - **Pre-commit:** Run `uv run ruff check --fix .` (auto-fix lint issues, including import sorting), `uv run ruff format .`, and `uv run pytest` before every commit. Fix any remaining failures. All three are needed: CI lints and checks formatting as separate steps, so a commit that ran only `ruff check` still fails `ruff format --check .`.
+- **Versioning:** Bump `version` in `pyproject.toml` in any PR that changes behaviour a user can see, matching the change's conventional-commit type: `feat:` bumps the minor, `fix:` the patch. This is not bookkeeping. `uv` keys its build cache on the version, so shipping two different builds as the same version means `uv tool install . --force` reports success and installs the older one - which happened, and cost a debugging session before anyone thought to compare the installed file's timestamp.
 - **Commit messages:** Use [Conventional Commits](https://www.conventionalcommits.org/):
   - `feat: add book export command`
   - `fix: handle missing ISBN in frontmatter`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.1.0"
+version = "0.2.0"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "libris"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Written because it cost a debugging session today.

`uv` keys its build cache on the package version. Six PRs landed while `pyproject.toml` still said `0.1.0` — the server, the matching extraction, superseded IDs, format, duplicate candidates, the decisions file — so `uv tool install . --force` reported success and installed a build from the previous day. The working tree had `libris merge --decisions`; the command on PATH did not.

Every signal said it had worked. `uv` printed `Installed 21 packages` and `libris==0.1.0 (from file:///D:/code/libris)`. What actually settled it was comparing the installed `cli.py`'s timestamp against the repo's — Aug 27 against Aug 28.

## What changed

**`AGENTS.md` gains a Versioning rule**: bump `version` in any PR that changes behaviour a user can see, matching the change's conventional-commit type — `feat:` bumps the minor, `fix:` the patch. The entry says *why*, because a bookkeeping rule with no stated reason is the kind people skip when they're busy.

**`AGENTS.md` also notes that `libris` on PATH is a `uv tool` snapshot**, not the working tree, with the refresh commands and the warning that the install output says "Installed" whether or not it rebuilt anything.

**Version bumped to `0.2.0`**, which is where it should have been several features ago.

## What this does not fix

There's still no way to ask a build which version it is — `libris --version` doesn't exist, so a bumped version is invisible at the point where you'd want it. Worth adding, and deliberately not smuggled into a docs PR.

No code changes. 357 tests pass, `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
