### PR TITLE
fix: keep a note's body indented through a repair pass

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Libris",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Add the book on this page to your Libris reading list.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.5.1"
+version = "0.5.2"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -31,6 +31,7 @@ from .markdown import (
     list_books,
     read_frontmatter,
     rename_book_file,
+    split_frontmatter,
     update_book_status,
     update_frontmatter_from_book,
 )
@@ -594,12 +595,10 @@ def _append_auto_enrich_note(
     content = file_path.read_text(encoding="utf-8")
 
     # Add 'review' to the tags in frontmatter
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if not match:
-        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
+    split = split_frontmatter(content)
 
-    if match:
-        data = yaml.safe_load(match.group(1))
+    if split is not None:
+        data = yaml.safe_load(split[0])
         if isinstance(data, dict):
             tags = data.get("tags")
             if isinstance(tags, str):
@@ -615,8 +614,8 @@ def _append_auto_enrich_note(
             else:
                 data["tags"] = ["review"]
             new_fm = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-            rest = match.group(2)
-            content = f"---\n{new_fm}\n---\n{rest.lstrip()}"
+            # The body goes back as it was read, leading newlines and all (#99).
+            content = f"---\n{new_fm}\n---\n{split[1]}"
 
     # Append the callout note to the body
     note = (

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -281,7 +281,7 @@ class FrontmatterUnreadable(ValueError):
     """A Book Note's frontmatter could not be parsed, so it was not written to."""
 
 
-def _split_frontmatter(content: str) -> Optional[tuple[str, str]]:
+def split_frontmatter(content: str) -> Optional[tuple[str, str]]:
     """Split a note into its frontmatter block and everything after it.
 
     Deliberately not a regex. The body is returned exactly as it was found -
@@ -325,7 +325,7 @@ def set_frontmatter_fields(file_path: Path, updates: Dict[str, Any]) -> None:
             not the place to rebuild a broken note.
     """
     content = file_path.read_text(encoding="utf-8")
-    split = _split_frontmatter(content)
+    split = split_frontmatter(content)
     if split is None:
         raise FrontmatterUnreadable(f"{file_path.name} has no readable frontmatter.")
 
@@ -427,17 +427,16 @@ def ensure_frontmatter_fields(
     """
     content = file_path.read_text(encoding="utf-8")
 
-    # Use a more robust regex to find the frontmatter block
-    # Matches --- at start of file, then content, then --- on its own line
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if not match:
-        # Fallback for files that might not have a newline after the closing ---
-        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
-        if not match:
-            return False, None
+    # Split by line rather than by regex. The regex this replaced ended
+    # `---\s*\n?(.*)`, and `\s*` is greedy over all whitespace: on a body opening
+    # with an indented code block it ate the blank line and the next line's
+    # indentation together, so a repair pass turned the first line of the block
+    # into a paragraph (#99).
+    split = split_frontmatter(content)
+    if split is None:
+        return False, None
 
-    frontmatter_yaml = match.group(1)
-    rest_of_content = match.group(2)
+    frontmatter_yaml, rest_of_content = split
 
     try:
         data = yaml.safe_load(frontmatter_yaml)
@@ -502,14 +501,16 @@ def ensure_frontmatter_fields(
         and stripped_content.startswith("## Notes")
         and not re.search(r"(?m)^#\s+", stripped_content)
     ):
-        rest_of_content = f"# {title}\n\n{rest_of_content.lstrip()}"
+        # Deliberately composing new content here, so the leading blank lines go
+        # rather than surviving between the heading and the body it introduces.
+        rest_of_content = f"\n# {title}\n\n{rest_of_content.lstrip()}"
         updated = True
 
     if updated and not dry_run:
-        # Use dump but ensure we don't add unnecessary trailing newlines or spaces
         new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-        # Ensure there is exactly one newline before and after the rest of the content
-        new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content.lstrip()}"
+        # The body goes back exactly as it was read - it carries its own leading
+        # newlines, and stripping them was what cost an indented block its indent.
+        new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content}"
         file_path.write_text(new_content, encoding="utf-8")
 
     return updated, data
@@ -648,14 +649,11 @@ def read_frontmatter(file_path: Path) -> Optional[Dict[str, Any]]:
 def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
     """Fill null frontmatter fields from a candidate. Returns True if changed."""
     content = file_path.read_text(encoding="utf-8")
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if not match:
-        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
-        if not match:
-            return False
+    split = split_frontmatter(content)
+    if split is None:
+        return False
 
-    frontmatter_yaml = match.group(1)
-    rest_of_content = match.group(2)
+    frontmatter_yaml, rest_of_content = split
 
     try:
         data = yaml.safe_load(frontmatter_yaml)
@@ -681,7 +679,9 @@ def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
         and stripped_content.startswith("## Notes")
         and not re.search(r"(?m)^#\s+", stripped_content)
     ):
-        rest_of_content = f"# {title}\n\n{rest_of_content.lstrip()}"
+        # Deliberately composing new content here, so the leading blank lines go
+        # rather than surviving between the heading and the body it introduces.
+        rest_of_content = f"\n# {title}\n\n{rest_of_content.lstrip()}"
         updated = True
 
     # Add description to body if missing
@@ -696,7 +696,9 @@ def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
 
     if updated:
         new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-        new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content.lstrip()}"
+        # As in ensure_frontmatter_fields: the body carries its own leading
+        # newlines, and stripping them cost an indented block its indent (#99).
+        new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content}"
         file_path.write_text(new_content, encoding="utf-8")
         return True
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -255,7 +255,7 @@ def create_book_note(
 
 
 def update_book_status(file_path: Path, new_status: str) -> None:
-    """Set the status in a Book Note's frontmatter, leaving the body untouched.
+    r"""Set the status in a Book Note's frontmatter, leaving the body untouched.
 
     This used to be an unanchored, uncounted `re.sub` for `r"(status:\s*)(.*)"` over
     the whole file, on the reasoning that a regex disturbs a note less than a

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -186,6 +186,59 @@ def test_update_book_status_refuses_a_note_it_cannot_parse(tmp_path):
     assert file_path.read_text(encoding="utf-8") == original
 
 
+# A body whose first element is an indented code block - four spaces is how
+# Markdown marks one without a fence, so losing them turns the first line into a
+# paragraph and leaves the rest as code (#99).
+_INDENTED_BODY = """
+    from libris import shelf
+    shelf.index_for(vault)
+
+A note about the snippet above.
+"""
+
+
+def test_ensure_frontmatter_fields_keeps_the_body_indented(tmp_path):
+    # Given a note whose body opens with an indented code block, and enough
+    # missing fields that the repair pass will rewrite it
+    file_path = tmp_path / "indented.md"
+    file_path.write_text(
+        "---\ntitle: A Book\nstatus: To Read\n---\n" + _INDENTED_BODY,
+        encoding="utf-8",
+    )
+
+    # When the repair pass runs, as `libris cleanup` runs it over every note
+    from libris.markdown import ensure_frontmatter_fields
+
+    updated, _ = ensure_frontmatter_fields(file_path)
+
+    # Then the code block is still a code block
+    assert updated
+    body = file_path.read_text(encoding="utf-8").split("\n---\n", 1)[1]
+    assert body == _INDENTED_BODY
+
+
+def test_update_frontmatter_from_book_keeps_the_body_indented(tmp_path):
+    # Given the same note, missing the fields a candidate would fill
+    file_path = tmp_path / "indented_enrich.md"
+    file_path.write_text(
+        "---\ntitle: A Book\nauthors: null\nisbn: null\n---\n" + _INDENTED_BODY,
+        encoding="utf-8",
+    )
+
+    # When enrichment fills them from a candidate
+    from libris.markdown import update_frontmatter_from_book
+
+    changed = update_frontmatter_from_book(
+        file_path,
+        BookCandidate(title="A Book", authors=["An Author"], isbn="9780000000001"),
+    )
+
+    # Then the reader's code block survives the write
+    assert changed
+    body = file_path.read_text(encoding="utf-8").split("\n---\n", 1)[1]
+    assert body == _INDENTED_BODY
+
+
 def test_ensure_frontmatter_fields(tmp_path):
     file_path = tmp_path / "legacy_book.md"
     file_path.write_text("""---


### PR DESCRIPTION
Closes #99.

A Book Note whose body opens with an indented code block lost the indent on its
first line and kept it on the rest, so Markdown rendered line one as a paragraph
and the remainder as code:

```
    from libris import shelf      ->  from libris import shelf
    shelf.index_for(vault)        ->      shelf.index_for(vault)
```

`libris cleanup` runs this over every note in the vault, so unlike #92 this one is
not latent - any note whose body opens with an indented block has already been
through it.

## The issue named the wrong cause, and I wrote the issue

#99 blamed `rest_of_content.lstrip()` and proposed `lstrip("\n")`. That fixes
nothing. The regex these functions split on ends `---\s*\n?(.*)`, and `\s*` is
greedy over all whitespace, so it eats the blank line and the next line's
indentation together - before `lstrip` is ever reached:

```
original body:      '\n    from libris import shelf\n    shelf.index_for(v)\n'
regex group(2):     'from libris import shelf\n    shelf.index_for(v)\n'
rest.lstrip("\n"):  'from libris import shelf\n    shelf.index_for(v)\n'
```

Corrected on the issue rather than quietly fixed, since the wrong reasoning was
published there.

## The fix

The split moves to `split_frontmatter`, which walks lines instead of matching a
pattern and returns the body exactly as it was found. Three functions change:
`ensure_frontmatter_fields`, `update_frontmatter_from_book`, and
`_append_auto_enrich_note`. The write side drops its `lstrip` too - the body
already carries its own leading newlines, and re-adding them is what made the
strip look necessary.

The two call sites that compose a heading keep their `lstrip`: those build new
content rather than carrying old content across, and the comment now says so.

`_split_frontmatter` loses its underscore, since three modules read notes through
it now. That makes this a partial execution of #101 rather than a change
independent of it; what remains there is `read_frontmatter`, `merge.py:40`,
`importer.py:214`, and the two `migrate.py` sites.

Before and after on the original repro:

```
before:  ---\r\n    from libris import shelf        indent gone, blank line gone
after:   ---\r\n\r\n    from libris import shelf    both preserved
```

(The `\r\n` is #100, deliberately untouched here.)

## Also included: a raw-string fix

Separate commit. `050cad3`, which landed on main from a Copilot Autofix suggestion
accepted in the GitHub UI, put `r"(status:\s*)(.*)"` inside a **non-raw** docstring:

```
SyntaxError: "\s" is an invalid escape sequence. Did you mean "\\s"?
```

CI does not catch it - ruff's `select` is `["E", "F", "S", "I"]` and invalid-escape
is `W605`, in the `W` family. Making the docstring raw fixes it. Adding `W` to the
select would catch the next one; not done here, since it wants its own look at
whatever else it flags.

## Testing

- New: a note whose body opens with a four-space indented code block keeps it
  through `ensure_frontmatter_fields`.
- New: the same through `update_frontmatter_from_book`.
- 460 tests pass with all extras; `ruff check` and `ruff format --check` clean.
- Version 0.5.1 -> 0.5.2 in `pyproject.toml` and `extension/manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwZ4KHT6qBi49NGGuXemoM
