### PR TITLE
refactor: one frontmatter reader, and a writer that keeps a note's line endings

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Libris",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Add the book on this page to your Libris reading list.",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["http://127.0.0.1:8787/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libris"
-version = "0.5.2"
+version = "0.5.3"
 description = "A simple CLI tool to track your reading list in Obsidian"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/libris/cli.py
+++ b/src/libris/cli.py
@@ -34,6 +34,7 @@ from .markdown import (
     split_frontmatter,
     update_book_status,
     update_frontmatter_from_book,
+    write_note,
 )
 from .matching import (
     best_match,
@@ -624,7 +625,7 @@ def _append_auto_enrich_note(
         f'> Query: "{original_query}" → Matched: "{matched_title}"\n'
         f"> Please verify this is the correct book.\n"
     )
-    file_path.write_text(content.rstrip() + note + "\n", encoding="utf-8")
+    write_note(file_path, content.rstrip() + note + "\n")
 
 
 def _enrich_interactive(file_path: Path, results: list | None = None) -> bool:

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -15,6 +15,7 @@ from .markdown import (
     list_books,
     split_frontmatter,
     update_book_status,
+    write_note,
 )
 from .matching import normalize_for_match
 
@@ -233,7 +234,7 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]) -> bool:
     # The body goes back as it was read. It carries its own leading newlines now
     # that the split preserves them, so stripping would delete a blank line the
     # reader put there (#99).
-    path.write_text(f"---\n{new_frontmatter}\n---\n{rest_of_content}", encoding="utf-8")
+    write_note(path, f"---\n{new_frontmatter}\n---\n{rest_of_content}")
     return True
 
 

--- a/src/libris/importer.py
+++ b/src/libris/importer.py
@@ -1,7 +1,6 @@
 """Import books from external sources (currently Audible JSON) into the vault."""
 
 import json
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -14,6 +13,7 @@ from .markdown import (
     FrontmatterUnreadable,
     create_book_note,
     list_books,
+    split_frontmatter,
     update_book_status,
 )
 from .matching import normalize_for_match
@@ -211,11 +211,11 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]) -> bool:
         return True
 
     content = path.read_text(encoding="utf-8")
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if match is None:
+    split = split_frontmatter(content)
+    if split is None:
         return False
 
-    frontmatter_yaml, rest_of_content = match.group(1), match.group(2)
+    frontmatter_yaml, rest_of_content = split
     try:
         data = yaml.safe_load(frontmatter_yaml)
     except yaml.YAMLError:
@@ -230,8 +230,10 @@ def _apply_updates(path: Path, book: ImportBook, updates: List[str]) -> bool:
 
     data["format"] = book.format
     new_frontmatter = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-    content_part = rest_of_content.lstrip("\n")
-    path.write_text(f"---\n{new_frontmatter}\n---\n{content_part}", encoding="utf-8")
+    # The body goes back as it was read. It carries its own leading newlines now
+    # that the split preserves them, so stripping would delete a blank line the
+    # reader put there (#99).
+    path.write_text(f"---\n{new_frontmatter}\n---\n{rest_of_content}", encoding="utf-8")
     return True
 
 

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -634,13 +634,11 @@ def find_duplicates(vault_path: Path) -> list[list[Path]]:
 def read_frontmatter(file_path: Path) -> Optional[Dict[str, Any]]:
     """Read and return the frontmatter dict from a markdown file, or None."""
     content = file_path.read_text(encoding="utf-8")
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if not match:
-        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
-        if not match:
-            return None
+    split = split_frontmatter(content)
+    if split is None:
+        return None
     try:
-        data = yaml.safe_load(match.group(1))
+        data = yaml.safe_load(split[0])
         return data if isinstance(data, dict) else None
     except Exception:
         return None

