### PR TITLE
feat(cli): report the installed version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.2.0"
+version = "0.3.0"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/__init__.py
+++ b/src/libris/__init__.py
@@ -1,1 +1,24 @@
-# libris package
+"""Libris - track the books you have read, are reading, or mean to read."""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+
+__all__ = ["installed_version"]
+
+
+def installed_version() -> str:
+    """The version of the installed libris distribution.
+
+    Read from package metadata rather than a constant, so it cannot disagree
+    with what was actually installed - which is the failure this exists to make
+    visible. `uv` keys its build cache on the version, so two builds sharing one
+    version are indistinguishable until something is missing.
+
+    Returns:
+        The version string, or "unknown" when libris is not installed as a
+        distribution, as when running from a source checkout without an install.
+    """
+    try:
+        return _distribution_version("libris")
+    except PackageNotFoundError:
+        return "unknown"

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import questionary
 import typer
 
+from . import installed_version
 from .api import GoogleBooksClient
 from .config import (
     ensure_server_token,
@@ -66,6 +67,27 @@ for _stream in (sys.stdout, sys.stderr):
 
 
 app = typer.Typer()
+
+
+def _show_version(value: bool) -> None:
+    """Print the installed version and stop, before any command runs."""
+    if value:
+        typer.echo(installed_version())
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_show_version,
+        is_eager=True,
+        help="Print the installed version and exit.",
+    ),
+) -> None:
+    """Track the books you have read, are reading, or mean to read."""
+
 
 _RENAME_SKIP_MESSAGES = {
     "missing_title": "missing title in frontmatter",

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -10,8 +10,6 @@ module fails on a core install. cli.py imports it lazily and says so.
 """
 
 import secrets
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as package_version
 from typing import Any
 
 import httpx
@@ -20,7 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from . import config, service
+from . import config, installed_version, service
 from .api import BookCandidate, GoogleBooksClient
 
 DEFAULT_HOST = "127.0.0.1"
@@ -138,10 +136,7 @@ class WriteResponse(BaseModel):
 
 def libris_version() -> str:
     """Get the installed libris version, or "unknown" if it cannot be read."""
-    try:
-        return package_version("libris")
-    except PackageNotFoundError:
-        return "unknown"
+    return installed_version()
 
 
 def create_app() -> FastAPI:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import sys
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -473,3 +474,35 @@ def test_cleanup_dry_run_refuses_to_combine_with_rename(tmp_path, monkeypatch):
     # a flag that says it writes nothing has to mean it
     assert result.exit_code != 0
     assert "--rename" in result.output
+
+
+def test_version_flag_reports_the_installed_version():
+    # Given a build whose version is the only way to tell it from another
+    from libris import installed_version
+
+    # When the version is asked for
+    result = runner.invoke(app, ["--version"])
+
+    # Then it is printed and nothing else runs
+    assert result.exit_code == 0
+    assert result.output.strip() == installed_version()
+
+
+def test_version_is_not_unknown_in_a_normal_install():
+    # Given libris installed as a distribution, as it is under test
+    from libris import installed_version
+
+    # Then the version is readable. "unknown" means the metadata is missing,
+    # which is exactly when a stale install goes unnoticed
+    assert installed_version() != "unknown"
+
+
+def test_the_server_reports_the_same_version():
+    # Given the daemon's /health, which also reports a version
+    pytest.importorskip("fastapi")
+    from libris import installed_version
+    from libris.server import libris_version
+
+    # Then it is the same one: two definitions of a version is how two builds
+    # come to disagree about which they are
+    assert libris_version() == installed_version()

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "libris"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Stacked on #80, so the version line stays coherent — `0.2.0` there, `0.3.0` here. GitHub retargets this to `main` when #80 merges.

Bumping a version only helps if something can read it back. Diagnosing today's stale install took comparing `cli.py` timestamps between the uv tool directory and the repo, because nothing on the machine would say which build was on PATH. `uv` had cheerfully reported `Installed`.

## What this adds

`libris --version`, as an eager Typer callback so it answers before any command runs.

The version is read from **package metadata**, not a constant. A constant can disagree with what was actually installed, which is precisely the failure this exists to expose — a build that thinks it's `0.3.0` while the metadata says otherwise would hide the problem rather than reveal it. When libris isn't installed as a distribution it reports `unknown`, which is itself the useful answer.

## One definition, not two

`server.py` had its own copy of the same `importlib.metadata` lookup, feeding `/health`. It now delegates to `libris.installed_version`, and a test asserts the daemon reports the same string the CLI does.

That duplication was small and harmless today. It is also exactly the shape of the drift this project has spent several PRs undoing — `author` against `authors`, two `normalize_for_match` implementations, a shape rule that existed in the reader and not the writer. Two definitions of a version is how two builds come to disagree about which they are.

## Verified

```
$ libris --version
0.3.0
```

All fifteen commands still listed in `--help`; adding an app callback can change how Typer exposes them, so that was checked rather than assumed.

360 tests with the server extra, 322 plus 2 skips without. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
