### PR TITLE
fix(config): refuse to treat the working directory as the Shelf

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Libris",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Add the book on this page to your Libris reading list.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.4.0"
+version = "0.4.1"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -11,6 +11,7 @@ import typer
 from . import installed_version
 from .api import GoogleBooksClient
 from .config import (
+    VaultNotConfigured,
     ensure_server_token,
     get_obsidian_vault_root,
     get_vault_path,
@@ -91,6 +92,27 @@ def main(
     """Track the books you have read, are reading, or mean to read."""
 
 
+def _require_vault_path() -> Path:
+    """Get the Shelf, or stop the command with an explanation.
+
+    Library code raises and the CLI reports, per `AGENTS.md`. Every command
+    that touches the Shelf needs the same three lines, so they live here rather
+    than at each of the eleven call sites.
+
+    Returns:
+        The resolved path to the configured Shelf.
+
+    Raises:
+        typer.Exit: With code 1 when no Shelf is configured.
+    """
+    try:
+        return get_vault_path()
+    except VaultNotConfigured:
+        typer.echo("No Shelf is configured, so there is nothing to read or write.")
+        typer.echo("Set one with: libris config --vault <path>")
+        raise typer.Exit(code=1) from None
+
+
 _RENAME_SKIP_MESSAGES = {
     "missing_title": "missing title in frontmatter",
     "missing_author": "missing author in frontmatter",
@@ -112,7 +134,7 @@ def _format_rename_skip(filename: str, result: RenameResult) -> str | None:
 @app.command()
 def status():
     """Update the status of a book in your vault."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     books = list_books(vault_path)
 
     if not books:
@@ -148,7 +170,7 @@ def list_cmd(
     ),
 ):
     """List all books in your vault."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     start = time.perf_counter() if timing else None
     books = list_books(vault_path)
     elapsed = (time.perf_counter() - start) if timing and start is not None else None
@@ -264,7 +286,7 @@ def add(
     book_index = choices.index(selected_choice)
     selected_book = books[book_index]
 
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     if not vault_path.exists():
         typer.echo(f"Vault path does not exist: {vault_path}")
         return
@@ -328,7 +350,12 @@ def config(
     if not vault_path and not api_key and not obsidian_vault:
         from .config import get_api_key
 
-        typer.echo(f"Current vault path: {get_vault_path()}")
+        # `libris config` with no arguments is how a person finds out what is
+        # set, so an unset Shelf is what it is here to report, not a failure.
+        if is_vault_configured():
+            typer.echo(f"Current vault path: {get_vault_path()}")
+        else:
+            typer.echo("Current vault path: Not set")
         obsidian_root = get_obsidian_vault_root()
         if obsidian_root:
             typer.echo(f"Obsidian vault root: {obsidian_root}")
@@ -346,7 +373,7 @@ def clean(
     ),
 ):
     """Select a specific book to clean its frontmatter."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     books = list_books(vault_path)
 
     if not books:
@@ -399,7 +426,7 @@ def cleanup(
     ),
 ):
     """Ensure all books in the vault have the correct frontmatter fields."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     books = list_books(vault_path)
 
     if not books:
@@ -692,7 +719,7 @@ def autoenrich(
     --interactive to select the right book; otherwise they are logged for later
     review.
     """
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     books = list_books(vault_path)
 
     if not books:
@@ -805,7 +832,7 @@ def enrich(
     ),
 ):
     """Search Google Books to fill in missing data for a book."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
 
     if filename is None:
         books = list_books(vault_path)
@@ -835,7 +862,7 @@ def enrich(
 @app.command()
 def duplicates():
     """Find and report duplicate books in the vault."""
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
 
     groups = find_duplicates(vault_path)
 
@@ -900,7 +927,7 @@ def merge(
     Without --auto: Interactive mode where you choose which books to merge.
     With --auto: Automatically merge books when ISBN + Google ID match and no metadata conflicts exist.
     """
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
 
     if decisions is not None:
         _merge_from_decisions(vault_path, Path(decisions), allow_conflicts, dry_run)
@@ -1082,7 +1109,7 @@ def import_cmd(
         typer.echo(f"File not found: {file_path}")
         raise typer.Exit(code=1)
 
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     if not vault_path.exists():
         typer.echo(f"Vault path does not exist: {vault_path}")
         raise typer.Exit(code=1)
@@ -1150,7 +1177,7 @@ def migrate(
     A dry run by default: summarises what would change, prints a sample of
     diffs, and writes nothing. Review the diff before using --apply.
     """
-    vault_path = get_vault_path()
+    vault_path = _require_vault_path()
     if not vault_path.exists():
         typer.echo(f"Shelf does not exist: {vault_path}")
         raise typer.Exit(code=1)
@@ -1278,10 +1305,9 @@ def serve(
         raise typer.Exit(1) from None
 
     if not is_vault_configured():
-        # get_vault_path falls back to the working directory (#82), so without
-        # this the daemon would serve whatever directory it was started in -
-        # and #55 starts it from a scheduled task, where nobody picked that
-        # directory at all.
+        # Checked here rather than left to _require_vault_path so the message
+        # names the daemon's problem: it has nothing to serve. #55 starts it
+        # from a scheduled task, where nobody is watching for a traceback.
         typer.echo("No Shelf is configured, so the daemon has nothing to serve.")
         typer.echo("Set one with: libris config --vault <path>")
         raise typer.Exit(1)

--- a/src/libris/config.py
+++ b/src/libris/config.py
@@ -50,22 +50,44 @@ def set_book_vault_path(path: Path):
     set_config(LEGACY_VAULT_KEY, resolved)
 
 
+class VaultNotConfigured(Exception):
+    """Raised when a Shelf is needed and nobody has chosen one.
+
+    This used to be a silent fallback to the working directory, which meant an
+    unconfigured Libris wrote Book Notes into whatever directory it was
+    launched from (#82). Refusing is the safer answer: a Shelf is a location a
+    person picks once, and guessing it wrong scatters notes somewhere they will
+    not think to look.
+    """
+
+
 def get_vault_path() -> Path:
+    """Get the configured Shelf.
+
+    Returns:
+        The resolved path to the Shelf.
+
+    Raises:
+        VaultNotConfigured: If neither the current nor the legacy vault key is
+            set. Callers that want to report the absence rather than fail on it
+            should ask `is_vault_configured` first.
+    """
     config = get_config()
     path_str = config.get(BOOK_VAULT_KEY) or config.get(LEGACY_VAULT_KEY)
     if not path_str:
-        return Path(".").resolve()
+        raise VaultNotConfigured(
+            "No Shelf is configured. Set one with: libris config --vault <path>"
+        )
     return Path(path_str).expanduser().resolve()
 
 
 def is_vault_configured() -> bool:
     """Check whether a Shelf has actually been configured.
 
-    `get_vault_path` falls back to the working directory when nothing is set
-    (see #82), so "the path it returns exists" says nothing about whether a
-    person chose it. The daemon needs the difference: it refuses to start
-    without a Shelf, and `/health` reports it so a Surface can tell "running"
-    from "usable" (ADR 0019).
+    `get_vault_path` raises when nothing is set (#82), so this exists for the
+    callers that must report the absence rather than fail on it: the daemon
+    refuses to start without a Shelf, and `/health` reports the difference so a
+    Surface can tell "running" from "usable" (ADR 0019).
 
     Returns:
         True when a vault path is set under either the current or legacy key.

--- a/src/libris/server.py
+++ b/src/libris/server.py
@@ -36,15 +36,14 @@ UNAUTHENTICATED_PATHS = frozenset({"/health"})
 class Health(BaseModel):
     """What the extension popup shows to say which Library it reached.
 
-    `vault_configured` is the difference between running and usable. Without a
-    configured Shelf `get_vault_path` falls back to the working directory (#82),
-    so a daemon started by a scheduled task would otherwise report a healthy
-    path nobody chose.
+    `vault_configured` is the difference between running and usable, and
+    `vault_path` is null rather than a guess when no Shelf is set (#82): a
+    daemon started by a scheduled task must not report a path nobody chose.
     """
 
     status: str
     version: str
-    vault_path: str
+    vault_path: str | None
     vault_configured: bool
 
 
@@ -268,11 +267,15 @@ def create_app() -> FastAPI:
     @app.get("/health", response_model=Health)
     async def health() -> Health:
         """Report that the daemon is up and which Shelf it is serving."""
+        # Health is the one endpoint that must answer while unconfigured -
+        # it is how the popup tells "not running" from "running but unusable"
+        # (ADR 0019) - so it reports the absence instead of raising on it.
+        configured = config.is_vault_configured()
         return Health(
             status="ok",
             version=libris_version(),
-            vault_path=str(config.get_vault_path()),
-            vault_configured=config.is_vault_configured(),
+            vault_path=str(config.get_vault_path()) if configured else None,
+            vault_configured=configured,
         )
 
     router = APIRouter(prefix="/api/v1")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,36 @@ def test_config_vault_path(tmp_path):
     assert "API key: *********-key" in result.output
 
 
+def test_config_reports_an_unset_vault_rather_than_guessing(tmp_path, monkeypatch):
+    # Given no configured Shelf, and a working directory that is not one
+    monkeypatch.chdir(tmp_path)
+
+    # When a person runs `libris config` to find out what is set
+    result = runner.invoke(app, ["config"])
+
+    # Then it says nothing is, instead of naming the directory it was run from
+    assert result.exit_code == 0
+    assert "Current vault path: Not set" in result.output
+    assert str(tmp_path) not in result.output
+
+
+def test_a_command_refuses_to_treat_the_working_directory_as_the_shelf(
+    tmp_path, monkeypatch
+):
+    # Given no configured Shelf, and a working directory holding a stray note
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Not A Book Note.md").write_text("# Not a Book Note", encoding="utf-8")
+
+    # When a command that reads the Shelf runs
+    result = runner.invoke(app, ["list"])
+
+    # Then it stops and says how to configure one, rather than reporting
+    # whatever happened to be in the directory it was launched from (#82)
+    assert result.exit_code == 1
+    assert "No Shelf is configured" in result.output
+    assert "libris config --vault" in result.output
+
+
 def test_config_vault_path_writes_legacy_and_new_keys(tmp_path):
     from libris.config import get_config_file
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for configuration lookup, and for refusing to guess a Shelf (#82)."""
+
+import pytest
+import yaml
+
+from libris.config import (
+    VaultNotConfigured,
+    get_config_file,
+    get_vault_path,
+    is_vault_configured,
+    set_book_vault_path,
+)
+
+
+def test_get_vault_path_refuses_to_guess_when_nothing_is_configured(
+    tmp_path, monkeypatch
+):
+    # Given no configured Shelf, and a working directory that is not one
+    monkeypatch.chdir(tmp_path)
+
+    # When something asks where the Shelf is
+    # Then it is told there is none, rather than handed the working directory
+    with pytest.raises(VaultNotConfigured):
+        get_vault_path()
+
+
+def test_get_vault_path_returns_the_configured_shelf(tmp_path):
+    # Given a configured Shelf
+    shelf = tmp_path / "shelf"
+    shelf.mkdir()
+    set_book_vault_path(shelf)
+
+    # When something asks where it is
+    # Then it gets the resolved path
+    assert get_vault_path() == shelf.resolve()
+
+
+def test_get_vault_path_reads_the_legacy_key(tmp_path):
+    # Given a config written before book_vault existed
+    shelf = tmp_path / "legacy"
+    shelf.mkdir()
+    get_config_file().write_text(
+        yaml.safe_dump({"vault_path": str(shelf.resolve())}), encoding="utf-8"
+    )
+
+    # When something asks where the Shelf is
+    # Then the legacy key still answers
+    assert get_vault_path() == shelf.resolve()
+
+
+def test_is_vault_configured_reports_the_absence_without_raising(tmp_path):
+    # Given no configured Shelf
+    # When a caller that must report rather than fail asks
+    # Then it gets an answer, not an exception
+    assert is_vault_configured() is False
+
+    # And once one is set, it says so
+    shelf = tmp_path / "shelf"
+    shelf.mkdir()
+    set_book_vault_path(shelf)
+    assert is_vault_configured() is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -216,9 +216,10 @@ def test_health_reports_that_no_shelf_is_configured(client):
     # When the popup checks the connection
     body = client.get("/health").json()
 
-    # Then it can tell running from usable, rather than trusting a path that
-    # get_vault_path invented from the working directory (#82)
+    # Then it can tell running from usable, and is given no path at all rather
+    # than one get_vault_path invented from the working directory (#82)
     assert body["vault_configured"] is False
+    assert body["vault_path"] is None
 
 
 def test_health_reports_a_configured_shelf(token, configured_shelf):

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "libris"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #82.

`get_vault_path` fell back to `Path(".").resolve()` when neither `book_vault` nor the legacy
key was set, and nothing warned. An unconfigured Libris therefore treated whatever directory
it was launched from as the Shelf, and every command that writes — `add`, `import`,
`clean --rename`, and `POST /api/v1/books` — wrote there. Running `libris serve` from the repo
root during development put Book Notes in `D:\code\libris`.

It now raises `VaultNotConfigured`. A Shelf is a location a person picks once, so guessing it
wrong scatters notes somewhere they will not think to look.

## Where the CLI catches it

The issue flagged the blast radius as the risk — `get_vault_path` reaches every command. It is
read at eleven sites in `cli.py`, all of them the same `vault_path = get_vault_path()`, so they
now call one `_require_vault_path()` helper that reports and exits 1 rather than eleven copies
of the same three lines. Library code raises and the CLI reports, per `AGENTS.md`.

## The two callers that must report the absence, not fail on it

Both ask `is_vault_configured()` instead, which is what it already existed for:

- **`libris config` with no arguments** is how a person finds out what is set, so an unset Shelf
  is the thing it is there to report. It says `Current vault path: Not set`.
- **`GET /health`** deliberately calls `get_vault_path` while unconfigured — it is how the popup
  tells "not running" from "running but unusable" (ADR 0019) — so raising there would have broken
  the extension's connection check. `Health.vault_path` is now `str | None` and is null rather
  than a guess. This is safe for the shipped extension: `client.js:89` refuses a daemon reporting
  `vault_configured: false` before `options.js:47` ever reads the path.

`libris serve` keeps its own guard so the message names the daemon's problem rather than the
CLI's — #55 starts it from a scheduled task, where nobody is watching for a traceback.

The issue proposed the error message point at `libris config set-vault-path`, which does not
exist. The message names the real command, `libris config --vault <path>`.

## Deliberately not done

The issue raised that a silent cwd default "may be load-bearing for someone running `libris list`
from inside their vault". It is not made explicit and opt-in here, because nothing yet shows that
anyone wants it; if that turns out to be wrong it is a new flag, not a restored fallback.

## Verification

- `uv run python -m pytest` — 394 passed (6 new)
- `uv run ruff check .` and `uv run ruff format --check .` — clean
- `npx vitest run` in `extension/` — 15 passed, against the happy-dom 20.12.0 this branch is
  rebased onto
- Ran `libris list` and `libris config` from the repo root with an empty config: exits 1 with the
  message, and reports `Not set`, instead of treating `D:\code\libris` as the Shelf

New tests: `tests/test_config.py` covers the raise, the configured and legacy-key paths, and
`is_vault_configured`; `tests/test_cli.py` covers a command refusing a stray `.md` in the working
directory and `libris config` reporting `Not set`; `tests/test_server.py` now asserts `/health`
answers with a null path.

Version bumped 0.4.0 → 0.4.1 in `pyproject.toml` and `extension/manifest.json` — user-visible
behaviour change, `fix:` takes the patch, and the manifest moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnq7obgG9F1B4EomanS2Et
