### PR TITLE
perf(service): serve Shelf queries from a revalidated index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ wheels/
 
 # claude worktrees 
 .claude/worktrees
+# Node, for the extension test and lint tooling only.
+node_modules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.3.0"
+version = "0.3.1"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -19,6 +19,7 @@ from .merge import (
     merge_two_books,
     write_merged_book,
 )
+from .shelf import index_for
 
 
 class Outcome(Enum):
@@ -194,9 +195,10 @@ def find_existing(
 ) -> BookNote | None:
     """Find a Book Note already on the Shelf describing this book.
 
-    Checked against the live Shelf rather than an index, so the answer is true
-    at the moment it is given - the stronger of the two duplicate guarantees
-    (ADR 0010).
+    Checked against the live Shelf, so the answer is true at the moment it is
+    given - the stronger of the two duplicate guarantees (ADR 0010). The notes
+    come from an index, which is revalidated against the filesystem on every
+    call rather than held for a lifetime, so that remains true.
 
     Args:
         vault_path: The Shelf to search.
@@ -211,11 +213,7 @@ def find_existing(
     wanted_title = normalize_for_match(title) if title else None
     wanted_author = normalize_for_match(authors[0]) if authors else None
 
-    for book_path in list_books(vault_path):
-        note = BookNote.read(book_path)
-        if note is None:
-            continue
-
+    for note in index_for(vault_path).notes():
         if isbn and note.frontmatter.get("isbn") == isbn:
             return note
         if (
@@ -232,11 +230,6 @@ def find_existing(
             and normalize_for_match(note.first_author) == wanted_author
         ):
             return note
-            if (
-                note.first_author
-                and normalize_for_match(note.first_author) == wanted_author
-            ):
-                return note
     return None
 
 
@@ -275,9 +268,8 @@ def find_similar(
     wanted_author = normalize_for_match(authors[0]) if authors else None
 
     found: list[BookNote] = []
-    for book_path in list_books(vault_path):
-        note = BookNote.read(book_path)
-        if note is None or not note.title:
+    for note in index_for(vault_path).notes():
+        if not note.title:
             continue
         if wanted_author is not None:
             if not note.first_author:

--- a/src/libris/shelf.py
+++ b/src/libris/shelf.py
@@ -29,9 +29,24 @@ from .markdown import BookNote
 Fingerprint = tuple[int, int]
 
 
-def _fingerprint(entry: os.DirEntry) -> Fingerprint:
-    """Describe a file precisely enough to notice it changing."""
-    info = entry.stat()
+def _describe(entry: os.DirEntry) -> Fingerprint | None:
+    """Describe a file precisely enough to notice it changing.
+
+    Args:
+        entry: A directory entry from the Shelf.
+
+    Returns:
+        The fingerprint, or None if this is not a readable file. `stat` and
+        `is_file` both reach the filesystem and can fail on an entry that is
+        being written or removed while the Shelf is listed, which is ordinary
+        on a vault that Obsidian and a sync client also write to.
+    """
+    try:
+        if not entry.is_file():
+            return None
+        info = entry.stat()
+    except OSError:
+        return None
     return (info.st_mtime_ns, info.st_size)
 
 
@@ -55,13 +70,18 @@ class ShelfIndex:
         """Every Book Note on the Shelf, as it stands right now.
 
         Returns:
