### PR TITLE
feat(mcp): serve the Library to an agent over stdio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,19 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12", "3.13"]
-        # The server extra is optional, so both states are supported states and
-        # both get tested: with it the daemon works, without it every other
-        # command still does.
-        extras: ["none", "server"]
+        # Both extras are optional, so every state is a supported state and each
+        # gets tested: with one the daemon or the MCP server works, without
+        # either every other command still does, and with both they coexist.
+        extras: ["none", "server", "mcp", "all"]
         include:
           - extras: "none"
             sync-args: ""
           - extras: "server"
             sync-args: "--extra server"
+          - extras: "mcp"
+            sync-args: "--extra mcp"
+          - extras: "all"
+            sync-args: "--all-extras"
     steps:
       - uses: actions/checkout@v7
 
@@ -34,12 +38,29 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen ${{ matrix.sync-args }}
 
-      # Server tests skip when FastAPI is absent, and skipped tests exit 0. This
-      # fails loudly if the extra ever stops installing, rather than letting the
-      # suite report green over a server that was never exercised.
+      # Tests for an absent extra skip themselves, and skipped tests exit 0. These
+      # fail loudly if an extra ever stops installing, rather than letting the
+      # suite report green over a surface that was never exercised.
       - name: Verify the server extra installed
-        if: matrix.extras == 'server'
+        if: matrix.extras == 'server' || matrix.extras == 'all'
         run: uv run python -c "import fastapi, uvicorn"
+
+      - name: Verify the mcp extra installed
+        if: matrix.extras == 'mcp' || matrix.extras == 'all'
+        run: uv run python -c "from mcp.server import MCPServer"
+
+      # The other half of the same guarantee: the no-extras leg exists to prove
+      # the core CLI works without them, which is worthless if something quietly
+      # pulls them in - a test dependency group did exactly that once.
+      - name: Verify neither extra installed
+        if: matrix.extras == 'none'
+        run: |
+          uv run python - <<'PY'
+          import importlib.util, sys
+          leaked = [m for m in ("fastapi", "mcp") if importlib.util.find_spec(m)]
+          if leaked:
+              sys.exit(f"The no-extras leg installed: {', '.join(leaked)}")
+          PY
 
       - name: Run tests
         run: uv run pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ tests/                # Mirrors src structure
 
 ```bash
 uv sync --frozen              # Install dependencies (use --frozen in CI)
+uv sync --all-extras          # ...plus the server and mcp extras, needed for the WHOLE suite.
+                              # Without them those tests skip themselves and the run still
+                              # reports green, which is how fifty missing tests hide.
 uv run pytest                 # Run tests (NEVER invoke pytest directly)
 uv run pytest tests/test_api.py::test_search  # Run a single test
 uv run pytest --cov=src/libris               # Run with coverage

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,6 +93,12 @@ asked. *Absorbed*: the Library already satisfied it, and the outcome names the L
 turned out to mean. *Rejected*: it could not apply and a person has to decide.
 _Avoid_: intent status, failure, error
 
+**Derived Field**:
+A field a write set that the caller did not name — the date stamped onto a Book Note when its
+Status moves to Read or Reading. Always reported back with the write, so a value nobody asked
+for is never one nobody sees.
+_Avoid_: default, implicit field, side effect
+
 **Resolution**:
 Turning a person's reference to a book ("that Sanderson one I just finished") into a Libris
 ID. Always performed while the person is still present to disambiguate.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ A simple CLI tool to track your reading list in Obsidian. The name comes from th
 ## Features
 - Search books using the Google Books API.
 - Add books to your Obsidian vault with a pre-defined schema (Frontmatter).
-- Track reading status (To Read, Reading, Finished).
+- Track reading status (To Read, Reading, Read, Not To Read).
 - Enrich existing book notes with data from Google Books.
 - Interactive search and selection.
+- Clip books from a book page with the [browser extension](#browser-extension).
+- Search and update your Library [from an assistant](#talking-to-libris-from-an-agent) over MCP.
 
 ## Installation
 Ensure you have `uv` installed.
@@ -239,6 +241,104 @@ The popup names the problem rather than reporting a generic failure:
 | That token doesn't match | The daemon is up and reachable, but the token is stale. Run `libris serve --show-token` and paste it again. |
 | Google Books couldn't be reached | The lookup failed upstream. Nothing was written; try again. |
 | This doesn't look like a book page | The page yielded no title and no identifier. This is not a lookup failure — you are probably not on a book's page. |
+
+## Talking to Libris from an agent
+
+Libris ships an MCP server, so an assistant can search your Library and move books through the
+reading cycle by talking to it. "What am I reading?", "add the new Sanderson", "I finished
+Oathbringer, four stars" — all of that, without you opening Obsidian.
+
+It reaches a book's catalogue fields only. It cannot read or write the notes you have written
+about a book: those stay in Obsidian, by design.
+
+### 1. Install it
+
+The MCP stack is optional, so it ships as an extra:
+
+```bash
+uv sync --extra mcp            # in this repo
+uv tool install 'libris[mcp]'  # anywhere else
+```
+
+You need a Shelf configured, the same one the CLI uses:
+
+```bash
+libris config --vault "/path/to/your/Book List"
+```
+
+### 2. Register it with your client
+
+The server speaks over stdio, so the client starts it for you — you never run `libris mcp`
+yourself. In Claude Code:
+
+```bash
+claude mcp add libris -- uv run --directory /path/to/libris libris mcp
+```
+
+Or, in an `mcp.json` (Claude Desktop, VS Code, and most other clients):
+
+```json
+{
+  "mcpServers": {
+    "libris": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/libris", "libris", "mcp"]
+    }
+  }
+}
+```
+
+**Use the `uv run --directory` form while developing.** `libris` on your PATH is a `uv tool`
+snapshot that goes stale silently, and a server registered once and started daily is where a
+stale snapshot hides longest. If you would rather register the installed command, run
+`uv tool install 'libris[mcp]' --force` after every change and use `libris` with no arguments
+before `mcp`.
+
+### The tools
+
+| Tool | What it does |
+| --- | --- |
+| `search_library` | Finds books you already have. Takes words that identify a book, an optional status, and a limit. Omit the query to list by status alone. |
+| `find_book` | Looks a book up in Google Books, to add it. This searches the outside world, not your Library. |
+| `add_book` | Adds a book by the Google Books id `find_book` returned. |
+| `update_book` | Sets a book's status, priority, rating, format or dates. |
+
+There is deliberately no tool that reads a note's body, and none that writes one.
+
+### What to expect
+
+**The first call is slow.** Libris parses your whole Shelf on the first question and keeps it
+after that — about 16 seconds against a 3,000-note vault, then about 60 milliseconds for
+everything afterwards. Connecting is quick; it is the first *question* that pauses. See
+[#94](https://github.com/tjsullivan1/libris/issues/94).
+
+**Search hands back everything plausible rather than picking.** Ask about a book you do not own
+and you may get a handful of loosely related titles rather than nothing, because a search that
+guesses confidently and guesses wrong is the failure mode Libris refuses. Read the titles.
+
+**Adding stops when you might already have the book.** If your Library holds something with a
+similar title, nothing is written — you are shown the near matches and asked. Say it is a
+different book and it goes ahead. This is stricter than the browser extension on purpose: there,
+a person is already looking at the near matches when they press the button.
+
+**Marking a book Read dates it today**, unless you say otherwise, and the answer tells you it
+did. If you finished it last Tuesday, say so and it will be corrected — but only while you are
+still in the conversation, because a stamped date is indistinguishable from a stated one
+afterwards.
+
+**Nothing can be cleared.** Fields can be set but not emptied, so "drop the priority on that
+one" has no answer yet. Refusing was the safer way to be wrong: an assistant that sends an empty
+value for "leave this alone" would otherwise erase a field nobody mentioned.
+
+### Troubleshooting
+
+| What you see | What it means |
+| --- | --- |
+| No Shelf is configured | The server is running but has no vault. Run `libris config --vault <path>`. |
+| Google Books has no volume '…' | The id was not one `find_book` returned. Ask it again rather than composing an id. |
+| Google Books could not be reached | The lookup failed upstream, and nothing was written. It also answers this for a badly-shaped id, because that is what the API returns. |
+| The mcp extra is not installed | `uv sync --extra mcp`, or `pip install 'libris[mcp]'`. |
+| The server never connects | Check the command runs on its own: `uv run --directory /path/to/libris libris mcp` should sit there waiting for input rather than exiting. |
 
 ## Schema
 Books are saved as Markdown files with the following frontmatter:

--- a/docs/adr/0022-the-library-serves-its-own-vocabularies.md
+++ b/docs/adr/0022-the-library-serves-its-own-vocabularies.md
@@ -30,3 +30,9 @@ the vocabulary, and generating a schema from the one definition is the Library s
 A model reads a tool schema before it composes a call, whereas a `fields` tool is one it can
 simply not call, which returns the guess this ADR exists to prevent. The cost is that the schema
 is built once per process, so a vocabulary change needs a restart.
+
+Correction of fact, not of decision: the example above is stale. The prompt that offered
+"Finished" belongs to `libris status`, not a `libris update` that has never existed, and it was
+changed to render from `STATUS_VALUES` in 44713a9 - the same commit that added the endpoint. The
+drift was real when this was written and is what the decision rests on; nothing in `src/` offers
+the value now.

--- a/docs/adr/0022-the-library-serves-its-own-vocabularies.md
+++ b/docs/adr/0022-the-library-serves-its-own-vocabularies.md
@@ -22,3 +22,11 @@ designed for two.
 `rating` is left unconstrained, as it is today. Nothing in `FIELD_VOCABULARIES` bounds it, and
 inventing a rule here would put the vocabulary's fourth definition in the place this decision
 exists to prevent.
+
+Extended for MCP: the tools carry the vocabularies as JSON Schema enums on `update_book` and
+`add_book`, generated from `FIELD_VOCABULARIES` at server start, rather than exposing a `fields`
+tool. This is the same decision, not an exception to it - the objection is to a client restating
+the vocabulary, and generating a schema from the one definition is the Library serving its own.
+A model reads a tool schema before it composes a call, whereas a `fields` tool is one it can
+simply not call, which returns the guess this ADR exists to prevent. The cost is that the schema
+is built once per process, so a vocabulary change needs a restart.

--- a/docs/adr/0023-mcp-moves-books-obsidian-holds-the-writing.md
+++ b/docs/adr/0023-mcp-moves-books-obsidian-holds-the-writing.md
@@ -1,0 +1,27 @@
+# The MCP surface is frontmatter only; note bodies stay in Obsidian
+
+A Book Note is frontmatter plus a body, and the body is where a reader's own writing lives
+(ADR 0009). The MCP tools reach only the frontmatter: they move a Book through the reading
+cycle and set its fields, and they neither read nor write a body. "What did I make of
+Oathbringer?" is not a question this Library answers to an agent, by choice rather than by
+omission.
+
+Reading was refused first. Handing a language model a person's private reading notes to
+summarise is a different product from tracking a reading list, and ADR 0007 keeps the tool
+definitions identical across stdio and Streamable HTTP - so a tool that reads bodies reads
+them off the machine too, the moment the remote transport lands.
+
+Writing went with it, though it looked separable. Appending a dictated remark means finding
+where `## Notes` ends and the description callout begins, which is reading the body; and an
+append the tool cannot read back is an append nobody can verify, into the one part of a note
+that cannot be regenerated. Every write path here rewrites the whole file rather than
+appending to it - `ensure_frontmatter_fields` re-dumps the YAML and reflows the body on every
+pass - so the risk is not deletion but a round-trip bug, in a structure the Obsidian Linter
+already damages four different ways. Under this decision an MCP write never runs that
+round-trip at all.
+
+The price is that "I finished it, and it dragged in the middle" loses its second clause. The
+rule is worth more than the clause: *MCP moves books through the reading cycle; Obsidian holds
+what you thought about them* is a boundary that answers the next tool's scope question without
+being re-argued. Adding body writes later is easy; withdrawing them once an agent relies on
+them is not.

--- a/docs/adr/0024-a-write-discloses-what-it-derived.md
+++ b/docs/adr/0024-a-write-discloses-what-it-derived.md
@@ -1,0 +1,29 @@
+# A write stamps the obvious date, and says that it did
+
+Follows ADR 0016.
+
+`update_book` sets only the fields it is given (the Intent rule), with one exception: setting
+`status` to Read stamps `date_finished`, and to Reading stamps `date_started`, when the field
+is empty. The response then names every field the Library set that the caller did not ask for,
+so the stamp is reported rather than assumed.
+
+Neither half works alone. Setting nothing means "I finished Oathbringer" records no date at
+all, and the Shelf shows where that ends up: of 1,608 notes marked Read, only 704 carry a
+`date_finished`, so the field is missing on the majority of the books it exists for. Stamping
+silently is worse in the other direction, and this vault already holds the evidence - 82 notes
+share `date_finished: 2020-12-11` and 28 share `2020-12-05`, which is one bulk operation
+recording "now" across a batch and preserved since as fact. A wrong date is indistinguishable
+from a right one afterwards, which is the silent-and-confident failure ADR 0003 refuses.
+
+Disclosure is what separates them. A person who meant last Tuesday hears "marked Read, dated
+today" and corrects it while still in the conversation - the same reason resolution happens
+there (ADR 0003), applied to a field instead of to an identity.
+
+Two rules keep it narrow. A stamp only fills an empty field, so re-marking a dated book never
+overwrites the original; a re-read is not something the Library models and inventing it here
+would be scope creep. And an explicit value always wins - the stamp is a fallback, never an
+override.
+
+Left unsolved: whose today. Over stdio the server runs on the reader's machine and the local
+date is right. The same tool over Streamable HTTP (ADR 0007) reads a container's UTC clock,
+which is another case of one definition giving two answers by location (ADR 0020).

--- a/docs/adr/0025-mcp-adds-by-candidate-id-not-by-echo.md
+++ b/docs/adr/0025-mcp-adds-by-candidate-id-not-by-echo.md
@@ -1,0 +1,30 @@
+# MCP names a Book Candidate by its id; only REST echoes one back
+
+Follows ADR 0008 and ADR 0012.
+
+`POST /api/v1/books` takes a whole Book Candidate back - title, authors, isbn, page count,
+genres, thumbnail and the full description. The MCP `add_book` takes a Google Books id and
+re-fetches the volume itself.
+
+The difference is the client, not the transport. The extension holds the candidate object it
+was given and returns it unchanged, so echoing costs nothing and proves nothing. A language
+model re-emits the record token by token, which pays for the description twice and, more
+seriously, gives the model an opportunity to alter what it is writing - tidying a title,
+dropping a subtitle, paraphrasing a blurb. The resulting Book Note then asserts something the
+source never said, with nothing downstream able to tell. ADR 0012 makes Libris the owner of
+the title field; echoing hands it to whatever the model felt like emitting.
+
+Naming the candidate by id means only its identity crosses the boundary and the metadata is
+always fetched by the code that fetched it the first time. The cost is a `GET /volumes/{id}`
+that `GoogleBooksClient` does not have yet, and one extra round trip to Google per add.
+
+Server-side handles were rejected: caching candidates and returning opaque tokens puts session
+state in a stdio process that dies between conversations, and an expired handle mid-flow has no
+good failure message.
+
+ADR 0008 predicted the two adapters would diverge, with MCP the coarse and tolerant one. Here it
+is the stricter of the two, and for the same underlying reason: the shape follows what the
+caller can be trusted to hold onto.
+
+A book Google Books does not have cannot be added over MCP at all under this decision. Left out
+of the first cut rather than built as a second, unvalidated write shape.

