### PR TITLE
perf(server): read the Shelf at startup so the first clip is not the slow one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.3.1"
+version = "0.3.2"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -156,7 +156,8 @@ async def _warm_index(app: FastAPI):
     """
     vault_path = config.get_vault_path()
     count = len(shelf.index_for(vault_path).notes())
-    print(f"Indexed {count} Book Notes from {vault_path}", flush=True)
+    import logging
+    logging.getLogger(__name__).info("Indexed %d Book Notes", count)
     yield
 
 

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -9,6 +9,7 @@ Optional: the web stack installs only with `libris[server]`, so importing this
 module fails on a core install. cli.py imports it lazily and says so.
 """
 
+import logging
 import secrets
 from contextlib import asynccontextmanager
 from typing import Any
@@ -156,7 +157,6 @@ async def _warm_index(app: FastAPI):
     """
     vault_path = config.get_vault_path()
     count = len(shelf.index_for(vault_path).notes())
-    import logging
     logging.getLogger(__name__).info("Indexed %d Book Notes", count)
     yield
 

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -10,6 +10,7 @@ module fails on a core install. cli.py imports it lazily and says so.
 """
 
 import secrets
+from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
@@ -18,7 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from . import config, installed_version, service
+from . import config, installed_version, service, shelf
 from .api import BookCandidate, GoogleBooksClient
 
 DEFAULT_HOST = "127.0.0.1"
@@ -139,6 +140,26 @@ def libris_version() -> str:
     return installed_version()
 
 
+@asynccontextmanager
+async def _warm_index(app: FastAPI):
+    """Read the Shelf before accepting requests.
+
+    The index makes every query after the first cost nothing, but the first
+    still pays for the whole Shelf - about seven seconds for 3,061 notes. Left
+    to happen on demand, that cost lands on somebody waiting in a browser
+    popup, which is the one moment it is least welcome.
+
+    So the daemon binds late instead. Started from a scheduled task at logon
+    (#55) nobody is waiting; started by hand it is one wait rather than a
+    surprise later. A Surface that connects during it sees no daemon at all,
+    which is a state the popup already reports plainly.
+    """
+    vault_path = config.get_vault_path()
+    count = len(shelf.index_for(vault_path).notes())
+    print(f"Indexed {count} Book Notes from {vault_path}", flush=True)
+    yield
+
+
 def create_app() -> FastAPI:
     """Build the daemon's ASGI app.
 
@@ -148,7 +169,7 @@ def create_app() -> FastAPI:
     Returns:
         The configured FastAPI application.
     """
-    app = FastAPI(title="Libris", version=libris_version())
+    app = FastAPI(title="Libris", version=libris_version(), lifespan=_warm_index)
 
     @app.middleware("http")
     async def require_token(request: Request, call_next):

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -142,7 +142,7 @@ def libris_version() -> str:
 
 
 @asynccontextmanager
-async def _warm_index(app: FastAPI):
+async def _warm_index(_app: FastAPI):
     """Read the Shelf before accepting requests.
 
     The index makes every query after the first cost nothing, but the first

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,10 +14,10 @@ import httpx  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from typer.testing import CliRunner  # noqa: E402
 
-from libris import config  # noqa: E402
+from libris import config, shelf  # noqa: E402
 from libris.api import BookCandidate  # noqa: E402
 from libris.cli import app as cli_app  # noqa: E402
-from libris.markdown import create_book_note  # noqa: E402
+from libris.markdown import BookNote, create_book_note  # noqa: E402
 from libris.server import create_app  # noqa: E402
 
 runner = CliRunner()
@@ -626,3 +626,41 @@ def test_an_exact_match_still_answers_directly(token, tmp_path):
     # Then it is answered, not offered as a maybe
     assert response.status_code == 200
     assert response.json()["libris_id"]
+
+
+# --- startup ---
+
+
+def test_the_shelf_is_read_before_the_daemon_accepts_requests(
+    token, tmp_path, monkeypatch
+):
+    # Given a Shelf holding a book, and no index yet
+    config.set_book_vault_path(tmp_path)
+    create_book_note(BookCandidate(title="Dune", authors=["Frank Herbert"]), tmp_path)
+    shelf.forget_indexes()
+
+    parsed = []
+    original = BookNote.read
+
+    def _counted(path):
+        parsed.append(path)
+        return original(path)
+
+    monkeypatch.setattr(BookNote, "read", staticmethod(_counted))
+
+    # When the daemon starts, and is then asked about a book it holds
+    with TestClient(create_app()) as client:
+        assert parsed, "the Shelf should be read during startup, not on demand"
+        parsed.clear()
+
+        response = client.get(
+            "/api/v1/books",
+            params={"title": "Dune", "authors": ["Frank Herbert"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    # Then the question itself parsed nothing. Reading this Shelf costs about
+    # seven seconds at its real size, and the daemon binds late so that lands on
+    # startup rather than on somebody waiting in a browser popup (#85).
+    assert response.status_code == 200
+    assert parsed == []

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "libris"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Follows #86, which made every Shelf query after the first cost nothing. The first still pays for
the whole Shelf — about seven seconds for 3,061 notes — and left on demand that lands on somebody
waiting in a browser popup, which is the one moment it is least welcome.

So the daemon reads the Shelf during startup and binds late instead.

| | Before | After |
| --- | --- | --- |
| `libris serve` to accepting requests | immediate | ~7.5s |
| First clip after the daemon starts | ~7.5s | instant |
| Every clip after that | instant | instant |

The trade is deliberate and was chosen explicitly: started from a scheduled task at logon (#55)
nobody is waiting through it, and started by hand it is one wait up front rather than a surprise
later. A Surface that connects during the wait finds no daemon at all, which the extension
already reports plainly as "start it with `libris serve`" — a worse message than those seven
seconds deserve, and better than a popup that appears to hang.

## Where it lives

In the app's lifespan rather than in the CLI, so it happens in whichever process ends up serving.
`libris serve --reload` runs the app in a child process, and warming the parent would have warmed
nothing.

## The test

It enters the lifespan, which no existing test does — a `TestClient` built without a `with` block
never starts the app, so warming would otherwise have shipped untested. It asserts both halves:
the Shelf is read during startup, and the request that follows parses nothing.

It asks about a Book the Shelf *holds* rather than one it does not, so it asserts the same thing
on either side of the 200-envelope change in #83. Written the other way it would have passed here
and failed after that merge.

Version 0.3.1 → **0.3.2**. A patch, and required rather than bookkeeping: #86 already shipped
0.3.1, and `uv` keys its build cache on the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFgPxnSw7ofTHnYndrU12U