-            The notes, in the order the filesystem reports them. Reparsed only
+            The notes, in the order the directory listed them. Reparsed only
             where a file appeared, changed or went away since the last call.
         """
         seen: set[str] = set()
+        found: list[BookNote] = []
 
         try:
-            entries = list(os.scandir(self.vault_path))
+            # Closed deterministically rather than left to exhaustion: if the
+            # listing raises partway, the directory handle would otherwise be
+            # held until the collector got to it.
+            with os.scandir(self.vault_path) as scan:
+                listing = [(entry.name, entry.path, _describe(entry)) for entry in scan]
         except FileNotFoundError:
             # A Shelf that has gone away holds no books, which is the truthful
             # answer and lets the caller report a miss rather than crash.
@@ -70,27 +90,42 @@ class ShelfIndex:
             self._unparseable.clear()
             return []
 
-        for entry in entries:
-            if not entry.name.endswith(".md") or not entry.is_file():
+        for name, path, fingerprint in listing:
+            if fingerprint is None or not name.endswith(".md"):
                 continue
-            seen.add(entry.name)
+            seen.add(name)
 
-            fingerprint = _fingerprint(entry)
-            if self._fingerprints.get(entry.name) == fingerprint:
+            cached = self._notes.get(name)
+            if cached is not None and self._fingerprints.get(name) == fingerprint:
+                found.append(cached)
                 continue
-            if self._unparseable.get(entry.name) == fingerprint:
+            if self._unparseable.get(name) == fingerprint:
                 continue
 
-            note = BookNote.read(Path(entry.path))
+            try:
+                note = BookNote.read(Path(path))
+            except OSError:
+                # The file moved, vanished or was locked between the listing and
+                # the read - Obsidian saving, a sync client, or Libris itself.
+                # The last parse stands rather than the Book being reported
+                # absent: a duplicate check that misses writes a second note and
+                # nothing ever surfaces it, where a momentarily stale title
+                # harms nobody. The fingerprint is left alone, so the next call
+                # tries again rather than trusting what it could not read.
+                if cached is not None:
+                    found.append(cached)
+                continue
+
             if note is None:
-                self._unparseable[entry.name] = fingerprint
-                self._notes.pop(entry.name, None)
-                self._fingerprints.pop(entry.name, None)
+                self._unparseable[name] = fingerprint
+                self._notes.pop(name, None)
+                self._fingerprints.pop(name, None)
                 continue
 
-            self._notes[entry.name] = note
-            self._fingerprints[entry.name] = fingerprint
-            self._unparseable.pop(entry.name, None)
+            self._notes[name] = note
+            self._fingerprints[name] = fingerprint
+            self._unparseable.pop(name, None)
+            found.append(note)
 
         for gone in self._notes.keys() - seen:
             del self._notes[gone]
@@ -98,7 +133,7 @@ class ShelfIndex:
         for gone in self._unparseable.keys() - seen:
             del self._unparseable[gone]
 
-        return list(self._notes.values())
+        return found
 
 
 _INDEXES: dict[Path, ShelfIndex] = {}

--- a/src/libris/shelf.py
+++ b/src/libris/shelf.py
@@ -1,0 +1,133 @@
+"""The Shelf's Book Notes, parsed once and revalidated against disk.
+
+Every query used to read and YAML-parse all 3,061 notes. Measured against the
+real Shelf that is about 8 seconds for one exact-match query and 13 for one
+Near Match query, and `GET /api/v1/books` runs both - so a browser popup that
+checks the Shelf twice in a flow spent the better part of a minute waiting.
+Parsing is where it goes: reading all 4.6 MB takes 1.5 seconds and parsing the
+frontmatter takes ten.
+
+So the parse happens once per note per change, rather than once per note per
+question.
+
+This does not weaken the guarantee the daemon exists to give (ADR 0010). The
+promise is that an answer is true at the moment it is given, and every call
+re-reads the directory and re-parses whatever changed - it is a revalidated
+index, never a cache with a lifetime. A note edited in Obsidian between two
+questions is seen by the second one.
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .markdown import BookNote
+
+# What distinguishes one version of a file from the next. `os.scandir` reports
+# both without a second system call, which is what makes revalidating the whole
+# Shelf cost about 30 milliseconds.
+Fingerprint = tuple[int, int]
+
+
+def _fingerprint(entry: os.DirEntry) -> Fingerprint:
+    """Describe a file precisely enough to notice it changing."""
+    info = entry.stat()
+    return (info.st_mtime_ns, info.st_size)
+
+
+@dataclass
+class ShelfIndex:
+    """Every Book Note on one Shelf, kept in step with the files.
+
+    Held for the life of a process. A CLI command builds it, asks one question
+    and throws it away, paying exactly what the old scan cost; the daemon keeps
+    it and pays only for what changed.
+    """
+
+    vault_path: Path
+    _notes: dict[str, BookNote] = field(default_factory=dict)
+    _fingerprints: dict[str, Fingerprint] = field(default_factory=dict)
+    # Files whose frontmatter would not parse. Remembered so a broken note is
+    # not re-read on every question, and re-read the moment it is edited.
+    _unparseable: dict[str, Fingerprint] = field(default_factory=dict)
+
+    def notes(self) -> list[BookNote]:
+        """Every Book Note on the Shelf, as it stands right now.
+
+        Returns:
+            The notes, in the order the filesystem reports them. Reparsed only
+            where a file appeared, changed or went away since the last call.
+        """
+        seen: set[str] = set()
+
+        try:
+            entries = list(os.scandir(self.vault_path))
+        except FileNotFoundError:
+            # A Shelf that has gone away holds no books, which is the truthful
+            # answer and lets the caller report a miss rather than crash.
+            self._notes.clear()
+            self._fingerprints.clear()
+            self._unparseable.clear()
+            return []
+
+        for entry in entries:
+            if not entry.name.endswith(".md") or not entry.is_file():
+                continue
+            seen.add(entry.name)
+
+            fingerprint = _fingerprint(entry)
+            if self._fingerprints.get(entry.name) == fingerprint:
+                continue
+            if self._unparseable.get(entry.name) == fingerprint:
+                continue
+
+            note = BookNote.read(Path(entry.path))
+            if note is None:
+                self._unparseable[entry.name] = fingerprint
+                self._notes.pop(entry.name, None)
+                self._fingerprints.pop(entry.name, None)
+                continue
+
+            self._notes[entry.name] = note
+            self._fingerprints[entry.name] = fingerprint
+            self._unparseable.pop(entry.name, None)
+
+        for gone in self._notes.keys() - seen:
+            del self._notes[gone]
+            del self._fingerprints[gone]
+        for gone in self._unparseable.keys() - seen:
+            del self._unparseable[gone]
+
+        return list(self._notes.values())
+
+
+_INDEXES: dict[Path, ShelfIndex] = {}
+
+
+def index_for(vault_path: Path) -> ShelfIndex:
+    """Get the index for a Shelf, building it if this process has none.
+
+    Keyed by path rather than held as one global, so a test pointing at a
+    temporary Shelf never sees another one's notes.
+
+    Args:
+        vault_path: The Shelf to index.
+
+    Returns:
+        The index for that Shelf.
+    """
+    resolved = vault_path.resolve()
+    index = _INDEXES.get(resolved)
+    if index is None:
+        index = ShelfIndex(vault_path=resolved)
+        _INDEXES[resolved] = index
+    return index
+
+
+def forget_indexes() -> None:
+    """Drop every index this process holds.
+
+    For tests, which reuse one process across many temporary Shelves and can
+    otherwise recreate a path a previous test already indexed.
+    """
+    _INDEXES.clear()

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -6,6 +6,7 @@ every note. Nothing caught it because every other test uses a vault holding one
 or two notes - so these tests count parses rather than trusting a stopwatch.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -223,3 +224,88 @@ def test_a_large_shelf_is_read_once_and_then_left_alone(tmp_path, counted_reads)
 
     # Then the Shelf was parsed once, not four times over
     assert len(counted_reads) == 300