--- a/docs/adr/0026-mcp-stops-on-a-near-match.md
+++ b/docs/adr/0026-mcp-stops-on-a-near-match.md
@@ -1,0 +1,26 @@
+# An MCP add stops on a Near Match; the REST one reports and writes
+
+Follows ADR 0003 and ADR 0010.
+
+`service.add_book` refuses to write only on an exact match - a shared ISBN, a shared Google
+Books id, or a normalised title and first author. Near Matches are the fuzzy remainder, and
+`GET /api/v1/books` hands them back beside a miss for a person to settle. The MCP `add_book`
+goes further: when Near Matches exist it writes nothing, returns them, and requires an explicit
+confirmation to proceed.
+
+The difference is where the person is standing. The extension shows Near Matches in a popup
+next to the button, so a human sees them before clicking. Over MCP the caller is the model, and
+a near match reported alongside a completed write arrives after the file exists - which turns
+one question into a cleanup task. ADR 0003 puts ambiguity back to the Surface while the person
+is still present to answer it; here the Surface only creates that moment if the tool refuses
+first.
+
+The cost is real and known. `find_similar` conflates 83 pairs on this Shelf, some genuine
+variants and some different books, so the confirmation will be asked for when it need not be.
+That trade is accepted because the two errors are not symmetric: a needless question costs one
+exchange, while a duplicate Book Note is permanent, splits a reader's writing across two files,
+and is found only by a duplicate sweep months later. The Shelf already carries three such
+groups.
+
+Every write also reports its Duplicate Guarantee (ADR 0016), constant over stdio and not
+constant once Streamable HTTP lands with the same tool definitions (ADR 0007, ADR 0020).

--- a/docs/adr/0027-rare-words-decide-a-search.md
+++ b/docs/adr/0027-rare-words-decide-a-search.md
@@ -1,0 +1,37 @@
+# A search is decided by rare words, and filler is a curated list
+
+Follows ADR 0003.
+
+`search_library` weighs each matched word by how few Book Notes carry it, and refuses a note
+that matched only filler. Both halves were added after the first implementation was measured
+against the real Shelf rather than designed in.
+
+Counting matched words alike is wrong, and obviously so once run. "that mistborn one" returned
+91 matches with no Mistborn book among the first six: "one" appears in 50 notes and "mistborn"
+in 3, both counted as one match, and the tie then went to the shortest title - "The Hot One",
+"Trust No One", "Eat That Frog". Weighing by rarity returns exactly the three Mistborn books.
+This is the ADR 0003 failure in a new place: an answer that is confident, wrong, and carries
+nothing that shows it is wrong.
+
+Weighting alone does not finish it, and the arithmetic says why. Weighted by rarity a note
+matching "that" and "one" scores above a note matching "mistborn", so filler still wins by
+accumulating. Nor can a frequency threshold cut it out: on this Shelf "poems" appears in 51
+notes and "one" in 50. They are statistically identical and only one of them names a book. The
+difference is linguistic, so the list is curated - pronouns, determiners, common prepositions
+and the filler of a spoken request - and holds no word that could title a book on its own. A
+query made of nothing but filler is taken at face value, because answering "the" with silence
+is worse than offering "The Road".
+
+The list is the net, not the mechanism. The MCP tool description asks the model for the words
+that identify a book rather than a whole spoken sentence, which is the right place for the
+problem: a language model is the best thing in this system at telling "mistborn" from "that
+... one I just finished". But an instruction is a promise and not a guarantee, and a model that
+passes the sentence through unedited must not get 91 wrong answers.
+
+No relevance floor was added. A search whose book is absent still returns whatever shares a
+word - "the way of kings" returns 38 notes led by "Kings of the Wyld", for a book this Shelf
+does not hold - and that is the behaviour ADR 0003 asks for. Cutting the tail would mean a
+confidence threshold, which is the one thing that ADR refuses by name.
+
+Words are weighed across what the status filter left rather than the whole Shelf, so narrowing
+to one status weighs words by how well they separate the books still in play.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Libris",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Add the book on this page to your Libris reading list.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.4.1"
+version = "0.5.0"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -21,6 +21,13 @@ server = [
     "uvicorn>=0.30",
 ]
 