--- a/src/libris/markdown.py
+++ b/src/libris/markdown.py
@@ -250,7 +250,7 @@ def create_book_note(
     yaml_content = yaml.dump(frontmatter, sort_keys=False, allow_unicode=True)
 
     body = render_body(book.title, "", book.description)
-    file_path.write_text(f"---\n{yaml_content}---\n\n{body}", encoding="utf-8")
+    write_note(file_path, f"---\n{yaml_content}---\n\n{body}")
     return file_path
 
 
@@ -304,6 +304,54 @@ def split_frontmatter(content: str) -> Optional[tuple[str, str]]:
     return None
 
 
+def note_newline(path: Path) -> str:
+    """The line ending a Book Note already uses.
+
+    Args:
+        path: The Book Note. It need not exist.
+
+    Returns:
+        The note's dominant line ending. A note that does not exist yet, or holds
+        no line at all, gets the platform's - there is nothing to preserve, and
+        creating a note is not the same act as rewriting one.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return os.linesep
+
+    crlf = raw.count(b"\r\n")
+    bare_lf = raw.count(b"\n") - crlf
+    if not crlf and not bare_lf:
+        return os.linesep
+    return "\r\n" if crlf >= bare_lf else "\n"
+
+
+def write_note(path: Path, content: str) -> None:
+    """Write a Book Note, keeping the line endings it already had.
+
+    `Path.write_text` leaves `newline=None`, and that translates every "\\n" to
+    `os.linesep` on the way out. It made every write platform-dependent: this
+    Shelf is stored CRLF, so reading a note on macOS and writing it back turned
+    all 3,059 of them into LF and showed every line as changed (#100). Writing
+    bytes takes the platform out of it.
+
+    The content is normalised to "\\n" before the note's own ending is applied,
+    because applying "\\r\\n" to text that already holds it is what produced
+    "\\r\\r\\n" on 1,345 notes once already - see the comment in
+    `migrate.plan_format_note_migration`.
+
+    Args:
+        path: The Book Note to write.
+        content: The note's full text.
+    """
+    newline = note_newline(path)
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+    if newline != "\n":
+        content = content.replace("\n", newline)
+    path.write_bytes(content.encode("utf-8"))
+
+
 def set_frontmatter_fields(file_path: Path, updates: Dict[str, Any]) -> None:
     """Set named frontmatter fields on a Book Note, leaving the body untouched.
 
@@ -339,7 +387,7 @@ def set_frontmatter_fields(file_path: Path, updates: Dict[str, Any]) -> None:
 
     data.update(updates)
     rendered = yaml.dump(data, sort_keys=False, allow_unicode=True).strip()
-    file_path.write_text("---\n" + rendered + "\n---\n" + body, encoding="utf-8")
+    write_note(file_path, "---\n" + rendered + "\n---\n" + body)
 
 
 def list_books(vault_path: Path):
@@ -511,7 +559,7 @@ def ensure_frontmatter_fields(
         # The body goes back exactly as it was read - it carries its own leading
         # newlines, and stripping them was what cost an indented block its indent.
         new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content}"
-        file_path.write_text(new_content, encoding="utf-8")
+        write_note(file_path, new_content)
 
     return updated, data
 
@@ -697,7 +745,7 @@ def update_frontmatter_from_book(file_path: Path, book: BookCandidate) -> bool:
         # As in ensure_frontmatter_fields: the body carries its own leading
         # newlines, and stripping them cost an indented block its indent (#99).
         new_content = f"---\n{new_frontmatter}\n---\n{rest_of_content}"
-        file_path.write_text(new_content, encoding="utf-8")
+        write_note(file_path, new_content)
         return True
 
     return False
@@ -731,7 +779,7 @@ def update_wikilinks_in_vault(
             new_content = new_content.replace(f"[[{old_stem}#", f"[[{new_stem}#")
             new_content = new_content.replace(f"[[{old_stem}^", f"[[{new_stem}^")
             if new_content != content:
-                md_file.write_text(new_content, encoding="utf-8")
+                write_note(md_file, new_content)
                 updated_count += 1
     return updated_count
 

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -16,6 +16,7 @@ from .markdown import (
     read_frontmatter,
     split_frontmatter,
     tidy_author,
+    write_note,
 )
 from .note_format import (
     MULTI_VALUED_FIELDS,
@@ -340,7 +341,7 @@ def write_merged_book(
         merged_frontmatter, sort_keys=False, allow_unicode=True
     ).strip()
     content = f"---\n{frontmatter_yaml}\n---\n{merged_body.lstrip()}"
-    primary_path.write_text(content, encoding="utf-8")
+    write_note(primary_path, content)
 
 
 def delete_secondary_file(secondary_path: Path) -> None:

--- a/src/libris/merge.py
+++ b/src/libris/merge.py
@@ -11,7 +11,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-from .markdown import _normalize_author, read_frontmatter, tidy_author
+from .markdown import (
+    _normalize_author,
+    read_frontmatter,
+    split_frontmatter,
+    tidy_author,
+)
 from .note_format import (
     MULTI_VALUED_FIELDS,
     READER_FIELDS,
@@ -37,13 +42,10 @@ def _count_nonnull_fields(frontmatter: Dict[str, Any]) -> int:
 def _extract_body_content(file_path: Path) -> str:
     """Extract the body content (everything after frontmatter) from a markdown file."""
     content = file_path.read_text(encoding="utf-8")
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
-    if not match:
-        match = re.match(r"^---\s*\n(.*?)\n---(.*)$", content, re.DOTALL)
-
-    if match:
-        return match.group(2) if len(match.groups()) > 1 else ""
-    return content
+    split = split_frontmatter(content)
+    if split is None:
+        return content
+    return split[1]
 
 
 def _merge_body_content(primary_body: str, secondary_body: str) -> str:

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import yaml
 
-from .markdown import BookNote, list_books
+from .markdown import BookNote, list_books, split_frontmatter
 from .note_format import (
     FORMAT_VALUES,
     LEAKED_HEADINGS,
@@ -203,8 +203,8 @@ def plan_note_migration(path: Path) -> NoteMigration:
         note that wants a human eye before it is written.
     """
     original = path.read_text(encoding="utf-8")
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", original, re.DOTALL)
-    if match is None:
+    split = split_frontmatter(original)
+    if split is None:
         return NoteMigration(
             path=path,
             original=original,
@@ -212,7 +212,11 @@ def plan_note_migration(path: Path) -> NoteMigration:
             warnings=["no parseable frontmatter; skipped"],
         )
 
-    frontmatter_text, body = match.group(1), match.group(2)
+    # This path recomposes the body rather than carrying it across - the
+    # composition below supplies its own blank line after the fence - so the
+    # leading newlines go here. `lstrip("\n")` rather than `lstrip()`, which
+    # would take an indented first line's indentation with them (#99).
+    frontmatter_text, body = split[0], split[1].lstrip("\n")
     note = BookNote.read(path)
     if note is None:
         return NoteMigration(
@@ -326,8 +330,8 @@ def plan_note_format_migration(path: Path) -> NoteMigration:
     # that back on write - emitting it here too produced \r\r\n on 1,345 notes.
     original = path.read_text(encoding="utf-8")
 
-    match = re.match(r"^---\n(.*?)\n---\n(.*)$", original, re.DOTALL)
-    if match is None:
+    split = split_frontmatter(original)
+    if split is None:
         return NoteMigration(
             path=path,
             original=original,
@@ -335,7 +339,10 @@ def plan_note_format_migration(path: Path) -> NoteMigration:
             warnings=["no parseable frontmatter"],
         )
 
-    frontmatter_text, body = match.group(1), match.group(2)
+    # Carried across rather than recomposed: this migration changes one field and
+    # must leave the body identical, so `migrated == original` still holds for a
+    # note whose format needs nothing.
+    frontmatter_text, body = split
 
     # Parsed before anything else: one unparseable note must not abort a
     # 3,136-note run, so it is reported and left alone, the same way

--- a/src/libris/migrate.py
+++ b/src/libris/migrate.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import yaml
 
-from .markdown import BookNote, list_books, split_frontmatter
+from .markdown import BookNote, list_books, split_frontmatter, write_note
 from .note_format import (
     FORMAT_VALUES,
     LEAKED_HEADINGS,
@@ -418,6 +418,6 @@ def apply_migration(plans: list[NoteMigration]) -> int:
     written = 0
     for plan in plans:
         if plan.changed:
-            plan.path.write_text(plan.migrated, encoding="utf-8")
+            write_note(plan.path, plan.migrated)
             written += 1
     return written

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -3,6 +3,8 @@ from datetime import date
 from pathlib import Path
 from statistics import median
 
+import pytest
+
 from libris.api import BookCandidate
 from libris.markdown import (
     compute_canonical_filename,
@@ -184,6 +186,74 @@ def test_update_book_status_refuses_a_note_it_cannot_parse(tmp_path):
     with pytest.raises(FrontmatterUnreadable):
         update_book_status(file_path, "Reading")
     assert file_path.read_text(encoding="utf-8") == original
+
+
+# Line endings are asserted on bytes throughout. `read_text` applies universal
+# newline translation, so a test that reads a note back as text cannot tell CRLF
+# from LF and would pass against the bug it is meant to pin (#100).
+_CRLF_NOTE = (
+    b"---\r\ntitle: A Book\r\nstatus: To Read\r\nlibris_id: lb-2026-0001\r\n---\r\n"
+    b"\r\n# A Book\r\n\r\nSome thoughts.\r\n"
+)
+_LF_NOTE = _CRLF_NOTE.replace(b"\r\n", b"\n")
+
+
+def _endings(raw: bytes) -> tuple[int, int]:
+    """Count (CRLF, bare LF) in a note's bytes."""
+    crlf = raw.count(b"\r\n")
+    return crlf, raw.count(b"\n") - crlf
+
+
+@pytest.mark.parametrize(
+    "note,expected",
+    [(_CRLF_NOTE, "crlf"), (_LF_NOTE, "lf")],
+    ids=["crlf-note", "lf-note"],
+)
+def test_a_write_keeps_the_line_endings_the_note_already_had(tmp_path, note, expected):
+    # Given a note stored with one kind of line ending
+    from libris.markdown import (
+        ensure_frontmatter_fields,
+        set_frontmatter_fields,
+        update_book_status,
+    )
+
+    for name, write in [
+        ("set_frontmatter", lambda p: set_frontmatter_fields(p, {"status": "Reading"})),
+        ("update_status", lambda p: update_book_status(p, "Reading")),
+        ("repair_pass", ensure_frontmatter_fields),
+    ]:
+        path = tmp_path / f"{expected}_{name}.md"
+        path.write_bytes(note)
+
+        # When libris writes to it
+        write(path)
+
+        # Then it still uses the endings it arrived with, whatever the platform
+        crlf, bare_lf = _endings(path.read_bytes())
+        if expected == "crlf":
+            assert bare_lf == 0, f"{name} introduced bare LF into a CRLF note"
+            assert crlf > 0
+        else:
+            assert crlf == 0, f"{name} converted an LF note to CRLF"
+            assert bare_lf > 0
+
+
+def test_write_note_never_doubles_a_carriage_return(tmp_path):
+    # Given a CRLF note, and content that already carries CRLF itself - the
+    # shape that produced \r\r\n across 1,345 notes when the platform added its
+    # own translation on top (see migrate.plan_format_note_migration)
+    from libris.markdown import write_note
+
+    path = tmp_path / "crlf.md"
+    path.write_bytes(_CRLF_NOTE)
+
+    # When it is written back
+    write_note(path, "---\r\ntitle: A Book\r\n---\r\n\r\nBody.\r\n")
+
+    # Then no line ends in two carriage returns
+    raw = path.read_bytes()
+    assert b"\r\r" not in raw
+    assert _endings(raw) == (raw.count(b"\r\n"), 0)
 
 
 # A body whose first element is an indented code block - four spaces is how


### PR DESCRIPTION
Closes #101. Closes #100.

Two commits, taken together because they touch the same lines: one reader for every
note, then one writer that does not rewrite what it was not asked to.

## Both issues needed correcting first

I surveyed the real Shelf (3,063 notes, read-only) before starting, and it
contradicted things I had written in both issues. Corrections are on the issues
themselves; the short version:

- **#101** claimed `migrate.py:329` had been silently skipping notes. It has not -
  it accepts all 3,063. And the CRLF divergence I reported is not reachable at all:
  every caller reads through `read_text`, which normalises `\r\n` to `\n` before any
  regex runs. So this refactor fixes no existing damage. It is worth doing because
  this duplication is what produced #92 and #99, both of which damaged a reader's
  own writing.
- **#100** had the premise backwards. I wrote that the Shelf is LF and libris churns
  it to CRLF; it is 3,059 CRLF to 4 LF. And the fix I proposed - `newline=""` on
  write - would have normalised all 3,059 notes to LF in one pass, because the
  content is already LF in memory by then.

## One reader (#101)

Six hand-rolled splits in three dialects now call `split_frontmatter`. The fallback
regex five of them carried is gone; no input was ever found that reached it.

Two sites needed different treatment, which is the argument for one reader rather
than seven:

- `plan_note_migration` **recomposes** the body, and its composition supplies its own
  blank line after the fence, so it strips leading newlines explicitly - with
  `lstrip("\n")`, so an indented first line keeps its indentation (#99).
- `plan_format_note_migration` **carries the body across**, so it now reproduces the
  blank line the regex used to eat. `migrated == original` therefore holds for a
  note whose format needs nothing, where before the planner proposed deleting a
  blank line.

**Verified against the real Shelf, planning only, nothing written.** Both migration
planners propose byte-identical content across all 3,063 notes, before and after:

```
                        BEFORE (main)      AFTER (this branch)
plan_migration          76 changed         76 changed
  content fingerprint   31d2d6bc05de7eab   31d2d6bc05de7eab
plan_format_migration   77 changed         77 changed
  content fingerprint   f3378025aa648f83   f3378025aa648f83
```

That hashes every planned note's full proposed text, not just which notes change.

## One writer (#100)

`Path.write_text` leaves `newline=None`, translating every `\n` to `os.linesep`.
On Windows that cancels the translation `read_text` applies coming in, so nobody
noticed. On macOS or Linux it does not cancel, and every one of the 3,059 CRLF notes
would be rewritten end to end the first time anything touched them there.

`write_note` learns the ending the note already uses, normalises the composed
content, applies that ending, and writes bytes. Nine sites move onto it.

```
                            BEFORE (main)        AFTER
LF note in  -> written  ->  CRLF (rewritten)     LF (unchanged)
CRLF note in -> written ->  CRLF on Windows      CRLF everywhere
                            LF on macOS/Linux
```

Content is normalised **before** the ending is applied, not after. Applying `\r\n`
to text that already holds it is what produced `\r\r\n` on 1,345 notes once already
- the warning is still sitting in `plan_format_note_migration`. A test pins that
now rather than a comment.

**Deliberately out of scope:** creating a note. A file that does not exist has no
ending to preserve, so `note_newline` falls back to `os.linesep` and creation keeps
exactly the behaviour it has today. That does leave new notes platform-dependent,
which wants its own decision rather than being smuggled into a fix about not
rewriting existing ones. Happy to file it.

## Testing

- New: a CRLF note stays CRLF and an LF note stays LF through
  `set_frontmatter_fields`, `update_book_status` and the repair pass - asserted on
  **bytes**, because `read_text` hides the difference and a text-level assertion
  would pass against the bug it is meant to pin.
- New: `write_note` never produces `\r\r\n`, even given content that already carries
  CRLF.
- 463 tests pass with all extras; `ruff check` and `ruff format --check` clean.
- Version 0.5.2 -> 0.5.3 in `pyproject.toml` and `extension/manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwZ4KHT6qBi49NGGuXemoM