+
+
+def test_notes_come_back_in_the_order_the_directory_lists_them(tmp_path):
+    # Given a Shelf that has been read, then churned
+    for title in ("Aaa", "Bbb", "Ccc"):
+        _shelve(tmp_path, title)
+    index = shelf.index_for(tmp_path)
+    index.notes()
+    (tmp_path / "Aaa - Frank Herbert.md").unlink()
+    _shelve(tmp_path, "Aaa")
+
+    # When it is read again
+    names = [n.path.name for n in index.notes()]
+
+    # Then the order follows the directory listing, not the order things
+    # happened to be parsed. find_existing returns the first match and the Shelf
+    # holds real duplicate groups, so which note answers is behaviour rather
+    # than an accident. Compared against a real listing rather than a sorted
+    # one: scandir order is alphabetical on NTFS and arbitrary on ext4, and CI
+    # runs the latter.
+    with os.scandir(tmp_path) as scan:
+        listed = [e.name for e in scan if e.name.endswith(".md")]
+    assert names == listed
+
+
+def test_a_file_locked_mid_write_keeps_its_last_known_content(tmp_path, monkeypatch):
+    # Given a Book Note already indexed
+    path = _shelve(tmp_path, "Dune")
+    index = shelf.index_for(tmp_path)
+    assert [n.title for n in index.notes()] == ["Dune"]
+
+    # When the file changes and is unreadable at the moment we go to read it,
+    # which is ordinary on a vault Obsidian and a sync client also write to
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("status: To Read", "status: Read"),
+        encoding="utf-8",
+    )
+
+    def _locked(_path):
+        raise PermissionError(32, "The process cannot access the file")
+
+    monkeypatch.setattr(BookNote, "read", staticmethod(_locked))
+
+    # Then the Book is still reported, from what was last parsed. Reporting it
+    # absent would let a duplicate check write a second note for a book already
+    # held, which nothing afterwards surfaces.
+    assert [n.title for n in index.notes()] == ["Dune"]
+
+
+def test_a_file_that_becomes_readable_again_is_re_read(tmp_path, monkeypatch):
+    # Given a note whose edit could not be read
+    path = _shelve(tmp_path, "Dune")
+    index = shelf.index_for(tmp_path)
+    index.notes()
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("status: To Read", "status: Read"),
+        encoding="utf-8",
+    )
+    original = BookNote.read
+    monkeypatch.setattr(
+        BookNote, "read", staticmethod(lambda _p: (_ for _ in ()).throw(OSError()))
+    )
+    index.notes()
+
+    # When the lock clears
+    monkeypatch.setattr(BookNote, "read", staticmethod(original))
+
+    # Then the edit is picked up. A failed read must not be remembered the way
+    # an unparseable one is: the fingerprint never changes again, so caching it
+    # would hide that note's contents for the life of the daemon.
+    assert index.notes()[0].frontmatter.get("status") == "Read"
+
+
+def test_a_note_deleted_between_the_listing_and_the_read_is_dropped(tmp_path):
+    # Given a Shelf holding two books, neither yet indexed
+    _shelve(tmp_path, "Dune")
+    doomed = _shelve(tmp_path, "Piranesi", author="Susanna Clarke")
+    index = shelf.index_for(tmp_path)
+
+    # When one is deleted before it was ever parsed - so there is nothing
+    # remembered to fall back on
+    doomed.unlink()
+
+    # Then the answer holds what survives, rather than raising
+    assert [n.title for n in index.notes()] == ["Dune"]

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -1,0 +1,225 @@
+"""The Shelf index, and the promise that it is never stale.
+
+The measurement that prompted it: against a 3,061-note Shelf, one exact-match
+query took 8 seconds and one Near Match query 13, because both read and parsed
+every note. Nothing caught it because every other test uses a vault holding one
+or two notes - so these tests count parses rather than trusting a stopwatch.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from libris import service, shelf
+from libris.api import BookCandidate
+from libris.markdown import BookNote, create_book_note
+
+
+@pytest.fixture(autouse=True)
+def fresh_indexes():
+    """Start every test with no index, and leave none behind.
+
+    The index lives for the life of the process, which is the point of it, and
+    a test run is one process holding many Shelves.
+    """
+    shelf.forget_indexes()
+    yield
+    shelf.forget_indexes()
+
+
+@pytest.fixture
+def counted_reads(monkeypatch):
+    """Count how many notes get parsed, which is the cost being removed."""
+    reads = []
+    original = BookNote.read
+
+    def _counted(path):
+        reads.append(Path(path).name)
+        return original(path)
+
+    monkeypatch.setattr(BookNote, "read", staticmethod(_counted))
+    return reads
+
+
+def _shelve(vault_path, title, author="Frank Herbert", **fields):
+    """Put a Book Note on a Shelf."""
+    return create_book_note(
+        BookCandidate(title=title, authors=[author], **fields), vault_path
+    )
+
+
+def test_a_note_is_parsed_once_however_often_it_is_asked_about(tmp_path, counted_reads):
+    # Given a Shelf of three books
+    for title in ("Dune", "Piranesi", "Mercy"):
+        _shelve(tmp_path, title)
+    index = shelf.index_for(tmp_path)
+
+    # When the Shelf is read four times
+    for _ in range(4):
+        index.notes()
+
+    # Then each note was parsed once, not four times. This is the whole saving:
+    # the daemon asks twice per popup flow and the files have not changed.
+    assert sorted(counted_reads) == sorted([p.name for p in tmp_path.glob("*.md")]), (
+        counted_reads
+    )
+
+
+def test_a_book_added_outside_libris_is_seen_immediately(tmp_path):
+    # Given a Shelf that has already been read
+    _shelve(tmp_path, "Dune")
+    index = shelf.index_for(tmp_path)
+    assert len(index.notes()) == 1
+
+    # When something else writes a note - Obsidian, or another Libris process
+    _shelve(tmp_path, "Piranesi", author="Susanna Clarke")
+
+    # Then the next question sees it. The index is revalidated per call, so the
+    # daemon's live-Shelf guarantee survives it (ADR 0010).
+    assert {n.title for n in index.notes()} == {"Dune", "Piranesi"}
+
+
+def test_a_book_edited_outside_libris_is_re_read(tmp_path):
+    # Given a Shelf that has already been read
+    path = _shelve(tmp_path, "Dune")
+    index = shelf.index_for(tmp_path)
+    assert index.notes()[0].frontmatter.get("status") == "To Read"
+
+    # When the note is edited in Obsidian
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("status: To Read", "status: Read"),
+        encoding="utf-8",
+    )
+
+    # Then the change is visible, not masked by what was parsed before
+    assert index.notes()[0].frontmatter.get("status") == "Read"
+
+
+def test_a_book_deleted_outside_libris_stops_being_reported(tmp_path):
+    # Given a Shelf of two books, already read
+    _shelve(tmp_path, "Dune")
+    doomed = _shelve(tmp_path, "Piranesi", author="Susanna Clarke")
+    index = shelf.index_for(tmp_path)
+    assert len(index.notes()) == 2
+
+    # When one is deleted
+    doomed.unlink()
+
+    # Then it is gone from the answer rather than lingering as a duplicate that
+    # cannot be found on disk
+    assert {n.title for n in index.notes()} == {"Dune"}
+
+
+def test_only_the_changed_note_is_re_read(tmp_path, counted_reads):
+    # Given a Shelf of three books, already read
+    for title in ("Dune", "Piranesi", "Mercy"):
+        _shelve(tmp_path, title)
+    index = shelf.index_for(tmp_path)
+    index.notes()
+    counted_reads.clear()
+
+    # When one of them is edited
+    edited = tmp_path / "Dune - Frank Herbert.md"
+    edited.write_text(
+        edited.read_text(encoding="utf-8").replace("status: To Read", "status: Read"),
+        encoding="utf-8",
+    )
+    index.notes()
+
+    # Then only that one is parsed again
+    assert counted_reads == [edited.name]
+
+
+def test_a_note_that_will_not_parse_is_skipped_and_not_re_read(tmp_path, counted_reads):
+    # Given a file that is not a Book Note at all
+    (tmp_path / "Broken.md").write_text("no frontmatter here", encoding="utf-8")
+    _shelve(tmp_path, "Dune")
+    index = shelf.index_for(tmp_path)
+
+    # When the Shelf is read twice
+    assert [n.title for n in index.notes()] == ["Dune"]
+    counted_reads.clear()
+    index.notes()
+
+    # Then the broken file is left out both times, and is not re-parsed on the
+    # second - a Shelf with a damaged note should not pay for it every call
+    assert counted_reads == []
+
+
+def test_a_repaired_note_is_picked_up(tmp_path):
+    # Given a file that would not parse
+    broken = tmp_path / "Broken.md"
+    broken.write_text("no frontmatter here", encoding="utf-8")
+    index = shelf.index_for(tmp_path)
+    assert index.notes() == []
+
+    # When it is repaired
+    broken.write_text(
+        "---\ntitle: Dune\nauthors:\n- Frank Herbert\n---\n", encoding="utf-8"
+    )
+
+    # Then it joins the Shelf, rather than being remembered as broken forever
+    assert [n.title for n in index.notes()] == ["Dune"]
+
+
+def test_a_shelf_that_is_not_there_holds_no_books(tmp_path):
+    # Given a configured Shelf that does not exist
+    missing = tmp_path / "gone"
+
+    # When it is read
+    # Then it answers empty rather than raising, so a Surface reports a miss
+    assert shelf.index_for(missing).notes() == []
+
+
+def test_two_shelves_do_not_see_each_other(tmp_path):
+    # Given two Shelves
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    _shelve(first, "Dune")
+    _shelve(second, "Piranesi", author="Susanna Clarke")
+
+    # Then each answers for itself
+    assert [n.title for n in shelf.index_for(first).notes()] == ["Dune"]
+    assert [n.title for n in shelf.index_for(second).notes()] == ["Piranesi"]
+
+
+def test_a_miss_reads_the_shelf_once_not_twice(tmp_path, counted_reads):
+    # Given a Shelf whose titles resemble what is being looked up
+    for title in ("The Brass Verdict: A Novel", "Dune", "Mercy"):
+        _shelve(tmp_path, title, author="Michael Connelly")
+    shelf.index_for(tmp_path).notes()
+    counted_reads.clear()
+
+    # When a Surface asks whether a Book is held and what nearly matches it -
+    # which is what GET /api/v1/books does on every miss
+    assert (
+        service.find_existing(
+            tmp_path, title="The Brass Verdict", authors=["Michael Connelly"]
+        )
+        is None
+    )
+    near = service.find_similar(
+        tmp_path, title="The Brass Verdict", authors=["Michael Connelly"]
+    )
+
+    # Then the Near Match is offered, and neither question re-read a thing.
+    # Before the index these were two full passes over the Shelf.
+    assert [n.title for n in near] == ["The Brass Verdict: A Novel"]
+    assert counted_reads == []
+
+
+def test_a_large_shelf_is_read_once_and_then_left_alone(tmp_path, counted_reads):
+    # Given a Shelf big enough for the cost to matter. The real one holds 3,061
+    # notes and took 8 seconds a query; a two-note fixture is what hid that.
+    for n in range(300):
+        _shelve(tmp_path, f"Book {n:03d}")
+
+    # When it is queried the way a popup queries it - twice per flow
+    for _ in range(2):
+        service.find_existing(tmp_path, isbn="9780441013593")
+        service.find_similar(tmp_path, title="Book 001", authors=["Frank Herbert"])
+
+    # Then the Shelf was parsed once, not four times over
+    assert len(counted_reads) == 300

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "libris"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #85. Blocks #83 — the extension cannot meet its acceptance criteria until this lands.

## The problem

Every Shelf query read and YAML-parsed all 3,061 notes. Measured against the real Shelf:

| Call | Cold cache | Warm |
| --- | --- | --- |
| `find_existing` (miss) | 43.9s | 8.0s |
| `find_similar` | — | 13.3s |

`GET /api/v1/books` on a miss runs both, and the extension's popup calls it twice per capture —
once against the raw scrape, once against the chosen candidate. So one clip spent about **42
seconds** waiting on the Shelf.

Profiling says it is parsing, not I/O:

| Step | Time |
| --- | --- |
| `list_books` (`os.scandir`) | 0.03s |
| Read all 4.6 MB | 1.5s |
| YAML-parse every frontmatter block | ~10s |

Nothing caught this because every test uses a `tmp_path` vault of one or two notes.

## The change

`ShelfIndex` parses each note once and keeps it, fingerprinted as `(mtime_ns, size)` from the
`os.scandir` call `list_books` already makes. Every query re-scans the directory — 30ms for the
whole Shelf — and reparses only what moved.

Against the real Shelf:

| | Before | After |
| --- | --- | --- |
| `find_existing`, first call | 8.0s | 8.6s (builds the index) |
| `find_existing`, thereafter | 8.0s | **0.022s** |
| `find_similar` | 13.3s | **0.092s** |
| `GET /api/v1/books` on a miss | ~21s | **~0.11s** |

`find_existing` and `find_similar` now share one index, so a miss stops scanning the Shelf twice.

## This does not weaken ADR 0010

The daemon's whole reason to exist is that it can promise a Book was not in your Library and now
is, because it checked the live Shelf. That promise survives, because this is **a revalidated
index, not a cache with a lifetime** — every call re-reads the directory and reparses whatever
changed. A note edited in Obsidian between two questions is seen by the second one. There are
tests for adding, editing and deleting a note behind Libris' back.

The one case it cannot distinguish is a write landing in the same nanosecond with an identical
file size, which is no worse than the race the previous code already ran between its own two
scans.

## Tests

Eleven, and they **count parses rather than timing anything** — a stopwatch assertion in CI is a
flake, and the number of parses is the actual claim. One builds a 300-note Shelf and asserts that
a popup's two queries read it once between them, because a two-note fixture is precisely what hid
this.

Also covered: a note that will not parse is skipped and not re-read on every call, and is picked
up once repaired; a Shelf that has been deleted answers empty rather than raising; two Shelves in
one process do not see each other.

## Also

`find_existing` loses the unreachable block left by 1861c90 ("Apply suggestions from code
review"), since this rewrites those lines anyway. Behaviour was never wrong — the outer `and`
chain already tested the author — and ruff cannot see it, because pyflakes has no
unreachable-code check.

`.gitignore` gains `node_modules/`, which #83 added on its own branch and which any branch off
`main` needs once the extension exists.

Version 0.3.0 → **0.3.1**. A patch, so #83 keeps the 0.4.0 it already claims rather than being
bumped to 0.5.0 for a merge-order accident.

## Not in scope

The first query after the daemon starts still pays 8.6s to build the index. Warming it during
startup would hide that, at the cost of `libris serve` taking ten seconds to bind — worth
deciding separately rather than folding in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFgPxnSw7ofTHnYndrU12U