+# The MCP server an agent drives (#93). Separate from `server` because stdio
+# needs no web stack, and optional for the same reason `server` is: the core
+# CLI installs without either, and cli.py imports this lazily too.
+mcp = [
+    "mcp>=2.1.1",
+]
+
 [dependency-groups]
 dev = [
   {include-group = "lint"},
@@ -34,6 +41,10 @@ lint = [
 test = [
   "pytest>=9.0.3",
   "pytest-cov",
+  # Both optional extras belong here rather than being left to the extra: the
+  # adapter tests skip themselves when their import is missing, and a suite that
+  # silently drops fifty tests looks exactly like a clean run.
+  "libris[server,mcp]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,11 @@ lint = [
 test = [
   "pytest>=9.0.3",
   "pytest-cov",
-  # Both optional extras belong here rather than being left to the extra: the
-  # adapter tests skip themselves when their import is missing, and a suite that
-  # silently drops fifty tests looks exactly like a clean run.
-  "libris[server,mcp]",
+  # The optional extras deliberately do NOT belong here. This group installs on
+  # every `uv sync`, including CI's no-extras leg, whose whole job is to prove
+  # the core CLI works without them. Locally, `uv sync --all-extras` runs the
+  # whole suite; CI covers each combination as a matrix leg and asserts the
+  # imports are present, so a silently-skipped fifty tests fails loudly instead.
 ]
 
 [project.scripts]

--- a/src/libris/api.py
+++ b/src/libris/api.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from urllib.parse import quote
 
 import httpx
 
@@ -169,24 +170,49 @@ class GoogleBooksClient:
         self.on_rate_limit(wait_time, attempt + 1, self.max_retries)
         time.sleep(wait_time)
 
-    def search(self, query: str) -> list[BookCandidate]:
-        params = {"q": query, "maxResults": 10}
+    def _identifying_params(self) -> dict:
+        """Build the params that say who is asking.
 
+        Returns:
+            The API key when one is configured, and otherwise a `quotaUser` so
+            an unauthenticated caller is rate limited on its own account rather
+            than against every anonymous user of the API.
+        """
+        params: dict = {}
         api_key = get_api_key()
         if api_key:
             params["key"] = api_key
-        else:
-            # Use a unique identifier to help avoid global rate limits for
-            # unauthenticated users.
-            try:
-                params["quotaUser"] = socket.gethostname()
-            except OSError:
-                logger.debug("Could not determine hostname for quotaUser.")
+            return params
+        try:
+            params["quotaUser"] = socket.gethostname()
+        except OSError:
+            logger.debug("Could not determine hostname for quotaUser.")
+        return params
+
+    def _get(self, url: str, params: dict) -> dict:
+        """Fetch one URL, retrying what is worth retrying.
+
+        Extracted from `search` so `get_volume` shares the retry and rate-limit
+        handling rather than growing a second, subtly different copy of it.
+
+        Args:
+            url: The endpoint to fetch.
+            params: Query parameters, before the identifying ones are added.
+
+        Returns:
+            The decoded JSON body.
+
+        Raises:
+            httpx.HTTPStatusError: If the response is an error the retries could
+                not clear.
+            httpx.RequestError: If the request could not be made.
+        """
+        params = {**params, **self._identifying_params()}
 
         with httpx.Client(timeout=self.timeout) as client:
             for attempt in range(self.max_retries + 1):
                 try:
-                    response = client.get(self.BASE_URL, params=params)
+                    response = client.get(url, params=params)
 
                     if response.status_code == 429:
                         if attempt < self.max_retries:
@@ -194,8 +220,7 @@ class GoogleBooksClient:
                             continue
 
                     response.raise_for_status()
-                    data = response.json()
-                    break
+                    return response.json()
                 except (httpx.HTTPStatusError, httpx.RequestError) as e:
                     if attempt < self.max_retries and (
                         isinstance(e, httpx.RequestError)
@@ -217,35 +242,94 @@ class GoogleBooksClient:
                         time.sleep(wait_time)
                         continue
                     raise
-            else:
-                # This part is technically reached if all retries for 429 were exhausted but no exception was raised
-                response.raise_for_status()
-                data = response.json()
+            # Reached when every 429 retry was used without an exception being
+            # raised: ask once more and let the error out this time.
+            response.raise_for_status()
+            return response.json()
 
-        items = data.get("items", [])
-        books = []
-        for item in items:
-            volume_info = item.get("volumeInfo", {})
+    @staticmethod
+    def _to_candidate(item: dict) -> BookCandidate:
+        """Build a Book Candidate from one Google Books volume.
 
-            # Extract ISBN
-            isbn = None
-            for ident in volume_info.get("industryIdentifiers", []):
-                if ident.get("type") == "ISBN_13":
-                    isbn = ident.get("identifier")
-                    break
-                if ident.get("type") == "ISBN_10" and not isbn:
-                    isbn = ident.get("identifier")
+        Args:
+            item: A volume, as the API returns it.
 
-            book = BookCandidate(
-                title=volume_info.get("title", "Unknown Title"),
-                authors=volume_info.get("authors", ["Unknown Author"]),
-                isbn=isbn,
-                page_count=volume_info.get("pageCount"),
-                published_date=volume_info.get("publishedDate"),
-                google_books_id=item.get("id"),
-                thumbnail=volume_info.get("imageLinks", {}).get("thumbnail"),
-                genres=volume_info.get("categories", []),
-                description=volume_info.get("description"),
-            )
-            books.append(book)
-        return books
+        Returns:
+            The candidate it describes. An ISBN-13 is preferred over an ISBN-10,
+            because that is what a Book Note records.
+        """
+        volume_info = item.get("volumeInfo", {})
+
+        isbn = None
+        for ident in volume_info.get("industryIdentifiers", []):
+            if ident.get("type") == "ISBN_13":
+                isbn = ident.get("identifier")
+                break
+            if ident.get("type") == "ISBN_10" and not isbn:
+                isbn = ident.get("identifier")
+
+        return BookCandidate(
+            title=volume_info.get("title", "Unknown Title"),
+            authors=volume_info.get("authors", ["Unknown Author"]),
+            isbn=isbn,
+            page_count=volume_info.get("pageCount"),
+            published_date=volume_info.get("publishedDate"),
+            google_books_id=item.get("id"),
+            thumbnail=volume_info.get("imageLinks", {}).get("thumbnail"),
+            genres=volume_info.get("categories", []),
+            description=volume_info.get("description"),
+        )
+
+    def search(self, query: str) -> list[BookCandidate]:
+        """Find Book Candidates matching a query.
+
+        Args:
+            query: A Google Books query, which may carry `intitle:` and
+                `inauthor:` operators.
+
+        Returns:
+            The candidates the API offered, in the order it offered them.
+        """
+        data = self._get(self.BASE_URL, {"q": query, "maxResults": 10})
+        return [self._to_candidate(item) for item in data.get("items", [])]
+
+    def get_volume(self, google_books_id: str) -> BookCandidate | None:
+        """Fetch one volume by the id that names it.
+
+        This is what lets a Surface name a Book Candidate instead of handing the
+        whole record back (ADR 0025): the metadata written into a Book Note is
+        always fetched by this code rather than retyped by a caller, so a note
+        can never assert something the source did not say.
+
+        Args:
+            google_books_id: The volume id, as carried on a Book Candidate.
+
+        Returns:
+            The candidate, or None if Google Books has no such volume.
+
+        Raises:
+            httpx.HTTPStatusError: If the API failed for any reason other than
+                the volume being absent. Only a 404 means "no such book";
+                anything else means the answer is unknown, and reporting that
+                as a miss would let a write proceed on nothing.
+            httpx.RequestError: If the request could not be made.
+
+        Note:
+            Google Books distinguishes an absent volume from a malformed id, and
+            not in the way you would expect. Measured against the live API: a
+            well-formed id naming nothing ("zzzzzzzzzzzz") answers 404 with "The
+            volume ID could not be found", while a malformed one ("x", or
+            anything not of the right shape) answers 503 "Service temporarily
+            unavailable". So a caller that invents an id - which for MCP means a
+            model that hallucinated or truncated one - is retried with backoff
+            and then told the service is down. A Surface reporting that failure
+            should name both causes rather than only the outage.
+        """
+        url = f"{self.BASE_URL}/{quote(google_books_id, safe='')}"
+        try:
+            data = self._get(url, {})
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        return self._to_candidate(data)

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -1316,3 +1316,41 @@ def serve(
     typer.echo(f"Libris daemon listening on http://{host}:{port}")
     typer.echo("Run `libris serve --show-token` for the token the extension needs.")
     server.run(host=host, port=port, reload=reload)
+
+
+@app.command()
+def mcp():
+    """Run the MCP server an agent drives, over stdio.
+
+    Speaks JSON-RPC on stdin and stdout, so it is started by an MCP client
+    rather than by hand. Register it with:
+
+        uv run --directory <repo> libris mcp
+
+    which always runs the working tree - `libris` on PATH is a `uv tool`
+    snapshot that goes stale silently, and a server registered once and spawned
+    daily is where that hides longest.
+    """
+    try:
+        from . import mcp_server
+    except ImportError:
+        # Written to stderr: stdout is the protocol channel, and a stray line on
+        # it corrupts the first message rather than being seen by anyone.
+        typer.echo(
+            "The mcp extra is not installed, so `libris mcp` cannot run.", err=True
+        )
+        typer.echo("Install it with: uv sync --extra mcp", err=True)
+        typer.echo("or, outside this repo: pip install 'libris[mcp]'", err=True)
+        raise typer.Exit(1) from None
+
+    if not is_vault_configured():
+        # Unlike `libris serve`, this starts anyway. An MCP client shows a server
+        # that exited as a connection failure and puts the reason on a stderr
+        # nobody reads, so the tools report the problem instead - to the person
+        # who can fix it, in the conversation where it came up.
+        typer.echo(
+            "No Shelf is configured; the tools will say so until one is set.",
+            err=True,
+        )
+
+    mcp_server.run()

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -271,6 +271,71 @@ def update_book_status(file_path: Path, new_status: str):
     file_path.write_text(new_content, encoding="utf-8")
 
 
+class FrontmatterUnreadable(ValueError):
+    """A Book Note's frontmatter could not be parsed, so it was not written to."""
+
+
+def _split_frontmatter(content: str) -> Optional[tuple[str, str]]:
+    """Split a note into its frontmatter block and everything after it.
+
+    Deliberately not a regex. The body is returned exactly as it was found -
+    every byte after the line closing the block, blank lines included - because
+    an update to one field must not reflow a reader's own writing (ADR 0023).
+
+    Args:
+        content: The whole file.
+
+    Returns:
+        The YAML text and the body, or None if there is no closed frontmatter
+        block at the start of the file.
+    """
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return None
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return "".join(lines[1:index]), "".join(lines[index + 1 :])
+    return None
+
+
+def set_frontmatter_fields(file_path: Path, updates: Dict[str, Any]) -> None:
+    """Set named frontmatter fields on a Book Note, leaving the body untouched.
+
+    The body is carried across exactly rather than re-rendered. Every other
+    write path here reconstructs a note - `ensure_frontmatter_fields` re-dumps
+    the YAML and reflows the body on every pass - which is right for a repair
+    pass and wrong for setting a status.
+
+    Field order is preserved for keys the note already carries; new keys are
+    appended, so an update does not reshuffle a note.
+
+    Args:
+        file_path: The Book Note to write.
+        updates: Field names and the values to set them to.
+
+    Raises:
+        FrontmatterUnreadable: If the file has no parseable frontmatter block.
+            Refused rather than repaired: this is the write path for one field,
+            not the place to rebuild a broken note.
+    """
+    content = file_path.read_text(encoding="utf-8")
+    split = _split_frontmatter(content)
+    if split is None:
+        raise FrontmatterUnreadable(f"{file_path.name} has no readable frontmatter.")
+
+    frontmatter_yaml, body = split
+    try:
+        data = yaml.safe_load(frontmatter_yaml)
+    except yaml.YAMLError as exc:
+        raise FrontmatterUnreadable(f"{file_path.name}: {exc}") from None
+    if not isinstance(data, dict):
+        raise FrontmatterUnreadable(f"{file_path.name} has no frontmatter mapping.")
+
+    data.update(updates)
+    rendered = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
+    file_path.write_text("---\n" + rendered + "\n---\n" + body, encoding="utf-8")
+
+
 def list_books(vault_path: Path):
     """Lists all markdown files in the vault, assuming each is a book note."""
     return [

--- a/src/libris/mcp_server.py
+++ b/src/libris/mcp_server.py
@@ -18,7 +18,7 @@ from mcp.server import MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import BaseModel, Field
 
-from . import config, service
+from . import config, installed_version, service
 from .api import GoogleBooksClient
 from .markdown import BookNote
 from .note_format import (
@@ -197,11 +197,9 @@ def create_server(name: str = "libris") -> "MCPServer":
     one: configuration is read at start rather than at import, and a test can
     build a server per configuration.
     """
-    from .server import libris_version
-
     mcp = MCPServer(
         name=name,
-        version=libris_version(),
+        version=installed_version(),
         instructions=INSTRUCTIONS,
     )
 

--- a/src/libris/mcp_server.py
+++ b/src/libris/mcp_server.py
@@ -1,0 +1,393 @@
+"""The MCP tools, with no logic in them.
+
+ADR 0008 puts resolution, creation and querying in `service.py`, so this module
+translates and nothing else: it turns tool arguments into service calls and
+service answers into structured results. The REST adapter next door does the
+same job for a different caller.
+
+The tool surface is deliberately small and reaches frontmatter only. A Book
+Note's body holds a reader's own writing and stays in Obsidian (ADR 0023), so
+there is no tool that reads one and none that writes one.
+"""
+
+from datetime import date
+from pathlib import Path
+from typing import Annotated, Literal
+
+from mcp.server import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from . import config, service
+from .api import GoogleBooksClient
+from .markdown import BookNote
+from .note_format import (
+    FORMAT_VALUES,
+    PRIORITY_VALUES,
+    STATUS_VALUES,
+    InvalidFieldValue,
+)
+
+# The vocabularies as the model sees them. Generated from note_format rather
+# than restated, so the Library still defines its own values (ADR 0022): a tool
+# schema is read before a call is composed, where a `fields` tool is one a model
+# can simply not call.
+Status = Literal[STATUS_VALUES]
+Priority = Literal[PRIORITY_VALUES]
+Format = Literal[FORMAT_VALUES]
+
+INSTRUCTIONS = """\
+Libris tracks which books someone has read, is reading, or means to read.
+
+Search the Library before adding to it, and pass the words that identify a book
+rather than the whole sentence someone said: "mistborn", not "that mistborn one
+I just finished".
+
+These tools reach a book's catalogue fields only. They cannot read or write the
+notes someone has written about a book - those live in Obsidian.\
+"""
+
+
+# Deliberately no startup warm-up, unlike `libris serve`, which warms the index
+# in `_warm_index`. The daemon can: it starts once, in the background, with
+# nobody waiting. This server is spawned by an MCP client that is waiting for
+# `initialize`, and parsing 3,063 notes takes 12-48 seconds (#94) - measured at
+# 49.4s to connect with a blocking warm-up against 5s without one, of which
+# about 2s is `uv run` and 4s is importing the SDK. A client that times out
+# during initialize records the server as failed rather than slow, which is the
+# worse failure: invisible, and indistinguishable from a broken adapter.
+#
+# So the cost sits on the first tool call, where a person can see it happening.
+# Warming in a background thread would get both, but `ShelfIndex.notes()`
+# mutates its caches unguarded, so a warm-up racing a tool call is a data race
+# for a 40-second window - more machinery than this deserves while #94 is open.
+# Fixing #94 (the loader swap alone takes the parse from 6.9s to 0.9s) makes a
+# blocking warm-up affordable, and this comment obsolete.
+
+
+def _shelf() -> Path:
+    """Get the configured Shelf, or say how to configure one.
+
+    The server starts without a Shelf on purpose. A stdio server that exits
+    during startup reaches its client as a connection failure, with the reason
+    on a stderr nobody reads; a tool that answers with the fix puts it in front
+    of the person who can apply it.
+    """
+    if not config.is_vault_configured():
+        # Asked before get_vault_path rather than after, because on this branch
+        # that function still falls back to the working directory (#82) - and
+        # an MCP client spawns this server from whatever directory it happens to
+        # be in. Without the guard, an unconfigured add_book would write Book
+        # Notes into a stranger's project folder.
+        raise ToolError(
+            "No Shelf is configured, so there is no Library to work with. "
+            "Set one with: libris config --vault <path>"
+        )
+    return config.get_vault_path()
+
+
+def _text(value: object) -> str | None:
+    """Render a frontmatter value as text, or None when it holds nothing.
+
+    Frontmatter arrives from YAML, so a date field is a `date` and a rating is
+    an `int`. Both are shown to a person rather than computed with.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+class Book(BaseModel):
+    """A Book Note as a tool reports it.
+
+    Carries the reading state as well as the identity, so a model choosing
+    between six Sandersons can tell them apart without six more calls.
+    """
+
+    libris_id: str | None
+    title: str | None
+    authors: list[str]
+    status: str | None = None
+    priority: str | None = None
+    rating: str | None = None
+    series: str | None = None
+    format: list[str] = []
+    date_started: str | None = None
+    date_finished: str | None = None
+    path: str | None = Field(
+        default=None,
+        description="Where the note lives. To show a person, not to pass back.",
+    )
+
+    @classmethod
+    def of(cls, note: BookNote) -> "Book":
+        """Build the tool form of a Book Note."""
+        frontmatter = note.frontmatter
+        formats = frontmatter.get("format") or []
+        return cls(
+            libris_id=note.libris_id,
+            title=note.title,
+            authors=note.authors,
+            status=_text(frontmatter.get("status")),
+            priority=_text(frontmatter.get("priority")),
+            rating=_text(frontmatter.get("rating")),
+            series=_text(frontmatter.get("series")),
+            format=[str(f) for f in formats] if isinstance(formats, list) else [],
+            date_started=_text(frontmatter.get("date_started")),
+            date_finished=_text(frontmatter.get("date_finished")),
+            path=str(note.path),
+        )
+
+
+class SearchAnswer(BaseModel):
+    """What the Library holds for a query, and how much of it was returned."""
+
+    total: int = Field(description="Every match, not just the ones returned.")
+    books: list[Book]
+
+
+class Candidate(BaseModel):
+    """A Book Candidate offered for adding.
+
+    Deliberately without the description and cover: they are the two heaviest
+    fields and neither helps anyone choose between editions. `add_book` fetches
+    the volume again by id, so nothing here needs to survive the round trip
+    (ADR 0025).
+    """
+
+    google_books_id: str = Field(description="Pass this to add_book.")
+    title: str
+    authors: list[str]
+    published_date: str | None = None
+    page_count: int | None = None
+    isbn: str | None = None
+
+
+class WriteAnswer(BaseModel):
+    """What a write did, and what stands behind it."""
+
+    outcome: str = Field(
+        description=("created, already_present, needs_confirmation, or updated.")
+    )
+    book: Book | None = None
+    guarantee: str = Field(
+        default="live_shelf",
+        description="What the duplicate check was made against.",
+    )
+    near_matches: list[Book] = Field(
+        default=[],
+        description="Books that stopped the write. Ask which, then set confirm.",
+    )
+    derived: dict[str, str] = Field(
+        default={},
+        description="Fields the Library set that you did not ask for.",
+    )
+
+
+def create_server(name: str = "libris") -> "MCPServer":
+    """Build the MCP server and its tools.
+
+    A factory rather than a module-level server, for the reason `create_app` is
+    one: configuration is read at start rather than at import, and a test can
+    build a server per configuration.
+    """
+    from .server import libris_version
+
+    mcp = MCPServer(
+        name=name,
+        version=libris_version(),
+        instructions=INSTRUCTIONS,
+    )
+
+    @mcp.tool()
+    def search_library(
+        query: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Words that identify a book - a title, an author, or both. "
+                    "Omit to list by filter alone."
+                )
+            ),
+        ] = None,
+        status: Annotated[
+            Status | None, Field(description="Narrow to one reading status.")
+        ] = None,
+        limit: Annotated[int, Field(ge=0, le=service.MAX_SEARCH_LIMIT)] = (
+            service.DEFAULT_SEARCH_LIMIT
+        ),
+    ) -> SearchAnswer:
+        """Find books already in the Library.
+
+        Returns every plausible match rather than deciding between them, so
+        check the titles before acting on one. `total` counts all matches; a
+        large total with no obvious answer usually means the book is not held.
+        """
+        try:
+            found = service.search_library(
+                _shelf(), query=query, status=status, limit=limit
+            )
+        except InvalidFieldValue as exc:
+            raise ToolError(str(exc)) from None
+        return SearchAnswer(total=found.total, books=[Book.of(n) for n in found.books])
+
+    @mcp.tool()
+    def find_book(
+        title: str | None = None,
+        authors: list[str] | None = None,
+        isbn: str | None = None,
+    ) -> list[Candidate]:
+        """Look up a book in Google Books, to add it to the Library.
+
+        This searches the outside world, not the Library - use search_library
+        for what is already held. Offer the candidates to the person and let
+        them pick the edition; pass the chosen google_books_id to add_book.
+        """
+        try:
+            candidates = service.lookup_candidates(
+                isbn=isbn, title=title, authors=authors or None
+            )
+        except Exception as exc:
+            raise ToolError(f"Google Books could not be reached: {exc}") from None
+
+        return [
+            Candidate(
+                google_books_id=c.google_books_id,
+                title=c.title,
+                authors=c.authors,
+                published_date=c.published_date,
+                page_count=c.page_count,
+                isbn=c.isbn,
+            )
+            for c in candidates
+            if c.google_books_id
+        ]
+
+    @mcp.tool()
+    def add_book(
+        google_books_id: Annotated[
+            str, Field(description="From find_book. Never invented.")
+        ],
+        status: Status | None = None,
+        priority: Priority | None = None,
+        format: list[Format] | None = None,
+        confirm: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Set only after a person has seen near_matches and said "
+                    "this is a different book."
+                )
+            ),
+        ] = False,
+    ) -> WriteAnswer:
+        """Add a book to the Library.
+
+        Stops and returns near_matches when the Library may already hold this
+        book, because a duplicate found afterwards is a cleanup task rather than
+        a question. Show them to the person, then call again with confirm.
+        """
+        shelf = _shelf()
+        candidate = GoogleBooksClient().get_volume(google_books_id)
+        if candidate is None:
+            raise ToolError(
+                f"Google Books has no volume {google_books_id!r}. Use find_book "
+                f"to get an id rather than composing one."
+            )
+
+        overrides: dict[str, object] = {}
+        if status is not None:
+            overrides["status"] = status
+        if priority is not None:
+            overrides["priority"] = priority
+        if format is not None:
+            overrides["format"] = list(format)
+
+        try:
+            result = service.add_book(
+                shelf,
+                candidate,
+                overrides=overrides or None,
+                stop_on_near_match=not confirm,
+            )
+        except ValueError as exc:
+            raise ToolError(str(exc)) from None
+
+        return WriteAnswer(
+            outcome=result.outcome.value,
+            book=_written(shelf, result),
+            near_matches=[Book.of(n) for n in result.near_matches],
+        )
+
+    @mcp.tool()
+    def update_book(
+        libris_id: Annotated[
+            str, Field(description="From search_library. Never invented.")
+        ],
+        status: Status | None = None,
+        priority: Priority | None = None,
+        rating: int | None = None,
+        format: list[Format] | None = None,
+        date_started: Annotated[str | None, Field(description="YYYY-MM-DD.")] = None,
+        date_finished: Annotated[str | None, Field(description="YYYY-MM-DD.")] = None,
+    ) -> WriteAnswer:
+        """Change a book's reading state.
+
+        Only the fields given are changed; anything omitted is left alone.
+        Marking a book Read dates it today unless you say otherwise, and says so
+        in `derived` - relay that, because a person who finished it last week
+        can only correct it now.
+        """
+        fields: dict[str, object] = {}
+        for name, value in (
+            ("status", status),
+            ("priority", priority),
+            ("rating", rating),
+            ("format", list(format) if format is not None else None),
+            ("date_started", date_started),
+            ("date_finished", date_finished),
+        ):
+            if value is not None:
+                fields[name] = value
+
+        if not fields:
+            raise ToolError("No fields were given, so there is nothing to change.")
+
+        try:
+            result = service.update_book(_shelf(), libris_id, fields)
+        except service.BookNotFound as exc:
+            raise ToolError(str(exc)) from None
+        except ValueError as exc:
+            # InvalidFieldValue subclasses ValueError, so this covers a value the
+            # Library does not define and a field that is not the reader's.
+            raise ToolError(str(exc)) from None
+
+        return WriteAnswer(
+            outcome="updated",
+            book=Book.of(result.note),
+            derived={k: str(v) for k, v in result.derived.items()},
+        )
+
+    return mcp
+
+
+def _written(vault_path: Path, result: "service.AddResult") -> Book | None:
+    """Describe the Book Note a write points at, when it points at one."""
+    if result.libris_id is None or result.path is None:
+        return None
+    note = BookNote.read(result.path)
+    if note is not None:
+        return Book.of(note)
+    return Book(
+        libris_id=result.libris_id,
+        title=result.title,
+        authors=result.authors,
+        path=str(result.path),
+    )
+
+
+def run() -> None:
+    """Serve the tools over stdio until the client disconnects."""
+    create_server().run(transport="stdio")

--- a/src/libris/mcp_server.py
+++ b/src/libris/mcp_server.py
@@ -14,6 +14,7 @@ from datetime import date
 from pathlib import Path
 from typing import Annotated, Literal
 
+import httpx
 from mcp.server import MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import BaseModel, Field
@@ -32,6 +33,12 @@ from .note_format import (
 # than restated, so the Library still defines its own values (ADR 0022): a tool
 # schema is read before a call is composed, where a `fields` tool is one a model
 # can simply not call.
+#
+# Subscripting Literal with a tuple is how Python passes it several arguments,
+# so these are each exactly the four/three/three strings and not "the tuple" -
+# `Literal[STATUS_VALUES] == Literal[*STATUS_VALUES]` is True. Written this way
+# because the values are a runtime import; a reviewer has already read it as a
+# bug once, hence this note.
 Status = Literal[STATUS_VALUES]
 Priority = Literal[PRIORITY_VALUES]
 Format = Literal[FORMAT_VALUES]
@@ -251,7 +258,10 @@ def create_server(name: str = "libris") -> "MCPServer":
             candidates = service.lookup_candidates(
                 isbn=isbn, title=title, authors=authors or None
             )
-        except Exception as exc:
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            # Only the upstream failures, matching the REST adapter. Catching
+            # every Exception would report a bug in this code as an outage, and
+            # a tool that never fails loudly is one nobody debugs.
             raise ToolError(f"Google Books could not be reached: {exc}") from None
 
         return [
@@ -292,7 +302,20 @@ def create_server(name: str = "libris") -> "MCPServer":
         a question. Show them to the person, then call again with confirm.
         """
         shelf = _shelf()
-        candidate = GoogleBooksClient().get_volume(google_books_id)
+        try:
+            candidate = GoogleBooksClient().get_volume(google_books_id)
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            # Both causes are named because the API cannot tell them apart for
+            # us. Measured against the live service: an id that is well formed
+            # but names nothing answers 404, while a malformed one answers 503
+            # "Service temporarily unavailable". Reporting only the outage would
+            # send someone looking at Google's status page for their own typo.
+            raise ToolError(
+                f"Could not fetch volume {google_books_id!r}: {exc}. Either "
+                f"Google Books is unreachable, or that id is malformed - it "
+                f"answers 503 rather than 404 for an id of the wrong shape. "
+                f"Use find_book to get an id rather than composing one."
+            ) from None
         if candidate is None:
             raise ToolError(
                 f"Google Books has no volume {google_books_id!r}. Use find_book "

--- a/src/libris/mcp_server.py
+++ b/src/libris/mcp_server.py
@@ -73,17 +73,21 @@ def _shelf() -> Path:
     on a stderr nobody reads; a tool that answers with the fix puts it in front
     of the person who can apply it.
     """
-    if not config.is_vault_configured():
-        # Asked before get_vault_path rather than after, because on this branch
-        # that function still falls back to the working directory (#82) - and
-        # an MCP client spawns this server from whatever directory it happens to
-        # be in. Without the guard, an unconfigured add_book would write Book
-        # Notes into a stranger's project folder.
-        raise ToolError(
-            "No Shelf is configured, so there is no Library to work with. "
-            "Set one with: libris config --vault <path>"
-        )
-    return config.get_vault_path()
+    try:
+        if not config.is_vault_configured():
+            raise config.VaultNotConfigured(
+                "No Shelf is configured, so there is no Library to work with."
+            )
+        return config.get_vault_path()
+    except config.VaultNotConfigured as exc:
+        # Asked and caught, rather than either alone. get_vault_path refuses to
+        # guess since #82, so the catch is what makes this correct; the question
+        # in front of it keeps the message the tool's own, and covers a Shelf
+        # unconfigured between the two calls. Getting this wrong is not a small
+        # thing here: an MCP client spawns the server from whatever directory it
+        # happens to be in, so a fallback to the working directory would write
+        # Book Notes into a stranger's project folder.
+        raise ToolError(f"{exc} Set one with: libris config --vault <path>") from None
 
 
 def _text(value: object) -> str | None:

--- a/src/libris/mcp_server.py
+++ b/src/libris/mcp_server.py
@@ -27,6 +27,7 @@ from .note_format import (
     PRIORITY_VALUES,
     STATUS_VALUES,
     InvalidFieldValue,
+    read_formats,
 )
 
 # The vocabularies as the model sees them. Generated from note_format rather
@@ -136,7 +137,13 @@ class Book(BaseModel):
     def of(cls, note: BookNote) -> "Book":
         """Build the tool form of a Book Note."""
         frontmatter = note.frontmatter
-        formats = frontmatter.get("format") or []
+        # Read through the vocabulary's own reader rather than trusting the
+        # shape on disk. `format` is a list in most notes and a bare string in
+        # some - two on the Shelf today - and Obsidian writes the field where
+        # Libris cannot guard it (ADR 0017), so the shape is not ours to assume.
+        # Testing `isinstance(..., list)` reported no format at all for those
+        # notes, and dropped the case repair besides.
+        formats = read_formats(frontmatter.get("format"))
         return cls(
             libris_id=note.libris_id,
             title=note.title,
@@ -145,7 +152,7 @@ class Book(BaseModel):
             priority=_text(frontmatter.get("priority")),
             rating=_text(frontmatter.get("rating")),
             series=_text(frontmatter.get("series")),
-            format=[str(f) for f in formats] if isinstance(formats, list) else [],
+            format=formats,
             date_started=_text(frontmatter.get("date_started")),
             date_finished=_text(frontmatter.get("date_finished")),
             path=str(note.path),

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -707,6 +707,7 @@ def update_book(
     if note is None:
         raise BookNotFound(f"No Book Note holds the id {libris_id!r}.")
 
+    written: dict[str, object] = {}
     for name, value in fields.items():
         if name not in READER_FIELDS:
             raise ValueError(
@@ -727,11 +728,26 @@ def update_book(
                 f"{name} was given no value. Omit a field to leave it unchanged; "
                 f"this call cannot clear one."
             )
-        validate_field_value(name, value)
-
-    written = {
-        name: normalize_field_value(name, value) for name, value in fields.items()
-    }
+        # Repair the shape, then check the repaired value, then write exactly
+        # what was checked. Validating first meant judging one value and writing
+        # another: `format: "audiobook"` and `["physical", "EBOOK"]` were both
+        # refused although normalization turns them into values the Library
+        # defines, while `ensure_frontmatter_fields` repairs that same field on
+        # every pass (ADR 0017). The MCP schema never sends those, but this is a
+        # service-layer call and its two adapters do not agree on what they send.
+        repaired = normalize_field_value(name, value)
+        if repaired is None or (
+            isinstance(repaired, (str, list, dict)) and not repaired
+        ):
+            # Normalization can empty a value that arrived non-empty - a format
+            # of unrecognised words comes back None - and that is a clear by
+            # another route.
+            raise ValueError(
+                f"{name} was given {value!r}, which holds no value the Library "
+                f"recognises. Omit a field to leave it unchanged."
+            )
+        validate_field_value(name, repaired)
+        written[name] = repaired
 
     derived: dict[str, object] = {}
     stamp = _STATUS_STAMPS.get(str(fields.get("status", "")))

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -434,9 +434,10 @@ def _weights(note_tokens: list[set[str]]) -> dict[str, float]:
         note_tokens: The word set of every Book Note being searched.
 
     Returns:
-        A weight per word. `1 + n/df` rather than `n/df`, so a word every note
-        carries still weighs something and a Shelf of near-identical titles does
-        not score nothing at all.
+        A weight per word: `log(1 + n/df)`. The log is what keeps one very rare
+        word from swamping the ranking outright, and the `1 +` inside it is what
+        keeps a word every note carries weighing something rather than zero, so
+        a Shelf of near-identical titles does not score nothing at all.
     """
     total = len(note_tokens)
     frequency: dict[str, int] = {}
@@ -528,9 +529,15 @@ def search_library(
             continue
         if status is not None and note.frontmatter.get("status") != status:
             continue
-        candidates.append(
-            (note, _search_tokens(note.title) | _search_tokens(" ".join(note.authors)))
+        # Only worth doing when something will be ranked. Listing "To Read"
+        # walks 1,452 notes on the real Shelf, and tokenizing every title and
+        # author to then sort alphabetically is work with no reader.
+        tokens = (
+            _search_tokens(note.title) | _search_tokens(" ".join(note.authors))
+            if query_tokens
+            else set()
         )
+        candidates.append((note, tokens))
 
     # Weighed across what the filter left, not the whole Shelf, so narrowing to
     # one status weighs words by how well they separate the books still in play.
@@ -706,12 +713,19 @@ def update_book(
                 f"{name} is not a field this Surface may set. "
                 f"Settable fields: {', '.join(sorted(READER_FIELDS))}."
             )
-        if value is None:
-            # A model that emits null for "leave this alone" would otherwise
-            # erase a field nobody mentioned. Clearing a field is not something
-            # this call does; omitting it is how you leave it alone.
+        if value is None or (isinstance(value, (str, list, dict)) and not value):
+            # Null is the obvious way to erase a field by accident; the empty
+            # string and the empty list are the quiet ones. `format: []` reaches
+            # normalize_field_value and comes back None, and an empty string
+            # writes an empty field - both are a clear, arrived at without
+            # anyone asking for one. A model that emits any of the three for
+            # "leave this alone" would erase a field nobody mentioned.
+            #
+            # Emptiness is tested by type rather than by truthiness, because a
+            # rating of 0 and a False are values a reader can mean.
             raise ValueError(
-                f"{name} was given no value. Omit a field to leave it unchanged."
+                f"{name} was given no value. Omit a field to leave it unchanged; "
+                f"this call cannot clear one."
             )
         validate_field_value(name, value)
 

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -9,11 +9,17 @@ adapter decides what a failure looks like on the wire.
 import math
 import re
 from dataclasses import dataclass, field
+from datetime import date
 from enum import Enum
 from pathlib import Path
 
 from .api import BookCandidate, GoogleBooksClient
-from .markdown import BookNote, create_book_note, list_books
+from .markdown import (
+    BookNote,
+    create_book_note,
+    list_books,
+    set_frontmatter_fields,
+)
 from .matching import best_match, normalize_for_match, titles_match
 from .merge import (
     delete_secondary_file,
@@ -21,7 +27,11 @@ from .merge import (
     merge_two_books,
     write_merged_book,
 )
-from .note_format import validate_field_value
+from .note_format import (
+    READER_FIELDS,
+    normalize_field_value,
+    validate_field_value,
+)
 from .shelf import index_for
 
 
@@ -595,6 +605,104 @@ def add_book(
         # cannot be read back rather than leaving the Surface with only a path.
         title=note.title if note else candidate.title,
         authors=note.authors if note else candidate.authors,
+    )
+
+
+class BookNotFound(Exception):
+    """No Book Note answers for the identity a write named.
+
+    A miss never writes and never creates (ADR 0003): an update that cannot find
+    its book is a question for the person who named it, not an excuse to add one.
+    """
+
+
+# The date a status implies when the note does not already carry one. The
+# Library has held half of this rule for years - `ensure_frontmatter_fields`
+# forces status to Read when a finish date is present - and this is the other
+# half (ADR 0024).
+_STATUS_STAMPS = {"Read": "date_finished", "Reading": "date_started"}
+
+
+@dataclass
+class UpdateResult:
+    """What an update did, including the parts nobody asked for.
+
+    `derived` names the fields the Library set on its own. It travels because a
+    stamped date is indistinguishable from a stated one afterwards, and a person
+    who meant last Tuesday can only correct it while still in the conversation
+    (ADR 0024).
+    """
+
+    note: BookNote
+    written: dict[str, object] = field(default_factory=dict)
+    derived: dict[str, object] = field(default_factory=dict)
+
+
+def update_book(
+    vault_path: Path,
+    libris_id: str,
+    fields: dict[str, object],
+) -> UpdateResult:
+    """Set fields on the Book Note holding an identity.
+
+    Only the named fields change, so an update can never overwrite a field it
+    knows nothing about. Only the reader's own fields may be named: a title
+    belongs to Libris (ADR 0012) and the bibliographic fields come from
+    enrichment rather than from someone talking.
+
+    Args:
+        vault_path: The Shelf to write into.
+        libris_id: The identity to update. A superseded identity resolves to the
+            note that absorbed it (ADR 0014), so an id picked up before a merge
+            still applies.
+        fields: Field names and the values to set them to.
+
+    Returns:
+        The updated Book Note, what was written, and anything the Library
+        derived.
+
+    Raises:
+        BookNotFound: If no note answers for the identity.
+        InvalidFieldValue: If a value is not one the Library defines.
+        ValueError: If a field is not the reader's to set, or a value is null.
+        FrontmatterUnreadable: If the note's frontmatter cannot be parsed.
+    """
+    note = find_by_libris_id(vault_path, libris_id)
+    if note is None:
+        raise BookNotFound(f"No Book Note holds the id {libris_id!r}.")
+
+    for name, value in fields.items():
+        if name not in READER_FIELDS:
+            raise ValueError(
+                f"{name} is not a field this Surface may set. "
+                f"Settable fields: {', '.join(sorted(READER_FIELDS))}."
+            )
+        if value is None:
+            # A model that emits null for "leave this alone" would otherwise
+            # erase a field nobody mentioned. Clearing a field is not something
+            # this call does; omitting it is how you leave it alone.
+            raise ValueError(
+                f"{name} was given no value. Omit a field to leave it unchanged."
+            )
+        validate_field_value(name, value)
+
+    written = {
+        name: normalize_field_value(name, value) for name, value in fields.items()
+    }
+
+    derived: dict[str, object] = {}
+    stamp = _STATUS_STAMPS.get(str(fields.get("status", "")))
+    if stamp and stamp not in fields and not note.frontmatter.get(stamp):
+        # Only ever fills an empty field, so re-marking a dated book Read leaves
+        # the original date alone. A re-read is not something the Library models.
+        derived[stamp] = date.today().isoformat()
+        written[stamp] = derived[stamp]
+
+    if written:
+        set_frontmatter_fields(note.path, written)
+
+    return UpdateResult(
+        note=BookNote.read(note.path) or note, written=written, derived=derived
     )
 
 

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -215,24 +215,23 @@ def find_by_libris_id(vault_path: Path, libris_id: str) -> BookNote | None:
 
     Note:
         Guaranteeing that a live identity wins means the scan cannot stop at the
-        first superseded match, so resolving an identity that is superseded or
-        unknown reads every Book Note: about 14 seconds against the 3,136-note
-        Shelf. Resolving one Intent that way is fine; resolving a queue of them
-        in a loop is not. A caller with many to resolve should build an index in
-        one pass instead.
+        first superseded match, so an identity that is superseded or unknown is
+        compared against every Book Note. Those comparisons come from the index
+        rather than from the disk: reading and parsing the Shelf per call cost
+        5.5 seconds for a live id and 10.4 for an unknown one against the real
+        3,063-note Shelf, where the same lookup through the index costs 27
+        milliseconds. update_book resolves an identity on every write, so that
+        was the difference between a tool that answers and one that stalls.
     """
     wanted = libris_id.strip() if libris_id else ""
     if not wanted:
-        # Checked after stripping: a whitespace-only id would otherwise read
-        # every note on the Shelf to find nothing.
+        # Checked before the scan: a whitespace-only id would otherwise be
+        # compared against every note on the Shelf to find nothing.
         return None
 
     superseding: BookNote | None = None
 
-    for book_path in list_books(vault_path):
-        note = BookNote.read(book_path)
-        if note is None:
-            continue
+    for note in index_for(vault_path).notes():
         if note.libris_id == wanted:
             return note
         if superseding is None and wanted in note.superseded_ids:

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -44,6 +44,9 @@ class Outcome(Enum):
 
     CREATED = "created"
     ALREADY_PRESENT = "already_present"
+    # Nothing was written, and will not be until a person answers. Only a
+    # Surface that asked to stop can receive this (ADR 0026).
+    NEEDS_CONFIRMATION = "needs_confirmation"
 
 
 @dataclass
@@ -58,10 +61,13 @@ class AddResult:
     """
 
     libris_id: str | None
-    path: Path
+    path: Path | None
     outcome: Outcome
     title: str | None = None
     authors: list[str] = field(default_factory=list)
+    # The Book Notes that stopped the write, when one was stopped. Empty in
+    # every other case, including a write that went ahead past them.
+    near_matches: list[BookNote] = field(default_factory=list)
 
 
 def is_isbn10(value: str) -> bool:
@@ -557,6 +563,7 @@ def add_book(
     vault_path: Path,
     candidate: BookCandidate,
     overrides: dict | None = None,
+    stop_on_near_match: bool = False,
 ) -> AddResult:
     """Add a Book to the Library, unless it is already held.
 
@@ -568,9 +575,16 @@ def add_book(
         vault_path: The Shelf to write into.
         candidate: The Book Candidate accepted by whoever chose it.
         overrides: Frontmatter fields to set, validated by create_book_note.
+        stop_on_near_match: Refuse to write when the Library holds a Near Match,
+            returning the candidates instead. For a Surface whose caller is a
+            model, where a near match reported after the write arrives too late
+            to be a question (ADR 0026). Off by default, because the extension
+            shows Near Matches to a person before they press the button and
+            asking twice would be asking nobody.
 
     Returns:
-        The identity of the Book Note and what happened to it.
+        The identity of the Book Note and what happened to it, or the Near
+        Matches that stopped it.
 
     Raises:
         InvalidFieldValue: If an override carries a value the Library does not
@@ -586,6 +600,8 @@ def add_book(
         authors=candidate.authors,
     )
     if existing is not None:
+        # The exact check answers first, so a Book the Library provably holds is
+        # reported as held rather than raised as a question with no useful answer.
         return AddResult(
             libris_id=existing.libris_id,
             path=existing.path,
@@ -593,6 +609,20 @@ def add_book(
             title=existing.title,
             authors=existing.authors,
         )
+
+    if stop_on_near_match:
+        near = find_similar(
+            vault_path, title=candidate.title, authors=candidate.authors
+        )
+        if near:
+            return AddResult(
+                libris_id=None,
+                path=None,
+                outcome=Outcome.NEEDS_CONFIRMATION,
+                title=candidate.title,
+                authors=candidate.authors,
+                near_matches=near,
+            )
 
     path = create_book_note(candidate, vault_path, overrides=overrides or None)
     note = BookNote.read(path)

--- a/src/libris/service.py
+++ b/src/libris/service.py
@@ -6,6 +6,7 @@ module knows about HTTP, and it raises rather than returning status codes: the
 adapter decides what a failure looks like on the wire.
 """
 
+import math
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -20,6 +21,7 @@ from .merge import (
     merge_two_books,
     write_merged_book,
 )
+from .note_format import validate_field_value
 from .shelf import index_for
 
 
@@ -324,6 +326,222 @@ def find_similar(
 
     found.sort(key=lambda n: len(n.title or ""))
     return found[:limit]
+
+
+# What a search returns when the caller does not say, and the most it will
+# return however loudly they ask. A Surface asking for everything is asking to
+# read 1,452 To Read notes into a context window, which is what the ceiling
+# exists to refuse; the total travels instead so the answer stays honest.
+DEFAULT_SEARCH_LIMIT = 20
+MAX_SEARCH_LIMIT = 50
+
+# Words that say how a person is talking rather than which book they mean. A
+# query still scores them - "The Way of Kings" should outrank "Kings of the
+# Wyld" partly on "of" - but a note matching nothing else is not a match, or
+# searching for a title with "the" in it would report most of the Shelf.
+#
+# Curated rather than derived, because frequency cannot do this job: measured on
+# the real Shelf, "poems" appears in 51 notes and "one" in 50. They are
+# statistically identical and only one of them names a book. The list covers
+# pronouns, determiners, common prepositions and the filler of a spoken request
+# ("that mistborn one I just finished"), and holds no word that could title a
+# book on its own.
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "about",
+        "am",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "i",
+        "in",
+        "is",
+        "it",
+        "its",
+        "just",
+        "me",
+        "mine",
+        "my",
+        "of",
+        "on",
+        "one",
+        "ones",
+        "or",
+        "some",
+        "that",
+        "the",
+        "these",
+        "this",
+        "those",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
+
+
+@dataclass
+class SearchResult:
+    """What the Library holds for a query, and how much of it was returned.
+
+    `total` counts every match, not the returned slice. A Surface that shows
+    five of 1,452 can then say so, rather than implying it saw them all.
+    """
+
+    total: int
+    limit: int
+    books: list[BookNote] = field(default_factory=list)
+
+
+def _search_tokens(text: str) -> set[str]:
+    """Split text into the normalized words a search compares."""
+    normalized = normalize_for_match(text)
+    return set(normalized.split()) if normalized else set()
+
+
+def _weights(note_tokens: list[set[str]]) -> dict[str, float]:
+    """Weigh each word on the Shelf by how few notes carry it.
+
+    A word naming three notes says far more about which book was meant than one
+    naming fifty, and scoring every matched word alike is what put "The Hot One"
+    above "The Final Empire: Mistborn Book 1" for "that mistborn one".
+
+    Args:
+        note_tokens: The word set of every Book Note being searched.
+
+    Returns:
+        A weight per word. `1 + n/df` rather than `n/df`, so a word every note
+        carries still weighs something and a Shelf of near-identical titles does
+        not score nothing at all.
+    """
+    total = len(note_tokens)
+    frequency: dict[str, int] = {}
+    for tokens in note_tokens:
+        for token in tokens:
+            frequency[token] = frequency.get(token, 0) + 1
+    return {token: math.log(1 + total / count) for token, count in frequency.items()}
+
+
+def _rank(
+    query_tokens: set[str],
+    note_tokens: set[str],
+    weights: dict[str, float],
+    distinctive: set[str],
+) -> tuple[float, float] | None:
+    """Score one Book Note against a query, or None when it does not match.
+
+    Ranks rather than decides, for the reason find_similar does (ADR 0003):
+    "Mercy" and "Long Road to Mercy" are different books that share a word, and
+    only the person asking can say which they meant. Both are returned; the note
+    the query describes best is put first.
+
+    Args:
+        query_tokens: The words the person used.
+        note_tokens: The words in this note's title and authors.
+        weights: What each word on this Shelf is worth.
+        distinctive: The query's words that could name a book, so a note that
+            matched only filler is never offered as an answer.
+
+    Returns:
+        The weight of what matched, and how much of the note that accounts for -
+        so a short title matching one word outranks a long one matching the same
+        word incidentally. None when nothing matched, or only filler did.
+    """
+    matched = query_tokens & note_tokens
+    if not matched or not (matched & distinctive):
+        return None
+
+    scored = sum(weights.get(token, 0.0) for token in matched)
+    available = sum(weights.get(token, 0.0) for token in note_tokens) or 1.0
+    return scored, scored / available
+
+
+def search_library(
+    vault_path: Path,
+    query: str | None = None,
+    status: str | None = None,
+    limit: int = DEFAULT_SEARCH_LIMIT,
+) -> SearchResult:
+    """Find the Book Notes a person is describing, without deciding which.
+
+    The free-text half is deliberately fuzzy and the filter half is not. A
+    status belongs to a closed vocabulary the Library defines (ADR 0022), so it
+    narrows exactly; the words someone actually said are matched loosely and
+    ranked, and every plausible answer goes back for them to settle (ADR 0003).
+
+    Args:
+        vault_path: The Shelf to search.
+        query: What the person said, matched against titles and authors. When
+            absent the filters answer alone - "what am I reading?" carries no
+            query at all.
+        status: A status to narrow to, from the Library's own vocabulary.
+        limit: The most notes to return, clamped to MAX_SEARCH_LIMIT.
+
+    Returns:
+        The matching Book Notes, best first, and the total number of matches
+        the limit may have cut short.
+
+    Raises:
+        InvalidFieldValue: If the status is not one the Library defines. Refused
+            rather than quietly matching nothing, which would report an empty
+            Library for a typo.
+    """
+    if status is not None:
+        validate_field_value("status", status)
+
+    limit = max(0, min(limit, MAX_SEARCH_LIMIT))
+    query_tokens = _search_tokens(query) if query else set()
+
+    # A query of nothing but filler is taken at face value - the alternative is
+    # answering "the" with silence, when the Shelf may well hold "The Road".
+    distinctive = query_tokens - _STOP_WORDS or query_tokens
+
+    candidates: list[tuple[BookNote, set[str]]] = []
+    for note in index_for(vault_path).notes():
+        if not note.title:
+            # Obsidian writes into this directory too, so a file that is not a
+            # Book Note is ordinary rather than exceptional.
+            continue
+        if status is not None and note.frontmatter.get("status") != status:
+            continue
+        candidates.append(
+            (note, _search_tokens(note.title) | _search_tokens(" ".join(note.authors)))
+        )
+
+    # Weighed across what the filter left, not the whole Shelf, so narrowing to
+    # one status weighs words by how well they separate the books still in play.
+    weights = _weights([tokens for _, tokens in candidates]) if query_tokens else {}
+
+    scored: list[tuple[tuple, BookNote]] = []
+    for note, note_tokens in candidates:
+        sort_title = normalize_for_match(note.title or "")
+        if not query_tokens:
+            # Nothing was asked, so nothing is ranked. Alphabetical is the order
+            # a person expects and, unlike relevance, is identical between two
+            # identical calls.
+            scored.append(((0.0, 0.0, 0, sort_title), note))
+            continue
+        rank = _rank(query_tokens, note_tokens, weights, distinctive)
+        if rank is None:
+            continue
+        matched, density = rank
+        scored.append(((-matched, -density, len(note.title or ""), sort_title), note))
+
+    scored.sort(key=lambda pair: pair[0])
+    return SearchResult(
+        total=len(scored),
+        limit=limit,
+        books=[note for _, note in scored[:limit]],
+    )
 
 
 def add_book(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
 
 from libris.api import GoogleBooksClient
 
@@ -40,3 +43,103 @@ def test_search_gatsby():
         assert len(books) == 1
         assert books[0].title == "The Great Gatsby"
         assert books[0].isbn == "1234567890123"
+
+
+# --- fetching one volume by id (ADR 0025) ---
+
+
+def _volume_payload(**overrides):
+    volume_info = {
+        "title": "Dune",
+        "authors": ["Frank Herbert"],
+        "industryIdentifiers": [{"type": "ISBN_13", "identifier": "9780441013593"}],
+        "pageCount": 412,
+        "publishedDate": "1965",
+        "imageLinks": {"thumbnail": "http://example.com/dune.jpg"},
+        "categories": ["Science Fiction"],
+        "description": "A desert planet.",
+    }
+    volume_info.update(overrides)
+    return {"id": "dune-1", "volumeInfo": volume_info}
+
+
+def test_a_volume_is_fetched_by_its_own_id():
+    # Given a Google Books volume
+    client = GoogleBooksClient()
+
+    with patch("httpx.Client.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.json.return_value = _volume_payload()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        # When it is asked for by id
+        candidate = client.get_volume("dune-1")
+
+        # Then the volume endpoint was addressed, not a search
+        url = mock_get.call_args.args[0]
+        assert url.endswith("/volumes/dune-1")
+
+    # And the candidate carries what the source said, rather than what a caller
+    # re-typed. This is the whole point of naming a candidate by id (ADR 0025).
+    assert candidate.title == "Dune"
+    assert candidate.authors == ["Frank Herbert"]
+    assert candidate.isbn == "9780441013593"
+    assert candidate.page_count == 412
+    assert candidate.google_books_id == "dune-1"
+    assert candidate.description == "A desert planet."
+
+
+def test_a_volume_that_does_not_exist_is_a_miss_not_a_crash():
+    # Given an id Google Books does not know
+    client = GoogleBooksClient(max_retries=0)
+
+    with patch("httpx.Client.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=mock_response
+        )
+        mock_get.return_value = mock_response
+
+        # When it is fetched
+        # Then it answers None. A caller can then say "no such volume" rather
+        # than surfacing an HTTP error to a person (ADR 0021).
+        assert client.get_volume("no-such-volume") is None
+
+
+def test_a_volume_id_is_escaped_into_the_path():
+    # Given an id carrying a character that would otherwise change the path
+    client = GoogleBooksClient()
+
+    with patch("httpx.Client.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.json.return_value = _volume_payload()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        client.get_volume("a/../b")
+
+        # Then it cannot climb out of the volumes path
+        url = mock_get.call_args.args[0]
+        assert url.endswith("/volumes/a%2F..%2Fb")
+
+
+def test_an_upstream_failure_is_raised_rather_than_swallowed():
+    # Given Google Books returning a server error
+    client = GoogleBooksClient(max_retries=0)
+
+    with patch("httpx.Client.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=mock_response
+        )
+        mock_get.return_value = mock_response
+
+        # When a volume is fetched
+        # Then it raises. Only a 404 means "no such book"; everything else means
+        # the answer is unknown, and reporting that as a miss would let a write
+        # proceed on nothing.
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get_volume("dune-1")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ tools/call over the SDK's in-memory transport.
 """
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -233,3 +234,29 @@ def test_connecting_does_not_read_the_shelf(shelved, monkeypatch):
     # initialize records the server as failed rather than slow (#94). The cost
     # belongs on the first tool call, where a person can see it happen.
     assert reads == []
+
+
+def test_the_adapter_does_not_need_the_server_extra(monkeypatch):
+    # Given an environment where the web stack is not installed, which is what
+    # `uv sync --extra mcp` gives you
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_fastapi(name, *args, **kwargs):
+        if name.split(".")[0] in {"fastapi", "uvicorn", "starlette"}:
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    for module in [m for m in list(sys.modules) if m.startswith("libris.server")]:
+        monkeypatch.delitem(sys.modules, module)
+    monkeypatch.setattr(builtins, "__import__", _no_fastapi)
+
+    # When the MCP server is built
+    server = create_server()
+
+    # Then it builds. The two extras are independent, and reaching into
+    # server.py for a version helper - which lives in libris/__init__.py anyway -
+    # made `libris mcp` require FastAPI to start. CI caught it; this keeps it
+    # caught, because a developer with both extras installed never sees it.
+    assert server.name == "libris"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,235 @@
+"""The MCP adapter, driven as a client actually drives it.
+
+These are deliberately thin. The behaviour lives in service.py and is tested
+there; what cannot be tested there is whether a tool registers, whether its
+schema is one a model can fill, and whether a failure comes back as something
+readable rather than as a dead connection. Those are the ones that look fine in
+a unit test and break on first use, so they go through a real tools/list and
+tools/call over the SDK's in-memory transport.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import anyio  # noqa: E402
+from mcp import Client  # noqa: E402
+
+from libris import config, shelf  # noqa: E402
+from libris.api import BookCandidate  # noqa: E402
+from libris.markdown import BookNote, create_book_note  # noqa: E402
+from libris.mcp_server import create_server  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def fresh_indexes():
+    """No index survives into another test's temporary Shelf."""
+    shelf.forget_indexes()
+    yield
+    shelf.forget_indexes()
+
+
+@pytest.fixture
+def shelved(tmp_path, monkeypatch):
+    """A configured Shelf holding two books."""
+    monkeypatch.setattr(config, "get_vault_path", lambda: tmp_path)
+    monkeypatch.setattr(config, "is_vault_configured", lambda: True)
+    create_book_note(
+        BookCandidate(title="Dune", authors=["Frank Herbert"]),
+        tmp_path,
+        overrides={"status": "Reading"},
+    )
+    create_book_note(
+        BookCandidate(title="Oathbringer", authors=["Brandon Sanderson"]),
+        tmp_path,
+        overrides={"status": "Read"},
+    )
+    return tmp_path
+
+
+def call(tool: str, arguments: dict | None = None):
+    """Run one tool through a real client, and hand back the result."""
+
+    async def _run():
+        async with Client(create_server()) as client:
+            return await client.call_tool(tool, arguments or {})
+
+    return anyio.run(_run)
+
+
+def list_tools():
+    """Ask the server what it offers, the way a client does."""
+
+    async def _run():
+        async with Client(create_server()) as client:
+            return (await client.list_tools()).tools
+
+    return anyio.run(_run)
+
+
+def payload(result):
+    """Read a tool result's structured content, or its text when it errored."""
+    if result.structured_content is not None:
+        return result.structured_content
+    return json.loads(result.content[0].text)
+
+
+def text(result):
+    """Read a tool result's text, which is where an error message lands."""
+    return result.content[0].text
+
+
+# --- what the model is shown ---
+
+
+def test_every_tool_is_offered(shelved):
+    # Given the server
+    # When a client lists its tools
+    names = {t.name for t in list_tools()}
+
+    # Then all four are there, and nothing that reads a note body is (ADR 0023)
+    assert names == {"search_library", "find_book", "add_book", "update_book"}
+    assert not {n for n in names if "note" in n or "body" in n}
+
+
+def test_the_vocabularies_ride_in_the_schemas(shelved):
+    # Given the tools that write
+    tools = {t.name: t for t in list_tools()}
+
+    # When their schemas are read, as a model reads them before composing a call
+    status = tools["update_book"].input_schema["properties"]["status"]
+    enums = status.get("enum") or [
+        e for branch in status.get("anyOf", []) for e in branch.get("enum", [])
+    ]
+
+    # Then the Library's own values are in them, generated rather than restated
+    # (ADR 0022). `libris update` still offers "Finished", which is exactly the
+    # drift a served vocabulary prevents.
+    assert enums == ["To Read", "Reading", "Read", "Not To Read"]
+    assert "Finished" not in enums
+
+
+# --- one round trip per tool ---
+
+
+def test_searching_the_library_answers_with_reading_state(shelved):
+    # When the Library is searched
+    answer = payload(call("search_library", {"query": "sanderson"}))
+
+    # Then the book comes back with enough to tell it from another (Q4)
+    assert answer["total"] == 1
+    book = answer["books"][0]
+    assert book["title"] == "Oathbringer"
+    assert book["status"] == "Read"
+    assert book["libris_id"]
+
+
+def test_searching_by_status_alone_answers_what_am_i_reading(shelved):
+    # When there is no query at all
+    answer = payload(call("search_library", {"status": "Reading"}))
+
+    # Then the filter answers it
+    assert [b["title"] for b in answer["books"]] == ["Dune"]
+
+
+def test_a_search_that_matches_nothing_is_not_an_error(shelved):
+    # When nothing matches
+    result = call("search_library", {"query": "neuromancer"})
+
+    # Then it succeeded and says so in the body. A miss is a miss (ADR 0021).
+    assert not result.is_error
+    assert payload(result) == {"total": 0, "books": []}
+
+
+def test_updating_a_book_reports_what_it_derived(shelved):
+    # Given the book being read
+    note = next(
+        n
+        for n in (BookNote.read(p) for p in Path(shelved).glob("*.md"))
+        if n.title == "Dune"
+    )
+
+    # When it is marked Read without a date
+    answer = payload(
+        call("update_book", {"libris_id": note.libris_id, "status": "Read"})
+    )
+
+    # Then the stamped date travels back, so the agent can relay it and a person
+    # who finished it last week can correct it (ADR 0024)
+    assert answer["outcome"] == "updated"
+    assert answer["book"]["status"] == "Read"
+    assert list(answer["derived"]) == ["date_finished"]
+
+
+# --- failures a person can act on ---
+
+
+def test_an_unknown_book_comes_back_readable_not_as_a_crash(shelved):
+    # When an identity nothing answers for is updated
+    result = call(
+        "update_book", {"libris_id": "01J0000000000000000000000A", "status": "Read"}
+    )
+
+    # Then the tool reports it in words rather than killing the connection
+    assert result.is_error
+    assert "01J0000000000000000000000A" in text(result)
+
+
+def test_a_value_the_library_rejects_names_what_is_allowed(shelved):
+    # Given a status the schema would have caught, sent anyway
+    result = call("update_book", {"libris_id": "x", "status": "Finished"})
+
+    # Then the answer says which values are legal, rather than only refusing
+    assert result.is_error
+    assert "Finished" in text(result)
+
+
+def test_an_update_naming_no_fields_says_so(shelved):
+    # When nothing is asked to change
+    result = call("update_book", {"libris_id": "anything"})
+
+    # Then it says so rather than reporting a successful no-op
+    assert result.is_error
+    assert "nothing to change" in text(result)
+
+
+def test_an_unconfigured_shelf_never_reaches_the_working_directory(
+    tmp_path, monkeypatch
+):
+    # Given a server started with no Shelf configured, which is allowed (Q11)
+    monkeypatch.setattr(config, "is_vault_configured", lambda: False)
+
+    # When a tool is called
+    result = call("search_library", {"query": "dune"})
+
+    # Then the fix reaches the person who can apply it, in the conversation.
+    # Exiting at startup would put this on a stderr nobody reads.
+    assert result.is_error
+    assert "libris config --vault" in text(result)
+
+
+def test_connecting_does_not_read_the_shelf(shelved, monkeypatch):
+    # Given a Shelf, and a count of how many notes get parsed
+    reads = []
+    original = BookNote.read
+    monkeypatch.setattr(
+        BookNote,
+        "read",
+        staticmethod(lambda path: (reads.append(path), original(path))[1]),
+    )
+
+    # When a client connects and lists the tools, but calls none
+    async def _connect():
+        async with Client(create_server()) as client:
+            return (await client.list_tools()).tools
+
+    assert len(anyio.run(_connect)) == 4
+
+    # Then nothing was parsed. A blocking warm-up here measured 49.4 seconds to
+    # connect against a real Shelf, and a client that times out during
+    # initialize records the server as failed rather than slow (#94). The cost
+    # belongs on the first tool call, where a person can see it happen.
+    assert reads == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -107,8 +107,10 @@ def test_the_vocabularies_ride_in_the_schemas(shelved):
     ]
 
     # Then the Library's own values are in them, generated rather than restated
-    # (ADR 0022). `libris update` still offers "Finished", which is exactly the
-    # drift a served vocabulary prevents.
+    # (ADR 0022). "Finished" is the value the `libris status` prompt used to
+    # offer from a hardcoded list, which no note has ever held - the drift a
+    # served vocabulary exists to prevent, named here so a client that starts
+    # keeping its own copy fails this test rather than repeating the mistake.
     assert enums == ["To Read", "Reading", "Read", "Not To Read"]
     assert "Finished" not in enums
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -262,3 +262,24 @@ def test_the_adapter_does_not_need_the_server_extra(monkeypatch):
     # made `libris mcp` require FastAPI to start. CI caught it; this keeps it
     # caught, because a developer with both extras installed never sees it.
     assert server.name == "libris"
+
+
+def test_a_bare_string_format_is_reported_not_dropped(shelved):
+    # Given a note whose format is a bare string rather than a list
+    note = next(
+        n
+        for n in (BookNote.read(p) for p in Path(shelved).glob("*.md"))
+        if n.title == "Dune"
+    )
+    raw = note.path.read_text(encoding="utf-8")
+    note.path.write_text(
+        raw.replace("format: null", "format: physical", 1), encoding="utf-8"
+    )
+
+    # When the book is searched for
+    answer = payload(call("search_library", {"query": "dune"}))
+
+    # Then the format is reported, and in the Library's own casing. Reaching into
+    # the frontmatter and testing isinstance(list) returned no format at all for
+    # these notes, which would tell an agent a book has none recorded.
+    assert answer["books"][0]["format"] == ["Physical"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,6 +5,8 @@ surface and the MCP tools cannot drift apart by reimplementing matching. These
 tests exercise that layer directly, with no HTTP involved.
 """
 
+from datetime import date
+
 import pytest
 
 from libris.api import BookCandidate
@@ -15,6 +17,7 @@ from libris.markdown import (
 from libris.note_format import InvalidFieldValue
 from libris.service import (
     MAX_SEARCH_LIMIT,
+    BookNotFound,
     DecisionStatus,
     Outcome,
     add_book,
@@ -24,6 +27,7 @@ from libris.service import (
     find_existing,
     is_isbn10,
     search_library,
+    update_book,
 )
 
 
@@ -638,3 +642,196 @@ def test_conversational_filler_does_not_pull_in_unrelated_books(tmp_path):
     # the first six.
     assert _titles(result) == ["The Final Empire: Mistborn Book 1"]
     assert result.total == 1
+
+
+# --- updating a Book Note ---
+
+
+def _read_back(vault_path, libris_id):
+    for path in vault_path.glob("*.md"):
+        note = BookNote.read(path)
+        if note and note.libris_id == libris_id:
+            return note
+    raise AssertionError(f"no note holds {libris_id}")
+
+
+def test_a_named_field_is_set(tmp_path):
+    # Given a book waiting to be read
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], status="To Read")
+
+    # When its status is moved on
+    update_book(tmp_path, note.libris_id, {"status": "Reading"})
+
+    # Then the Shelf holds the new value
+    assert _read_back(tmp_path, note.libris_id).frontmatter["status"] == "Reading"
+
+
+def test_fields_that_were_not_named_are_left_alone(tmp_path):
+    # Given a book carrying a rating nobody mentioned
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], status="To Read", rating=5)
+
+    # When only the status is set
+    update_book(tmp_path, note.libris_id, {"status": "Reading"})
+
+    # Then the rating survives. An update names only the fields it changes, so
+    # it can never overwrite a field it knows nothing about.
+    assert _read_back(tmp_path, note.libris_id).frontmatter["rating"] == 5
+
+
+def test_finishing_a_book_stamps_the_date_and_says_so(tmp_path):
+    # Given a book being read, with no finish date
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], status="Reading")
+
+    # When it is marked Read without a date
+    result = update_book(tmp_path, note.libris_id, {"status": "Read"})
+
+    # Then today is stamped, and reported as something the caller did not ask
+    # for - so a person who meant last Tuesday can correct it (ADR 0024)
+    today = date.today().isoformat()
+    assert _read_back(tmp_path, note.libris_id).frontmatter["date_finished"] == today
+    assert result.derived == {"date_finished": today}
+
+
+def test_starting_a_book_stamps_the_started_date(tmp_path):
+    # Given a book nobody has opened
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], status="To Read")
+
+    # When it is marked Reading
+    result = update_book(tmp_path, note.libris_id, {"status": "Reading"})
+
+    # Then the start date is stamped and disclosed
+    assert result.derived == {"date_started": date.today().isoformat()}
+
+
+def test_an_explicit_date_is_never_overridden(tmp_path):
+    # Given a book being read
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], status="Reading")
+
+    # When it is marked Read with the date it was actually finished
+    result = update_book(
+        tmp_path, note.libris_id, {"status": "Read", "date_finished": "2026-08-25"}
+    )
+
+    # Then that date stands and nothing is derived. The stamp is a fallback,
+    # never an override (ADR 0024).
+    written = _read_back(tmp_path, note.libris_id).frontmatter["date_finished"]
+    assert str(written) == "2026-08-25"
+    assert result.derived == {}
+
+
+def test_a_date_already_on_the_note_is_not_restamped(tmp_path):
+    # Given a book finished years ago
+    note = _shelve(
+        tmp_path, "Dune", ["Frank Herbert"], status="Read", date_finished="2019-04-01"
+    )
+
+    # When its status is set to Read once more
+    result = update_book(tmp_path, note.libris_id, {"status": "Read"})
+
+    # Then the original date survives. A re-read is not something the Library
+    # models, and inventing one here would be scope creep (ADR 0024).
+    written = _read_back(tmp_path, note.libris_id).frontmatter["date_finished"]
+    assert str(written) == "2019-04-01"
+    assert result.derived == {}
+
+
+def test_a_value_the_library_does_not_define_is_refused(tmp_path):
+    # Given a status outside the four the Library allows
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When it is written
+    # Then it is refused. `libris update` offers "Finished" to this day, which
+    # is the drift ADR 0022 exists to stop.
+    with pytest.raises(InvalidFieldValue):
+        update_book(tmp_path, note.libris_id, {"status": "Finished"})
+
+
+def test_a_field_that_is_not_the_readers_is_refused(tmp_path):
+    # Given a field describing the edition rather than the reading of it
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When it is written
+    # Then it is refused: Libris owns the title (ADR 0012), and bibliographic
+    # fields come from enrichment rather than from someone talking.
+    with pytest.raises(ValueError):
+        update_book(tmp_path, note.libris_id, {"title": "Doon"})
+
+
+def test_a_null_does_not_silently_clear_a_field(tmp_path):
+    # Given a book carrying a rating
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], rating=5)
+
+    # When a null arrives for it
+    # Then it is refused rather than treated as "clear this". A model emitting
+    # null for "unchanged" would otherwise erase a field nobody mentioned.
+    with pytest.raises(ValueError):
+        update_book(tmp_path, note.libris_id, {"rating": None})
+    assert _read_back(tmp_path, note.libris_id).frontmatter["rating"] == 5
+
+
+def test_an_unknown_identity_is_not_found(tmp_path):
+    # Given a Shelf that holds no such book
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When an identity nothing answers for is updated
+    # Then it fails rather than creating anything (ADR 0003)
+    with pytest.raises(BookNotFound):
+        update_book(tmp_path, "01J0000000000000000000000A", {"status": "Read"})
+    assert len(list(tmp_path.glob("*.md"))) == 1
+
+
+def test_a_multi_valued_field_takes_several_values(tmp_path):
+    # Given a book owned on paper and listened to as an audiobook
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When both formats are recorded
+    update_book(tmp_path, note.libris_id, {"format": ["Physical", "Audiobook"]})
+
+    # Then both stand. Several at once is normal for a Format (ADR 0017).
+    assert _read_back(tmp_path, note.libris_id).frontmatter["format"] == [
+        "Physical",
+        "Audiobook",
+    ]
+
+
+def test_a_superseded_identity_still_updates_the_survivor(tmp_path):
+    # Given a note that absorbed another in a merge
+    survivor = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+    dead_id = "01J0000000000000000000000A"
+    raw = survivor.path.read_text(encoding="utf-8")
+    marker = "superseded_ids:" + chr(10) + "- " + dead_id + chr(10) + "status:"
+    survivor.path.write_text(raw.replace("status:", marker, 1), encoding="utf-8")
+
+    # When the identity that was merged away is updated
+    result = update_book(tmp_path, dead_id, {"status": "Read"})
+
+    # Then it reaches the surviving note. An ID picked up before a merge still
+    # applies rather than being rejected for a note Libris itself destroyed
+    # (ADR 0014).
+    assert result.note.libris_id == survivor.libris_id
+    assert _read_back(tmp_path, survivor.libris_id).frontmatter["status"] == "Read"
+
+
+def test_the_body_is_left_exactly_as_it_was(tmp_path):
+    # Given a note whose body holds the reader's own writing, including a line
+    # that looks like a frontmatter field
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+    raw = note.path.read_text(encoding="utf-8")
+    frontmatter = raw.split("---", 2)[1]
+    body = (
+        "# Dune"
+        + chr(10) * 2
+        + "## Notes"
+        + chr(10) * 2
+        + "Wrote this. status: unclear."
+        + chr(10)
+    )
+    note.path.write_text("---" + frontmatter + "---" + chr(10) + body, encoding="utf-8")
+
+    # When the status is updated
+    update_book(tmp_path, note.libris_id, {"status": "Read"})
+
+    # Then the body survives exactly, including that line. An MCP write reaches
+    # frontmatter and nothing else (ADR 0023), and that line is the shape of the
+    # bug in #92.
+    assert note.path.read_text(encoding="utf-8").endswith(body)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14,6 +14,7 @@ from libris.markdown import (
 )
 from libris.note_format import InvalidFieldValue
 from libris.service import (
+    MAX_SEARCH_LIMIT,
     DecisionStatus,
     Outcome,
     add_book,
@@ -22,6 +23,7 @@ from libris.service import (
     find_by_libris_id,
     find_existing,
     is_isbn10,
+    search_library,
 )
 
 
@@ -382,3 +384,257 @@ def test_a_conflicting_pair_is_reported_not_merged(tmp_path):
     # yours"
     assert [o.status for o in outcomes] == [DecisionStatus.CONFLICTED]
     assert len(list(tmp_path.glob("*.md"))) == 2
+
+
+# --- searching the Library ---
+
+
+def _shelve(vault_path, title, authors, **overrides):
+    """Put one Book Note on a Shelf and hand back the note."""
+    path = create_book_note(
+        _candidate(title=title, authors=authors),
+        vault_path,
+        overrides=overrides or None,
+    )
+    return BookNote.read(path)
+
+
+def _titles(result):
+    return [note.title for note in result.books]
+
+
+def test_a_title_query_finds_the_note(tmp_path):
+    # Given a Shelf holding one book
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When the Library is searched for its title
+    result = search_library(tmp_path, query="dune")
+
+    # Then it is found
+    assert _titles(result) == ["Dune"]
+    assert result.total == 1
+
+
+def test_an_author_alone_finds_their_books(tmp_path):
+    # Given two books by one author and one by another
+    _shelve(tmp_path, "The Way of Kings", ["Brandon Sanderson"])
+    _shelve(tmp_path, "Oathbringer", ["Brandon Sanderson"])
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When someone asks for "that Sanderson one" - a query with no title in it
+    result = search_library(tmp_path, query="sanderson")
+
+    # Then both of theirs come back. This is the case find_similar cannot serve:
+    # it returns nothing without a title, and treats an author as an exact
+    # equality filter rather than something to search on (ADR 0003).
+    assert sorted(_titles(result)) == ["Oathbringer", "The Way of Kings"]
+
+
+def test_the_tighter_title_outranks_the_one_that_merely_contains_it(tmp_path):
+    # Given two different books that share a word
+    _shelve(tmp_path, "Long Road to Mercy", ["David Baldacci"])
+    _shelve(tmp_path, "Mercy", ["Jodi Picoult"])
+
+    # When the shared word is searched for
+    result = search_library(tmp_path, query="mercy")
+
+    # Then both are offered, because deciding between them is not this layer's
+    # job (ADR 0003) - but the note the query describes wholly comes first.
+    assert _titles(result) == ["Mercy", "Long Road to Mercy"]
+
+
+def test_more_matched_words_outrank_fewer(tmp_path):
+    # Given a Shelf where one title answers more of the query than the other
+    _shelve(tmp_path, "The Way of Kings", ["Brandon Sanderson"])
+    _shelve(tmp_path, "Kings of the Wyld", ["Nicholas Eames"])
+
+    # When several words are searched for
+    result = search_library(tmp_path, query="way of kings")
+
+    # Then the note matching more of them ranks first
+    assert _titles(result)[0] == "The Way of Kings"
+
+
+def test_the_query_is_normalized_before_matching(tmp_path):
+    # Given a note whose title carries punctuation and capitals
+    _shelve(tmp_path, "Mistborn: The Final Empire", ["Brandon Sanderson"])
+
+    # When the query carries neither
+    result = search_library(tmp_path, query="MISTBORN final empire")
+
+    # Then it still matches, the same way every other comparison here normalizes
+    assert _titles(result) == ["Mistborn: The Final Empire"]
+
+
+def test_a_miss_is_a_miss(tmp_path):
+    # Given a Shelf that holds nothing like the query
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When something absent is searched for
+    result = search_library(tmp_path, query="neuromancer")
+
+    # Then nothing is invented (ADR 0003)
+    assert result.books == []
+    assert result.total == 0
+
+
+def test_a_status_narrows_the_search(tmp_path):
+    # Given the same author held at two different points in the reading cycle
+    _shelve(tmp_path, "Oathbringer", ["Brandon Sanderson"], status="Read")
+    _shelve(tmp_path, "The Way of Kings", ["Brandon Sanderson"], status="To Read")
+
+    # When the search is narrowed to what has been read
+    result = search_library(tmp_path, query="sanderson", status="Read")
+
+    # Then only that one comes back. Status is not fuzzy - it is a closed
+    # vocabulary the Library defines (ADR 0022) - so it filters rather than ranks.
+    assert _titles(result) == ["Oathbringer"]
+    assert result.total == 1
+
+
+def test_a_status_the_library_does_not_define_is_refused(tmp_path):
+    # Given a status outside the four the Library allows
+    # When it is used to narrow a search
+    # Then it is refused rather than silently matching nothing
+    with pytest.raises(InvalidFieldValue):
+        search_library(tmp_path, status="Finished")
+
+
+def test_omitting_the_query_lists_by_filter(tmp_path):
+    # Given a Shelf where one book is being read
+    _shelve(tmp_path, "Oathbringer", ["Brandon Sanderson"], status="Reading")
+    _shelve(tmp_path, "Dune", ["Frank Herbert"], status="To Read")
+
+    # When there is no query at all - "what am I reading?"
+    result = search_library(tmp_path, status="Reading")
+
+    # Then the filter alone answers it
+    assert _titles(result) == ["Oathbringer"]
+
+
+def test_omitting_everything_lists_the_whole_shelf(tmp_path):
+    # Given a Shelf of three books
+    for title in ("Dune", "Oathbringer", "Neuromancer"):
+        _shelve(tmp_path, title, ["Someone"])
+
+    # When nothing is asked for
+    result = search_library(tmp_path)
+
+    # Then the whole Shelf is counted, in a deterministic order
+    assert result.total == 3
+    assert _titles(result) == ["Dune", "Neuromancer", "Oathbringer"]
+
+
+def test_the_total_counts_matches_the_limit_did_not_return(tmp_path):
+    # Given more books than will be returned
+    for index in range(5):
+        _shelve(tmp_path, f"Dune {index}", ["Frank Herbert"])
+
+    # When the search is limited
+    result = search_library(tmp_path, query="dune", limit=2)
+
+    # Then the caller is told how many there really were, so a Surface can say
+    # "1,452 on the list, here are some" rather than implying it saw them all
+    assert len(result.books) == 2
+    assert result.total == 5
+
+
+def test_the_limit_is_capped(tmp_path):
+    # Given a Shelf and a caller asking for more than the ceiling
+    for index in range(3):
+        _shelve(tmp_path, f"Dune {index}", ["Frank Herbert"])
+
+    # When an absurd limit is requested
+    result = search_library(tmp_path, query="dune", limit=10_000)
+
+    # Then it is clamped rather than honoured. Reading a whole Library into a
+    # context window is the thing the cap exists to prevent.
+    assert result.limit == MAX_SEARCH_LIMIT
+
+
+def test_a_limit_of_zero_returns_nothing_but_still_counts(tmp_path):
+    # Given a Shelf holding matches
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When nothing is asked to be returned
+    result = search_library(tmp_path, query="dune", limit=0)
+
+    # Then the count still answers "how many", which is a real question
+    assert result.books == []
+    assert result.total == 1
+
+
+def test_a_note_without_a_title_is_skipped_rather_than_crashing(tmp_path):
+    # Given a Shelf holding a file with frontmatter but no title
+    (tmp_path / "broken.md").write_text(
+        "---\nlibris_id: 01J0000000000000000000000A\ntitle:\nauthors: []\n---\n",
+        encoding="utf-8",
+    )
+    _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When the Library is listed
+    result = search_library(tmp_path)
+
+    # Then the untitled note is passed over. Obsidian writes into this directory
+    # too, so a note Libris did not create is ordinary rather than exceptional.
+    assert _titles(result) == ["Dune"]
+
+
+def test_a_common_word_alone_does_not_make_a_match(tmp_path):
+    # Given a Shelf where one note shares only a common word with the query
+    _shelve(tmp_path, "The Way of Kings", ["Brandon Sanderson"])
+    _shelve(tmp_path, "The Silmarillion", ["J.R.R. Tolkien"])
+
+    # When a title carrying that word is searched for
+    result = search_library(tmp_path, query="the way of kings")
+
+    # Then the note matching on "the" alone is not offered. Otherwise a title
+    # with an article in it would report most of a 3,000-note Shelf as a match,
+    # and the total would stop meaning anything.
+    assert _titles(result) == ["The Way of Kings"]
+
+
+def test_a_query_of_only_common_words_is_taken_at_face_value(tmp_path):
+    # Given a note whose title really is a common word
+    _shelve(tmp_path, "The Road", ["Cormac McCarthy"])
+
+    # When that is all the person said
+    result = search_library(tmp_path, query="the")
+
+    # Then it still matches, rather than the guard swallowing the only query
+    # the person gave
+    assert _titles(result) == ["The Road"]
+
+
+def test_a_distinctive_word_outweighs_a_common_one(tmp_path):
+    # Given a Shelf where one word is everywhere, on notes short enough that
+    # brevity alone would float them to the top
+    for subject in ("Big", "New", "Old", "Best", "Grey"):
+        _shelve(tmp_path, f"{subject} Book", ["Ann Bell"])
+    _shelve(tmp_path, "Book", ["Ann Bell"])
+    _shelve(tmp_path, "Mistborn: The Final Empire", ["Brandon Sanderson"])
+
+    # When a query names both a common word and a rare one
+    result = search_library(tmp_path, query="mistborn book")
+
+    # Then the rare word decides. Counting matched words alone ties these at one
+    # apiece, and the tie then goes to the shortest note - which is the wrong
+    # book for a reason that has nothing to do with what was asked.
+    assert _titles(result)[0] == "Mistborn: The Final Empire"
+
+
+def test_conversational_filler_does_not_pull_in_unrelated_books(tmp_path):
+    # Given the Shelf someone would actually be talking about
+    _shelve(tmp_path, "The Final Empire: Mistborn Book 1", ["Brandon Sanderson"])
+    _shelve(tmp_path, "The Hot One", ["Lauren Blakely"])
+    _shelve(tmp_path, "Eat That Frog", ["Brian Tracy"])
+
+    # When someone says it the way a person says it
+    result = search_library(tmp_path, query="that mistborn one")
+
+    # Then only the book they described comes back. Measured against the real
+    # Shelf, "that" and "one" appear in 39 and 50 notes while "mistborn" appears
+    # in 3, and weighting them alike returned 91 matches with no Mistborn among
+    # the first six.
+    assert _titles(result) == ["The Final Empire: Mistborn Book 1"]
+    assert result.total == 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,6 +9,7 @@ from datetime import date
 
 import pytest
 
+from libris import service
 from libris.api import BookCandidate
 from libris.markdown import (
     BookNote,  # noqa: F401
@@ -919,3 +920,66 @@ def test_confirming_writes_even_over_a_near_match(tmp_path):
     # carried.
     assert result.outcome is Outcome.CREATED
     assert len(list(tmp_path.glob("*.md"))) == 2
+
+
+def test_an_empty_string_does_not_clear_a_field(tmp_path):
+    # Given a book carrying a start date
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], date_started="2019-04-01")
+
+    # When an empty string arrives for it
+    # Then it is refused. Null is the obvious way to erase a field by accident;
+    # the empty string is the quiet one, and it passes every vocabulary check
+    # because the field has no vocabulary.
+    with pytest.raises(ValueError):
+        update_book(tmp_path, note.libris_id, {"date_started": ""})
+    written = _read_back(tmp_path, note.libris_id).frontmatter["date_started"]
+    assert str(written) == "2019-04-01"
+
+
+def test_an_empty_list_does_not_clear_a_multi_valued_field(tmp_path):
+    # Given a book recorded in two formats
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], format=["Physical", "Ebook"])
+
+    # When an empty list arrives for it
+    # Then it is refused. This one is quieter still: an empty list passes
+    # validation entry by entry because there are no entries, and then
+    # normalize_field_value turns it into None - a clear nobody asked for.
+    with pytest.raises(ValueError):
+        update_book(tmp_path, note.libris_id, {"format": []})
+    assert _read_back(tmp_path, note.libris_id).frontmatter["format"] == [
+        "Physical",
+        "Ebook",
+    ]
+
+
+def test_a_rating_of_zero_is_a_value_not_an_absence(tmp_path):
+    # Given a book with no rating
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When it is rated zero
+    update_book(tmp_path, note.libris_id, {"rating": 0})
+
+    # Then it is written. Emptiness is tested by type rather than truthiness,
+    # because a zero and a False are things a reader can mean.
+    assert _read_back(tmp_path, note.libris_id).frontmatter["rating"] == 0
+
+
+def test_listing_by_filter_does_not_tokenize_every_note(tmp_path, monkeypatch):
+    # Given a Shelf and a count of how often a note's words are split
+    for title in ("Dune", "Piranesi", "Mercy"):
+        _shelve(tmp_path, title, ["Someone"], status="To Read")
+
+    calls = []
+    real = service._search_tokens
+    monkeypatch.setattr(
+        service, "_search_tokens", lambda text: (calls.append(text), real(text))[1]
+    )
+
+    # When the Library is listed by status alone
+    result = service.search_library(tmp_path, status="To Read")
+
+    # Then nothing was tokenized. Listing "To Read" walks 1,452 notes on the
+    # real Shelf, and splitting every title and author to then sort them
+    # alphabetically is work with no reader.
+    assert len(result.books) == 3
+    assert calls == []

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -835,3 +835,87 @@ def test_the_body_is_left_exactly_as_it_was(tmp_path):
     # frontmatter and nothing else (ADR 0023), and that line is the shape of the
     # bug in #92.
     assert note.path.read_text(encoding="utf-8").endswith(body)
+
+
+# --- adding over a Near Match (ADR 0026) ---
+
+
+def test_a_near_match_stops_the_write_when_asked_to(tmp_path):
+    # Given a Library already holding something that may be this Book
+    create_book_note(_candidate(title="The Brass Verdict: A Novel"), tmp_path)
+
+    # When a Surface that wants to ask first tries to add it
+    result = add_book(
+        tmp_path, _candidate(title="The Brass Verdict"), stop_on_near_match=True
+    )
+
+    # Then nothing is written and the near matches come back for a person to
+    # settle. Over MCP the caller is a model, so a near match reported after the
+    # write arrives too late to be a question (ADR 0026).
+    assert result.outcome is Outcome.NEEDS_CONFIRMATION
+    assert [n.title for n in result.near_matches] == ["The Brass Verdict: A Novel"]
+    assert result.libris_id is None
+    assert len(list(tmp_path.glob("*.md"))) == 1
+
+
+def test_a_near_match_does_not_stop_the_write_by_default(tmp_path):
+    # Given the same Library
+    create_book_note(_candidate(title="The Brass Verdict: A Novel"), tmp_path)
+
+    # When a Surface with a person already looking at the near matches adds it -
+    # which is what the extension's popup does
+    result = add_book(tmp_path, _candidate(title="The Brass Verdict"))
+
+    # Then it writes. The two adapters differ deliberately, and this is the REST
+    # half of ADR 0026.
+    assert result.outcome is Outcome.CREATED
+    assert len(list(tmp_path.glob("*.md"))) == 2
+
+
+def test_stopping_is_not_triggered_when_nothing_is_near(tmp_path):
+    # Given a Library holding something else entirely
+    create_book_note(_candidate(title="Dune"), tmp_path)
+
+    # When an unrelated Book is added by a Surface that would have asked
+    result = add_book(
+        tmp_path, _candidate(title="Neuromancer"), stop_on_near_match=True
+    )
+
+    # Then it writes without a question. The confirmation is the price of an
+    # ambiguity, not of every add.
+    assert result.outcome is Outcome.CREATED
+    assert result.near_matches == []
+
+
+def test_a_book_already_held_is_reported_as_held_not_as_a_question(tmp_path):
+    # Given a Library that exactly holds this Book
+    create_book_note(_candidate(isbn="9780441013593"), tmp_path)
+
+    # When it is added again by a Surface that would have asked
+    result = add_book(
+        tmp_path, _candidate(isbn="9780441013593"), stop_on_near_match=True
+    )
+
+    # Then the exact check answers first. Asking "did you mean this one?" about a
+    # Book the Library provably already holds is a question with no useful answer.
+    assert result.outcome is Outcome.ALREADY_PRESENT
+    assert result.libris_id is not None
+
+
+def test_confirming_writes_even_over_a_near_match(tmp_path):
+    # Given a near match that stopped a first attempt
+    create_book_note(_candidate(title="The Brass Verdict: A Novel"), tmp_path)
+    stopped = add_book(
+        tmp_path, _candidate(title="The Brass Verdict"), stop_on_near_match=True
+    )
+    assert stopped.outcome is Outcome.NEEDS_CONFIRMATION
+
+    # When the person says it is a different Book
+    result = add_book(
+        tmp_path, _candidate(title="The Brass Verdict"), stop_on_near_match=False
+    )
+
+    # Then it writes. Confirmation is the second call, not a flag the first one
+    # carried.
+    assert result.outcome is Outcome.CREATED
+    assert len(list(tmp_path.glob("*.md"))) == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -983,3 +983,50 @@ def test_listing_by_filter_does_not_tokenize_every_note(tmp_path, monkeypatch):
     # alphabetically is work with no reader.
     assert len(result.books) == 3
     assert calls == []
+
+
+def test_a_format_written_as_a_bare_string_is_repaired_not_refused(tmp_path):
+    # Given a note whose format is a bare string, which two notes on the real
+    # Shelf hold and which Obsidian can write at any time (ADR 0017)
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+    raw = note.path.read_text(encoding="utf-8")
+    note.path.write_text(
+        raw.replace("format: null", "format: Physical", 1), encoding="utf-8"
+    )
+
+    # When a second format is recorded
+    update_book(tmp_path, note.libris_id, {"format": ["Physical", "Audiobook"]})
+
+    # Then the write lands
+    assert _read_back(tmp_path, note.libris_id).frontmatter["format"] == [
+        "Physical",
+        "Audiobook",
+    ]
+
+
+def test_a_format_is_repaired_before_it_is_judged(tmp_path):
+    # Given a format in a shape and case the Library repairs elsewhere
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"])
+
+    # When it arrives that way
+    update_book(tmp_path, note.libris_id, {"format": ["physical", "EBOOK"]})
+
+    # Then it is repaired and written, rather than refused for a spelling the
+    # Library corrects on every other pass. Validating before normalizing judged
+    # one value and wrote a different one.
+    assert _read_back(tmp_path, note.libris_id).frontmatter["format"] == [
+        "Physical",
+        "Ebook",
+    ]
+
+
+def test_a_format_of_nothing_recognisable_is_still_refused(tmp_path):
+    # Given a format holding no value the Library defines
+    note = _shelve(tmp_path, "Dune", ["Frank Herbert"], format=["Physical"])
+
+    # When it arrives
+    # Then it is refused rather than normalized away to nothing. Repairing before
+    # judging must not become a second route to clearing a field.
+    with pytest.raises(ValueError):
+        update_book(tmp_path, note.libris_id, {"format": ["papyrus"]})
+    assert _read_back(tmp_path, note.libris_id).frontmatter["format"] == ["Physical"]

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -309,3 +309,37 @@ def test_a_note_deleted_between_the_listing_and_the_read_is_dropped(tmp_path):
 
     # Then the answer holds what survives, rather than raising
     assert [n.title for n in index.notes()] == ["Dune"]
+
+
+def test_resolving_an_identity_does_not_re_read_the_shelf(tmp_path, counted_reads):
+    # Given a Shelf that has already been read once
+    paths = [_shelve(tmp_path, title) for title in ("Dune", "Piranesi", "Mercy")]
+    wanted = BookNote.read(paths[1]).libris_id
+    shelf.index_for(tmp_path).notes()
+    counted_reads.clear()
+
+    # When an identity is resolved, twice
+    assert service.find_by_libris_id(tmp_path, wanted).libris_id == wanted
+    assert service.find_by_libris_id(tmp_path, wanted).libris_id == wanted
+
+    # Then nothing was parsed again. Measured against the real Shelf this was
+    # 5.5 seconds per call against 27 milliseconds through the index, and
+    # update_book resolves an identity on every write.
+    assert counted_reads == []
+
+
+def test_resolving_an_unknown_identity_does_not_re_read_the_shelf(
+    tmp_path, counted_reads
+):
+    # Given a Shelf that has already been read once
+    for title in ("Dune", "Piranesi", "Mercy"):
+        _shelve(tmp_path, title)
+    shelf.index_for(tmp_path).notes()
+    counted_reads.clear()
+
+    # When an identity nothing answers for is resolved - the case that has to
+    # look at every note before it can say no
+    assert service.find_by_libris_id(tmp_path, "01J0000000000000000000000A") is None
+
+    # Then it still costs nothing. This was the worst case at 10.4 seconds.
+    assert counted_reads == []

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -43,12 +47,106 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -157,6 +255,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +361,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -228,12 +389,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -291,8 +478,35 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "libris"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -304,6 +518,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
+]
 server = [
     { name = "fastapi" },
     { name = "uvicorn" },
@@ -312,6 +529,7 @@ server = [
 [package.dev-dependencies]
 dev = [
     { name = "ipython" },
+    { name = "libris", extra = ["mcp", "server"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -320,6 +538,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
+    { name = "libris", extra = ["mcp", "server"] },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -328,6 +547,7 @@ test = [
 requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.1.1" },
     { name = "python-ulid", specifier = ">=4.0.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.1.1" },
@@ -335,17 +555,19 @@ requires-dist = [
     { name = "typer", specifier = ">=0.24.1" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30" },
 ]
-provides-extras = ["server"]
+provides-extras = ["server", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "ipython" },
+    { name = "libris", extras = ["server", "mcp"] },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
 lint = [{ name = "ruff" }]
 test = [
+    { name = "libris", extras = ["server", "mcp"] },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov" },
 ]
@@ -375,12 +597,62 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -450,6 +722,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -552,6 +833,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -582,12 +877,40 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "python-ulid"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/41/65079023c81491a21799c0120bce5925366b6913596bf797806f19973290/python_ulid-4.0.1.tar.gz", hash = "sha256:bbeec02556190bb9dc3401faa7268696acbfbe7b6db9908c155dc3548629f20c", size = 101683, upload-time = "2026-07-20T15:21:41.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/15/8b39b36f55b6618ec4ca9b55134dcfd9c04cecbc72709f5d8e6bdebed9cd/python_ulid-4.0.1-py3-none-any.whl", hash = "sha256:6f1d69ceb97e99fe542df8476ebcd7a668284bf53ee14b3106bcc6a341a95ed9", size = 14609, upload-time = "2026-07-20T15:21:40.214Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -649,6 +972,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -659,6 +996,102 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -693,6 +1126,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e1/8a41e88e825ea26c44333897c7ffe35fe60153a2cfc097a5bd1d209ad281/sse_starlette-3.4.10.tar.gz", hash = "sha256:c6c87280d8feb4e55a8d79633782766b9cac6a26da5c79a145d00aa404117a86", size = 33720, upload-time = "2026-09-03T09:36:24.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/3c/96018a51c7301a64f7b0579d9ce8f9b69dd39ca8ed5aa100ba3feadee503/sse_starlette-3.4.10-py3-none-any.whl", hash = "sha256:710f5f5b0527409903a22a91699db02f76f4c2eb9204e882e4ee7cada76bdf75", size = 17120, upload-time = "2026-09-03T09:36:22.56Z" },
 ]
 
 [[package]]
@@ -735,6 +1181,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,6 @@ server = [
 [package.dev-dependencies]
 dev = [
     { name = "ipython" },
-    { name = "libris", extra = ["mcp", "server"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -538,7 +537,6 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "libris", extra = ["mcp", "server"] },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -560,14 +558,12 @@ provides-extras = ["server", "mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "ipython" },
-    { name = "libris", extras = ["server", "mcp"] },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
 lint = [{ name = "ruff" }]
 test = [
-    { name = "libris", extras = ["server", "mcp"] },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov" },
 ]


### PR DESCRIPTION
Closes #93.

Four MCP tools over the existing service layer, so an assistant can search the Library and move books through the reading cycle. Designed in a grilling session first; the reasoning lives in ADRs 0023-0027 rather than in this description.

## The tools

| Tool | Takes | Returns |
| --- | --- | --- |
| `search_library` | `query?`, `status?`, `limit` | `{total, books[]}` with reading state on each |
| `find_book` | `title?`, `authors?`, `isbn?` | Slim Book Candidates |
| `add_book` | `google_books_id`, overrides, `confirm?` | `{outcome, book, guarantee, near_matches}` |
| `update_book` | `libris_id`, reader fields | `{outcome, book, derived}` |

No tool reads or writes a note body. That is the boundary the rest sit on (ADR 0023): MCP moves books through the reading cycle, Obsidian holds what you thought about them.

## Decisions worth reviewing

- **ADR 0023** - frontmatter only. Writing a dictated remark means parsing the body to find where `## Notes` ends, and an append the tool cannot read back is one nobody can verify.
- **ADR 0024** - marking a book Read stamps today's date, and the response says it did. This Shelf already shows the alternative: 82 notes share `date_finished: 2020-12-11`, which is one bulk operation preserved since as fact.
- **ADR 0025** - `add_book` names a candidate by id and the server re-fetches it, where REST echoes the whole record back. A model re-emitting metadata token by token can quietly alter what gets written, and ADR 0012 makes Libris the owner of the title.
- **ADR 0026** - an MCP add stops on a Near Match and asks; the extension reports and writes. Different callers: the popup has a person looking at the near matches before they press the button, MCP does not.
- **ADR 0027** - words are weighed by rarity, and conversational filler is a curated list. Written after measurement, not before.

## Two defects the real Shelf found

Both invisible to the test suite, which uses two-note fixtures.

**Search was useless for the query it was designed for.** `"that mistborn one"` returned 91 matches with no Mistborn among the first six: `one` appears in 50 notes, `mistborn` in 3, and equal weighting made them tie. Weighting alone does not fix it either, since a note matching `that` and `one` then outscores one matching `mistborn` - and no frequency threshold separates them, because `poems` appears in 51 notes and `one` in 50. Curated filler plus rarity weighting; it now returns exactly the three Mistborn books.

**`find_by_libris_id` re-read the whole Shelf on every call** - 5.5s for a live id, 10.4s for an unknown one - while `find_existing` and `find_similar` had already moved to the revalidated index. `update_book` resolves an identity on every write, so marking a book Read would have taken six seconds forever. Now 0.05s. Pinned by tests that count parses rather than time.

## Known, deliberate gaps

- **The first tool call takes about 16 seconds** against a 3,000-note Shelf; later ones take 60ms. There is no startup warm-up on purpose: a blocking one made `initialize` take 49.4s, and a client that times out there records the server as failed rather than slow. Measurements and the path out are in #94, which this makes considerably more urgent.
- **No field can be cleared.** `null` is refused rather than treated as "empty this", because a model emitting `null` for "unchanged" would erase a field nobody mentioned. So "drop the priority on that one" has no answer yet. Reversible in the safe direction.
- **A book Google Books does not hold cannot be added** over MCP.

## Shape changed from the spec in #93

`update_book` takes named optional parameters rather than a `fields` mapping. Still one tool rather than a verb per field, but a `dict[str, Any]` has nowhere to carry the vocabulary enums, and ADR 0022 requires the model to read them from the schema. The two cannot both hold.

## Verification

447 tests, ruff clean. Beyond the suite, driven as a real stdio subprocess against the 3,063-note Shelf: connect 4.4s, first call 16.3s, later calls 61ms, and `"that mistborn one i just finished"` returns the three Mistborn books. Raw JSON-RPC over the pipe confirms every stdout line parses as JSON and stderr stays empty - stdout is the protocol channel, and `libris mcp` writes its warnings to stderr for that reason. `update_book` was exercised against copies of 40 real Book Notes: bodies came back byte-identical and all 19 fields survived in order.

Registration is documented for Claude Code and for an `mcp.json`, both using `uv run --directory` - a server registered once and started daily is where a stale `uv tool` snapshot hides longest.

Version to 0.5.0, with `extension/manifest.json`. Rebased onto main after #91 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkUSHLhNCxXBfjEtRGaK9z